### PR TITLE
Use consistent index settings in all tracks

### DIFF
--- a/eventdata/challenges/default.json
+++ b/eventdata/challenges/default.json
@@ -9,9 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-                "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {

--- a/eventdata/index.json
+++ b/eventdata/index.json
@@ -1,6 +1,7 @@
 {
   "settings": {
-    "index.number_of_shards": 5
+    "index.number_of_shards": 5,
+    "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
     "doc": {

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -9,9 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-                "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -155,9 +153,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-                "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -193,7 +189,6 @@
           "operation": {
             "operation-type": "create-index",
             "settings": {
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.sort.field": ["country_code.raw", "admin1_code.raw"],
               "index.sort.order": ["asc", "asc"]
             }
@@ -232,7 +227,6 @@
           "operation": {
             "operation-type": "create-index",
             "settings": {
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.refresh_interval": "30s",
               "index.number_of_shards": 6,
               "index.translog.flush_threshold_size": "4g"

--- a/geonames/index.json
+++ b/geonames/index.json
@@ -1,6 +1,7 @@
 {
   "settings": {
-    "index.number_of_shards": 5
+    "index.number_of_shards": 5,
+    "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
     "type": {

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -9,9 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-                "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -84,9 +82,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-                "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -132,7 +128,6 @@
           "operation": {
             "operation-type": "create-index",
             "settings": {
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.refresh_interval": "30s",
               "index.number_of_shards": 6,
               "index.translog.flush_threshold_size": "4g"

--- a/geopoint/index.json
+++ b/geopoint/index.json
@@ -1,6 +1,7 @@
 {
   "settings": {
-    "index.number_of_shards": 5
+    "index.number_of_shards": 5,
+    "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
     "type": {

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -9,9 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-                "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -92,9 +90,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-                "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -140,7 +136,6 @@
           "operation": {
             "operation-type": "create-index",
             "settings": {
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.sort.field": "@timestamp",
               "index.sort.order": "desc"
             }

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -1,6 +1,7 @@
 {
   "settings": {
-    "index.number_of_shards": 5
+    "index.number_of_shards": 5,
+    "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
     "type": {

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -9,10 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-              "index.number_of_shards": 1,
-              "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -107,10 +104,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-              "index.number_of_shards": 1,
-              "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {

--- a/nested/index.json
+++ b/nested/index.json
@@ -1,4 +1,8 @@
 {
+  "settings": {
+    "index.number_of_shards": 1,
+    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+  },
   "mappings": {
     "question": {
       "dynamic": "strict",

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -9,11 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-              "index.number_of_shards": 1,
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
-              "index.queries.cache.enabled": false
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -115,11 +111,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-              "index.number_of_shards": 1,
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
-              "index.queries.cache.enabled": false
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {

--- a/noaa/index.json
+++ b/noaa/index.json
@@ -1,4 +1,9 @@
 {
+  "settings": {
+    "index.number_of_shards": 1,
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.queries.cache.enabled": false
+  },
   "mappings": {
     "summary": {
       "dynamic": "strict",

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -10,9 +10,7 @@
           "operation": {
             "operation-type": "create-index",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-              "index.number_of_shards": 1,
               "index.codec": "best_compression",
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.refresh_interval": "30s",
               "index.translog.flush_threshold_size": "4g"
             }{%- endif %}
@@ -73,9 +71,7 @@
           "operation": {
             "operation-type": "create-index",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-              "index.number_of_shards": 1,
               "index.codec": "best_compression",
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.refresh_interval": "30s",
               "index.translog.flush_threshold_size": "4g"
             }{%- endif %}
@@ -115,9 +111,7 @@
           "operation": {
             "operation-type": "create-index",
             "settings": {
-              "index.number_of_shards": 1,
               "index.codec": "best_compression",
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.refresh_interval": "30s",
               "index.translog.flush_threshold_size": "4g",
               "index.sort.field": "pickup_datetime",

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -1,4 +1,8 @@
 {
+  "settings": {
+    "index.number_of_shards": 1,
+    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+  },
   "mappings": {
     "type": {
       "_source": {

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -9,10 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
-              "index.queries.cache.enabled": false
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {

--- a/percolator/index.json
+++ b/percolator/index.json
@@ -1,6 +1,8 @@
 {
   "settings": {
-    "index.number_of_shards": 5
+    "index.number_of_shards": 5,
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.queries.cache.enabled": false
   },
   "mappings": {
     "content": {

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -12,9 +12,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-              "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -101,9 +99,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-              "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -149,7 +145,6 @@
           "operation": {
             "operation-type": "create-index",
             "settings": {
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.sort.field": "timestamp",
               "index.sort.order": "desc"
             }
@@ -198,7 +193,6 @@
           "operation": {
             "operation-type": "create-index",
             "settings": {
-              "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.refresh_interval": "30s",
               "index.number_of_shards": 6,
               "index.translog.flush_threshold_size": "4g"

--- a/pmc/index.json
+++ b/pmc/index.json
@@ -1,6 +1,7 @@
 {
   "settings": {
-    "index.number_of_shards": 5
+    "index.number_of_shards": 5,
+    "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
     "articles": {

--- a/so/challenges/default.json
+++ b/so/challenges/default.json
@@ -9,9 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-                "index.number_of_replicas": {{number_of_replicas | default(0)}}
-            }{%- endif %}
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {

--- a/so/index.json
+++ b/so/index.json
@@ -1,6 +1,7 @@
 {
   "settings": {
-    "index.number_of_shards": 5
+    "index.number_of_shards": 5,
+    "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
     "doc": {


### PR DESCRIPTION
With this commit we use more consistent index settings across all
tracks. This means that we specify the number of shards and the number
of replicas explicitly in the index definition. We also simplify
how the `index_settings` track parameter is applied.