### PR TITLE
Add source_enabled as track parameter

### DIFF
--- a/geonames/README.md
+++ b/geonames/README.md
@@ -39,6 +39,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
+* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index. 
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.
 

--- a/geonames/index.json
+++ b/geonames/index.json
@@ -2,6 +2,9 @@
   "mappings": {
     "type": {
       "dynamic": "strict",
+      "_source": {
+        "enabled": {{ source_enabled | default(true) | tojson }}
+      },
       "properties": {
         "elevation": {
           "type": "integer"

--- a/geopoint/README.md
+++ b/geopoint/README.md
@@ -21,6 +21,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
+* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.
 

--- a/geopoint/index.json
+++ b/geopoint/index.json
@@ -2,6 +2,9 @@
   "mappings": {
     "type": {
       "dynamic": "strict",
+      "_source": {
+        "enabled": {{ source_enabled | default(true) | tojson }}
+      },
       "properties": {
         "location": {
           "type": "geo_point"

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -30,6 +30,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
+* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.
 

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -2,6 +2,9 @@
   "mappings": {
     "type": {
       "dynamic": "strict",
+      "_source": {
+        "enabled": {{ source_enabled | default(true) | tojson }}
+      },
       "properties": {
         "@timestamp": {
           "format": "epoch_second",

--- a/nested/README.md
+++ b/nested/README.md
@@ -54,6 +54,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_indexing_clients` (default: 4): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
+* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.
 

--- a/nested/index.json
+++ b/nested/index.json
@@ -2,6 +2,9 @@
   "mappings": {
     "question": {
       "dynamic": "strict",
+      "_source": {
+        "enabled": {{ source_enabled | default(true) | tojson }}
+      },
       "properties": {
         "user": {
           "type": "keyword"

--- a/noaa/README.md
+++ b/noaa/README.md
@@ -48,5 +48,6 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
+* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/noaa/index.json
+++ b/noaa/index.json
@@ -2,6 +2,9 @@
   "mappings": {
     "summary": {
       "dynamic": "strict",
+      "_source": {
+        "enabled": {{ source_enabled | default(true) | tojson }}
+      },
       "properties": {
         "AWDR": {
           "type": "keyword"

--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -61,5 +61,6 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
+* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "type": {
+      "_source": {
+        "enabled": {{ source_enabled | default(true) | tojson }}
+      },
       "properties": {
         "surcharge": {
           "scaling_factor": 100,

--- a/percolator/README.md
+++ b/percolator/README.md
@@ -24,6 +24,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
+* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.
 

--- a/percolator/index.json
+++ b/percolator/index.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "content": {
+      "_source": {
+        "enabled": {{ source_enabled | default(true) | tojson }}
+      },
       "dynamic": "strict",
       "properties": {
         "body": {

--- a/pmc/README.md
+++ b/pmc/README.md
@@ -30,6 +30,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
+* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * [`default_search_timeout`](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/search.html#global-search-timeout) (default: -1)
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/pmc/index.json
+++ b/pmc/index.json
@@ -1,6 +1,9 @@
 {
   "mappings": {
     "articles": {
+      "_source": {
+        "enabled": {{ source_enabled | default(true) | tojson }}
+      },
       "dynamic": "strict",
       "properties": {
         "name": {


### PR DESCRIPTION
With this commit we add a new parameter `source_enabled` to each track
which allows to enable / disable storing the `_source` field in the
index. The default value is `true`.