### PR TITLE
Benchmarks to compare autohisto with date histogram

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -40,6 +40,20 @@
           "warmup-iterations": 50,
           "iterations": 100,
           "target-throughput": 2
+        },
+        {
+          "operation": "autohisto_agg",
+          "clients": 1,
+          "warmup-iterations": 50,
+          "iterations": 100,
+          "target-throughput": 2
+        },
+        {
+          "operation": "date_histogram_agg",
+          "clients": 1,
+          "warmup-iterations": 50,
+          "iterations": 100,
+          "target-throughput": 2
         }
       ]
     },

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -61,12 +61,12 @@
       "body": {
         "size": 0,
         "aggs": {
-					"dropoffs_over_time": {
-						"auto_date_histogram": {
-							"field": "dropoff_datetime",
-							"buckets": 500
-						}
-					}
+          "dropoffs_over_time": {
+            "auto_date_histogram": {
+              "field": "dropoff_datetime",
+              "buckets": 500
+            }
+          }
         }
       }
     },
@@ -77,12 +77,12 @@
       "body": {
         "size": 0,
         "aggs": {
-					"dropoffs_over_time": {
-						"date_histogram": {
-							"field": "dropoff_datetime",
-							"interval": "day"
-						}
-					}
+          "dropoffs_over_time": {
+            "date_histogram": {
+              "field": "dropoff_datetime",
+              "interval": "day"
+            }
+          }
         }
       }
     }

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -60,11 +60,20 @@
       "cache": false,
       "body": {
         "size": 0,
+        "query": {
+          "range": {
+            "dropoff_datetime": {
+              "gte": "01/01/2015",
+              "lte": "21/01/2015",
+              "format": "dd/MM/yyyy"
+            }
+          }
+        },
         "aggs": {
           "dropoffs_over_time": {
             "auto_date_histogram": {
               "field": "dropoff_datetime",
-              "buckets": 500
+              "buckets": 20
             }
           }
         }
@@ -76,6 +85,15 @@
       "cache": false,
       "body": {
         "size": 0,
+        "query": {
+          "range": {
+              "dropoff_datetime": {
+              "gte": "01/01/2015",
+              "lte": "21/01/2015",
+              "format": "dd/MM/yyyy"
+            }
+          }
+        },
         "aggs": {
           "dropoffs_over_time": {
             "date_histogram": {

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -53,4 +53,36 @@
           }
         }
       }
+    },
+    {
+      "name": "autohisto_agg",
+      "operation-type": "search",
+      "cache": false,
+      "body": {
+        "size": 0,
+        "aggs": {
+					"dropoffs_over_time": {
+						"auto_date_histogram": {
+							"field": "dropoff_datetime",
+							"buckets": 500
+						}
+					}
+        }
+      }
+    },
+    {
+      "name": "date_histogram_agg",
+      "operation-type": "search",
+      "cache": false,
+      "body": {
+        "size": 0,
+        "aggs": {
+					"dropoffs_over_time": {
+						"date_histogram": {
+							"field": "dropoff_datetime",
+							"interval": "day"
+						}
+					}
+        }
+      }
     }


### PR DESCRIPTION
This PR pairs with [this autohisto PR](https://github.com/elastic/elasticsearch/pull/28993) and adds two aggregations for comparison, which @colings86 suggested.

To test, I ran rally locally using `esrally --track-path=/Users/paulsanwald/Code/rally-tracks/nyc_taxis`. Using the full NYC taxi data set on my local laptop gave a few errors that I was unable to reproduce using a subset of the dataset, adjusting the number of buckets to correspond to date_histogram to ensure we're doing an apples to apples comparison. Here's the results from a local run:

```
|   All |                Min Throughput |       autohisto_agg |       2.01 |  ops/s |
|   All |             Median Throughput |       autohisto_agg |       2.02 |  ops/s |
|   All |                Max Throughput |       autohisto_agg |       2.04 |  ops/s |
|   All |       50th percentile latency |       autohisto_agg |    7.04785 |     ms |
|   All |       90th percentile latency |       autohisto_agg |    9.29401 |     ms |
|   All |       99th percentile latency |       autohisto_agg |    9.47358 |     ms |
|   All |      100th percentile latency |       autohisto_agg |    9.50069 |     ms |
|   All |  50th percentile service time |       autohisto_agg |    4.03652 |     ms |
|   All |  90th percentile service time |       autohisto_agg |    4.29146 |     ms |
|   All |  99th percentile service time |       autohisto_agg |    5.12963 |     ms |
|   All | 100th percentile service time |       autohisto_agg |    6.79592 |     ms |
|   All |                    error rate |       autohisto_agg |          0 |      % |
|   All |                Min Throughput |  date_histogram_agg |       2.01 |  ops/s |
|   All |             Median Throughput |  date_histogram_agg |       2.02 |  ops/s |
|   All |                Max Throughput |  date_histogram_agg |       2.04 |  ops/s |
|   All |       50th percentile latency |  date_histogram_agg |    8.33197 |     ms |
|   All |       90th percentile latency |  date_histogram_agg |    8.89726 |     ms |
|   All |       99th percentile latency |  date_histogram_agg |    9.02826 |     ms |
|   All |      100th percentile latency |  date_histogram_agg |    9.03734 |     ms |
|   All |  50th percentile service time |  date_histogram_agg |    3.80297 |     ms |
|   All |  90th percentile service time |  date_histogram_agg |    3.93656 |     ms |
|   All |  99th percentile service time |  date_histogram_agg |    4.38513 |     ms |
|   All | 100th percentile service time |  date_histogram_agg |     4.5412 |     ms |
|   All |                    error rate |  date_histogram_agg |          0 |      % |
```