### PR TITLE
Adds challenges to benchmark index sorting

### DIFF
--- a/geonames/track.json
+++ b/geonames/track.json
@@ -359,7 +359,7 @@
       ]
     },
     {
-      "name": "append-fast-sorted no-conflicts",
+      "name": "append-fast-sorted-no-conflicts",
       "description": "Indexes the whole document corpus in an index sorted by country_code field in ascending order and using a setup that will lead to a larger indexing throughput than the default settings. Document ids are unique so all index operations are append only.",
       "index-settings": {
         "index.number_of_replicas": 0,

--- a/geonames/track.json
+++ b/geonames/track.json
@@ -359,6 +359,29 @@
       ]
     },
     {
+      "name": "append-fast-sorted no-conflicts",
+      "description": "Indexes the whole document corpus in an index sorted by country_code field in ascending order and using a setup that will lead to a larger indexing throughput than the default settings. Document ids are unique so all index operations are append only.",
+      "index-settings": {
+        "index.number_of_replicas": 0,
+        "index.refresh_interval": "30s",
+        "index.number_of_shards": 6,
+        "index.translog.flush_threshold_size": "4g",
+        "index.sort.field": ["country_code.raw", "admin1_code.raw"],
+        "index.sort.order": ["asc", "asc"]
+      },
+      "schedule": [
+        {
+          "operation": "index-append",
+          "warmup-time-period": 120,
+          "clients": 8
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        }
+      ]
+    },
+    {
       "name": "append-fast-with-conflicts",
       "description": "Indexes the whole document corpus using a setup that will lead to a larger indexing throughput than the default settings. Rally will produce duplicate ids in 25% of all documents (not configurable) so we can simulate a scenario with appends most of the time and some updates in between.",
       "index-settings": {
@@ -381,4 +404,3 @@
     }
   ]
 }
-

--- a/logging/track.json
+++ b/logging/track.json
@@ -344,6 +344,29 @@
           "clients": 1
         }
       ]
+    },
+    {
+      "name": "append-fast-sorted-no-conflicts",
+      "description": "Indexes the whole document corpus in an index sorted by timestamp field in descending order (most recent first) and using a setup that will lead to a larger indexing throughput than the default settings. Document ids are unique so all index operations are append only.",
+      "index-settings": {
+        "index.number_of_replicas": 0,
+        "index.refresh_interval": "30s",
+        "index.number_of_shards": 6,
+        "index.translog.flush_threshold_size": "4g",
+        "index.sort.field": "@timestamp",
+        "index.sort.order": "desc"
+      },
+      "schedule": [
+        {
+          "operation": "index-append",
+          "warmup-time-period": 240,
+          "clients": 8
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        }
+      ]
     }
   ]
 }

--- a/nyc_taxis/track.json
+++ b/nyc_taxis/track.json
@@ -136,6 +136,26 @@
       ]
     },
     {
+      "name": "append-sorted-no-conflicts-index-only",
+      "description": "Indexes the whole document corpus in an index sorted by pickup_datetime field in descending order (most recent first) and using a setup that will lead to a larger indexing throughput than the default settings and produce a smaller index (higher compression rate). Document ids are unique so all index operations are append only.",
+      "index-settings": {
+        "index.number_of_shards": 1,
+        "index.codec": "best_compression",
+        "index.number_of_replicas": 0,
+        "index.refresh_interval": "30s",
+        "index.translog.flush_threshold_size": "4g",
+        "index.sort.field": "pickup_datetime",
+        "index.sort.order": "desc"
+      },
+      "schedule": [
+        {
+          "operation": "index",
+          "warmup-time-period": 240,
+          "clients": 8
+        }
+      ]
+    },
+    {
       "#COMMENT": "Temporary workaround for more realistic benchmarks with two nodes",
       "name": "append-no-conflicts-index-only-1-replica",
       "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
@@ -152,4 +172,3 @@
     }
   ]
 }
-

--- a/pmc/track.json
+++ b/pmc/track.json
@@ -257,6 +257,29 @@
       ]
     },
     {
+      "name": "append-fast-sorted-no-conflicts",
+      "description": "Indexes the whole document corpus in an index sorted by timestamp field in descending order (most recent first) and using a setup that will lead to a larger indexing throughput than the default settings. Document ids are unique so all index operations are append only.",
+      "index-settings": {
+        "index.number_of_replicas": 0,
+        "index.refresh_interval": "30s",
+        "index.number_of_shards": 6,
+        "index.translog.flush_threshold_size": "4g",
+        "index.sort.field": "timestamp",
+        "index.sort.order": "desc"
+      },
+      "schedule": [
+        {
+          "operation": "index-append",
+          "warmup-time-period": 240,
+          "clients": 8
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        }
+      ]
+    },
+    {
       "name": "append-fast-with-conflicts",
       "description": "Indexes the whole document corpus using a setup that will lead to a larger indexing throughput than the default settings. Rally will produce duplicate ids in 25% of all documents (not configurable) so we can simulate a scenario with appends most of the time and some updates in between.",
       "index-settings": {
@@ -279,4 +302,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
This change adds some challenges to the existing tracks to measure the cost of index sorting.
The goal of these new challenges is just to provide benchmarks for index sorting in various cases.
The challenges measure only indexing throughput and merges since we don't have search/aggs features that take advantage of the index sorting yet.
These challenges are also only compatible with elasticsearch master because index sorting is a new feature in 6.x.

Closes #21