### PR TITLE
Set number of shards explicitly for all tracks

### DIFF
--- a/eventdata/index.json
+++ b/eventdata/index.json
@@ -1,4 +1,7 @@
 {
+  "settings": {
+    "index.number_of_shards": 5
+  },
   "mappings": {
     "doc": {
       "dynamic": "strict",

--- a/geonames/index.json
+++ b/geonames/index.json
@@ -1,4 +1,7 @@
 {
+  "settings": {
+    "index.number_of_shards": 5
+  },
   "mappings": {
     "type": {
       "dynamic": "strict",

--- a/geopoint/index.json
+++ b/geopoint/index.json
@@ -1,4 +1,7 @@
 {
+  "settings": {
+    "index.number_of_shards": 5
+  },
   "mappings": {
     "type": {
       "dynamic": "strict",

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -1,4 +1,7 @@
 {
+  "settings": {
+    "index.number_of_shards": 5
+  },
   "mappings": {
     "type": {
       "dynamic": "strict",

--- a/percolator/index.json
+++ b/percolator/index.json
@@ -1,4 +1,7 @@
 {
+  "settings": {
+    "index.number_of_shards": 5
+  },
   "mappings": {
     "content": {
       "_source": {

--- a/pmc/index.json
+++ b/pmc/index.json
@@ -1,4 +1,7 @@
 {
+  "settings": {
+    "index.number_of_shards": 5
+  },
   "mappings": {
     "articles": {
       "_source": {

--- a/so/index.json
+++ b/so/index.json
@@ -1,4 +1,7 @@
 {
+  "settings": {
+    "index.number_of_shards": 5
+  },
   "mappings": {
     "doc": {
       "dynamic": "strict",


### PR DESCRIPTION
With this commit we set the number of shards explicitly to the default
of five shards in order to keep results consistent.

Relates elastic/elasticsearch#30539