### PR TITLE
added append-index-only-with-ingest-pipeline challenge to http_logs

### DIFF
--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -42,7 +42,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `ingest_pipeline`: Only applicable for `--challenge=append-index-only-with-ingest-pipeline`, selects which ingest
-node pipeline to run. Valid options are `grok` (default), `baseline`, and `geoip`. 
+node pipeline to run. Valid options are `'grok'` (default), `'baseline'`, and `'geoip'`. For example: `--challenge=append-index-only-with-ingest-pipeline --track-params="ingest_pipeline:'baseline'" `
 
 ### License
 

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -22,6 +22,13 @@ Modifications:
 }
 ```
 
+Alternatively, an `unparsed` set of documents are also provided. The `unparsed` data set is identical to the standard 
+data set, except the timestamp is ISO8601 and all the fields are unparsed via the `message` field.  For example:
+
+```json
+{"message" : "211.11.9.0 - - [1998-06-21T15:00:01-05:00] \"GET /english/index.html HTTP/1.0\" 304 0"}
+```
+
 ### Parameters
 
 This track allows to overwrite the following parameters with Rally 0.8.0+ using `--track-params`:
@@ -34,6 +41,8 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `ingest_pipeline`: Only applicable for `--challenge=append-index-only-with-ingest-pipeline`, selects which ingest
+node pipeline to run. Valid options are `grok` (default), `baseline`, and `geoip`. 
 
 ### License
 

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -42,7 +42,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `ingest_pipeline`: Only applicable for `--challenge=append-index-only-with-ingest-pipeline`, selects which ingest
-node pipeline to run. Valid options are `'grok'` (default), `'baseline'`, and `'geoip'`. For example: `--challenge=append-index-only-with-ingest-pipeline --track-params="ingest_pipeline:'baseline'" `
+node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'geoip'`. For example: `--challenge=append-index-only-with-ingest-pipeline --track-params="ingest_pipeline:'baseline'" `
 
 ### License
 

--- a/http_logs/_tools/unparse.rb
+++ b/http_logs/_tools/unparse.rb
@@ -64,6 +64,7 @@ Dir.glob(File.join(ARGV[0], "*.json")).select do |file|
           data = JSON.parse(line)
           logline = getValue(data,'clientip')  + " - - [" + Time.at(data['@timestamp'].to_i).iso8601 + "] \\\"" + getValue(data,'request') + "\\\" " + getValue(data,'status') + " " + getValue(data,'size')
           json_log_line = "{\"message\" : \"" + logline + "\"}\n"
+          #TODO: validate this is proper JSON. ~15 rows (.02%) were post modified to remove an invalid '\' char in the resultant JSON
           json_file.write(json_log_line)
         rescue => e
           puts e

--- a/http_logs/_tools/unparse.rb
+++ b/http_logs/_tools/unparse.rb
@@ -1,0 +1,78 @@
+require "json"
+require "time"
+
+################
+#
+# Reconstructs (un-parses) the existing http_logs corpora (data set). The introduction of ingest node pipelines
+# requires the data to be JSON, but un-parsed log lines. This script was used to create the `http_logs_unparsed`, which
+# is a mirror copy of "http_logs`, except it is un-parsed AND the timestamp is ISO8601 (not epoch_seconds)
+#
+# The output of this is is a file with lines of JSON that appear as follows:
+#
+# {"message" : "30.87.8.0 - - [1998-05-24T15:00:01-05:00] \"GET /images/info.gif HTTP/1.0\" 200 1251"}
+# {"message" : "28.87.8.0 - - [1998-05-24T15:00:01-05:00] \"GET /french/images/hm_official.gif HTTP/1.1\" 200 972"}
+# {"message" : "17.87.8.0 - - [1998-05-24T15:00:01-05:00] \"GET /french/hosts/cfo/images/cfo/cfophot3.jpg HTTP/1.0\" 200 6695"}
+#
+# Usage:
+#
+# rm *.unparse.json
+# rm *.bz2
+#
+# wget http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs/documents-181998.json.bz2
+# bunzip2 documents-181998.json.bz2
+#
+# wget http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs/documents-191998.json.bz2
+# bunzip2 documents-191998.json.bz2
+#
+# wget http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs/documents-201998.json.bz2
+# bunzip2 documents-201998.json.bz2
+#
+# wget http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs/documents-211998.json.bz2
+# bunzip2 documents-211998.json.bz2
+#
+# wget http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs/documents-221998.json.bz2
+# bunzip2 documents-221998.json.bz2
+#
+# wget http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs/documents-231998.json.bz2
+# bunzip2 documents-231998.json.bz2
+#
+# wget http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs/documents-241998.json.bz2
+# bunzip2 documents-241998.json.bz2
+#
+# ruby unparse.rb .
+#
+# #############
+
+def self.getValue(data,key)
+  data[key].nil? ? "-" : data[key].to_s
+end
+
+threads = 4
+running = 0
+Dir.glob(File.join(ARGV[0], "*.json")).select do |file|
+  File.open(file.gsub('json', 'unparsed.json'), 'w') do |json_file|
+    while running >= threads
+      sleep 1
+    end
+    running = running + 1
+    Thread.new do
+      i = 0;
+      File.open(file).each do |line|
+        begin
+          i += 1;
+          print "." if i % 10000 == 0
+          data = JSON.parse(line)
+          logline = getValue(data,'clientip')  + " - - [" + Time.at(data['@timestamp'].to_i).iso8601 + "] \\\"" + getValue(data,'request') + "\\\" " + getValue(data,'status') + " " + getValue(data,'size')
+          json_log_line = "{\"message\" : \"" + logline + "\"}\n"
+          json_file.write(json_log_line)
+        rescue => e
+          puts e
+        end
+      end
+      running = running - 1
+    end
+    while running > 0
+      sleep 1
+    end
+  end
+end

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -198,10 +198,10 @@
           }
         },
         {
-        "operation": "create-http-log-{{ingest_pipeline | default('grok')}}-pipeline"
+        "operation": "create-http-log-{{ingest_pipeline | default('baseline')}}-pipeline"
         },
         {
-          "operation": "index-append-with-ingest-{{ingest_pipeline | default('grok')}}-pipeline",
+          "operation": "index-append-with-ingest-{{ingest_pipeline | default('baseline')}}-pipeline",
           "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}}
         },

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -175,7 +175,7 @@
     },
     {
       "name": "append-index-only-with-ingest-pipeline",
-      "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. Runs the documents through an ingest node pipeline to parse the http logs. Requires --elasticsearch-plugins='ingest-geoip' ",
+      "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. Runs the documents through an ingest node pipeline to parse the http logs. May require --elasticsearch-plugins='ingest-geoip' ",
       "schedule": [
         {
           "operation": "delete-index"
@@ -198,10 +198,10 @@
           }
         },
         {
-        "operation": "create-http-log-pipeline"
+        "operation": "create-http-log-{{ingest_pipeline | default('grok')}}-pipeline"
         },
         {
-          "operation": "index-append-with-ingest-pipeline",
+          "operation": "index-append-with-ingest-{{ingest_pipeline | default('grok')}}-pipeline",
           "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}}
         },

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -172,4 +172,52 @@
           "clients": 1
         }
       ]
+    },
+    {
+      "name": "append-index-only-with-ingest-pipeline",
+      "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. Runs the documents through an ingest node pipeline to parse the http logs. Requires --elasticsearch-plugins='ingest-geoip' ",
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "logs-*",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+        "operation": "create-http-log-pipeline"
+        },
+        {
+          "operation": "index-append-with-ingest-pipeline",
+          "warmup-time-period": 240,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "clients": 1
+        }
+      ]
     }

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -11,6 +11,7 @@
       },
       "properties": {
         "@timestamp": {
+          "format": "strict_date_optional_time||epoch_second",
           "type": "date"
         },
         "clientip": {

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -11,11 +11,15 @@
       },
       "properties": {
         "@timestamp": {
-          "format": "epoch_second",
           "type": "date"
         },
         "clientip": {
           "type": "ip"
+        },
+        "message": {
+          "type": "keyword",
+          "index": false,
+          "doc_values": false
         },
         "request": {
           "type": "text",
@@ -31,6 +35,13 @@
         },
         "size": {
           "type": "integer"
+        },
+        "geoip" : {
+          "properties" : {
+             "country_name": { "type": "keyword" },
+             "city_name": { "type": "keyword" },
+             "location" : { "type" : "geo_point" }
+          }
         }
       }
     }

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -6,12 +6,28 @@
       "corpora": "http_logs"
     },
     {
-      "name": "index-append-with-ingest-pipeline",
+      "name": "index-append-with-ingest-baseline-pipeline",
       "operation-type": "bulk",
       "bulk-size": {{bulk_size | default(5000)}},
       "ingest-percentage": {{ingest_percentage | default(100)}},
-      "pipeline": "http-log-pipeline",
+      "pipeline": "http-log-baseline-pipeline",
+      "corpora": "http_logs"
+    },
+    {
+      "name": "index-append-with-ingest-grok-pipeline",
+      "operation-type": "bulk",
+      "bulk-size": {{bulk_size | default(5000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}},
+      "pipeline": "http-log-grok-pipeline",
       "corpora": "http_logs_unparsed"
+    },
+    {
+      "name": "index-append-with-ingest-geoip-pipeline",
+      "operation-type": "bulk",
+      "bulk-size": {{bulk_size | default(5000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}},
+      "pipeline": "http-log-geoip-pipeline",
+      "corpora": "http_logs"
     },
     {
       "name": "default",
@@ -86,11 +102,27 @@
       }
     },
     {
-      "name": "create-http-log-pipeline",
+      "name": "create-http-log-baseline-pipeline",
       "operation-type": "put-pipeline",
-      "id": "http-log-pipeline",
+      "id": "http-log-baseline-pipeline",
       "body": {
-        "description": "Process an http log line",
+        "description": "Process an the documents with a processor that does nothing. Baseline for overhead of pipeline.",
+        "processors": [
+          {
+            "uppercase": {
+              "field": "doesnotexist",
+              "ignore_missing": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "create-http-log-grok-pipeline",
+      "operation-type": "put-pipeline",
+      "id": "http-log-grok-pipeline",
+      "body": {
+        "description": "Process an http log line with grok. Requires the `unparsed` data set.",
         "processors": [
           {
             "grok": {
@@ -99,7 +131,17 @@
                 "%{IPORHOST:clientip} %{HTTPDUSER} %{USER} \\[%{TIMESTAMP_ISO8601:@timestamp}\\] \"(?:%{WORD} %{NOTSPACE:request}(?: HTTP/%{NUMBER})?|%{DATA})\" %{NUMBER:status} (?:%{NUMBER:size}|-)"
               ]
             }
-          },
+          }
+        ]
+      }
+    },
+    {
+      "name": "create-http-log-geoip-pipeline",
+      "operation-type": "put-pipeline",
+      "id": "http-log-geoip-pipeline",
+      "body": {
+        "description": "Enrich the data with the geo-ip filter. Requires --elasticsearch-plugins='ingest-geoip'",
+        "processors": [
           {
             "geoip": {
                "field": "clientip",

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -2,7 +2,16 @@
       "name": "index-append",
       "operation-type": "bulk",
       "bulk-size": {{bulk_size | default(5000)}},
-      "ingest-percentage": {{ingest_percentage | default(100)}}
+      "ingest-percentage": {{ingest_percentage | default(100)}},
+      "corpora": "http_logs"
+    },
+    {
+      "name": "index-append-with-ingest-pipeline",
+      "operation-type": "bulk",
+      "bulk-size": {{bulk_size | default(5000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}},
+      "pipeline": "http-log-pipeline",
+      "corpora": "http_logs_unparsed"
     },
     {
       "name": "default",
@@ -74,5 +83,33 @@
         "query": {
           "match_all": {}
         }
+      }
+    },
+    {
+      "name": "create-http-log-pipeline",
+      "operation-type": "put-pipeline",
+      "id": "http-log-pipeline",
+      "body": {
+        "description": "Process an http log line",
+        "processors": [
+          {
+            "grok": {
+              "field": "message",
+              "patterns": [
+                "%{IPORHOST:clientip} %{HTTPDUSER} %{USER} \\[%{TIMESTAMP_ISO8601:@timestamp}\\] \"(?:%{WORD} %{NOTSPACE:request}(?: HTTP/%{NUMBER})?|%{DATA})\" %{NUMBER:status} (?:%{NUMBER:size}|-)"
+              ]
+            }
+          },
+          {
+            "geoip": {
+               "field": "clientip",
+               "properties": [
+                  "city_name",
+                  "country_name",
+                  "location"
+                ]
+            }
+          }
+        ]
       }
     }

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -42,118 +42,121 @@
     }
   ],
   "corpora": [
-    {
-      "name": "http_logs",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs",
-      "target-type": "type",
-      "documents": [
+      {%- if ingest_pipeline is defined and ingest_pipeline == "grok" %}
         {
-          "target-index": "logs-181998",
-          "source-file": "documents-181998.json.bz2",
-          "document-count": 2708746,
-          "compressed-bytes": 13815456,
-          "uncompressed-bytes": 363512754
-        },
-        {
-          "target-index": "logs-191998",
-          "source-file": "documents-191998.json.bz2",
-          "document-count": 9697882,
-          "compressed-bytes": 49439633,
-          "uncompressed-bytes": 1301732149
-        },
-        {
-          "target-index": "logs-201998",
-          "source-file": "documents-201998.json.bz2",
-          "document-count": 13053463,
-          "compressed-bytes": 65623436,
-          "uncompressed-bytes": 1744012279
-        },
-        {
-          "target-index": "logs-211998",
-          "source-file": "documents-211998.json.bz2",
-          "document-count": 17647279,
-          "compressed-bytes": 88258230,
-          "uncompressed-bytes": 2364230815
-        },
-        {
-          "target-index": "logs-221998",
-          "source-file": "documents-221998.json.bz2",
-          "document-count": 10716760,
-          "compressed-bytes": 54160603,
-          "uncompressed-bytes": 1438320123
-        },
-        {
-          "target-index": "logs-231998",
-          "source-file": "documents-231998.json.bz2",
-          "document-count": 11961342,
-          "compressed-bytes": 60927822,
-          "uncompressed-bytes": 1597530673
-        },
-        {
-          "target-index": "logs-241998",
-          "source-file": "documents-241998.json.bz2",
-          "document-count": 181463624,
-          "compressed-bytes": 905378242,
-          "uncompressed-bytes": 24555905444
-        }
-      ]
-    },
-    {
-      "name": "http_logs_unparsed",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs",
-      "target-type": "type",
-      "documents": [
-        {
-          "target-index": "logs-181998",
-          "source-file": "documents-181998.unparsed.json.bz2",
-          "document-count": 2708746,
-          "compressed-bytes": 13064317,
-          "uncompressed-bytes": 303920342
-        },
-        {
-          "target-index": "logs-191998",
-          "source-file": "documents-191998.unparsed.json.bz2",
-          "document-count": 9697882,
-          "compressed-bytes": 47211781,
-          "uncompressed-bytes": 1088378738
-        },
-        {
-          "target-index": "logs-201998",
-          "source-file": "documents-201998.unparsed.json.bz2",
-          "document-count": 13053463,
-          "compressed-bytes": 63174979,
-          "uncompressed-bytes": 1456836090
-        },
-        {
-          "target-index": "logs-211998",
-          "source-file": "documents-211998.unparsed.json.bz2",
-          "document-count": 17647279,
-          "compressed-bytes": 85607179,
-          "uncompressed-bytes": 1975990671
-        },
-        {
-          "target-index": "logs-221998",
-          "source-file": "documents-221998.unparsed.json.bz2",
-          "document-count": 10716760,
-          "compressed-bytes": 53190976,
-          "uncompressed-bytes": 1202551382
-        },
-        {
-          "target-index": "logs-231998",
-          "source-file": "documents-231998.unparsed.json.bz2",
-          "document-count": 11961342,
-          "compressed-bytes": 60705435,
-          "uncompressed-bytes": 1334381144
-        },
-        {
-          "target-index": "logs-241998",
-          "source-file": "documents-241998.unparsed.json.bz2",
-          "document-count": 181463624,
-          "compressed-bytes": 897719968,
-          "uncompressed-bytes": 20563705716
-        }
-      ]
-    }
+          "name": "http_logs_unparsed",
+          "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs",
+          "target-type": "type",
+          "documents": [
+          {
+            "target-index": "logs-181998",
+            "source-file": "documents-181998.unparsed.json.bz2",
+            "document-count": 2708746,
+            "compressed-bytes": 13064317,
+            "uncompressed-bytes": 303920342
+          },
+          {
+            "target-index": "logs-191998",
+            "source-file": "documents-191998.unparsed.json.bz2",
+            "document-count": 9697882,
+            "compressed-bytes": 47211781,
+            "uncompressed-bytes": 1088378738
+          },
+          {
+            "target-index": "logs-201998",
+            "source-file": "documents-201998.unparsed.json.bz2",
+            "document-count": 13053463,
+            "compressed-bytes": 63174979,
+            "uncompressed-bytes": 1456836090
+          },
+          {
+            "target-index": "logs-211998",
+            "source-file": "documents-211998.unparsed.json.bz2",
+            "document-count": 17647279,
+            "compressed-bytes": 85607179,
+            "uncompressed-bytes": 1975990671
+          },
+          {
+            "target-index": "logs-221998",
+            "source-file": "documents-221998.unparsed.json.bz2",
+            "document-count": 10716760,
+            "compressed-bytes": 53190976,
+            "uncompressed-bytes": 1202551382
+          },
+          {
+            "target-index": "logs-231998",
+            "source-file": "documents-231998.unparsed.json.bz2",
+            "document-count": 11961342,
+            "compressed-bytes": 60705435,
+            "uncompressed-bytes": 1334381144
+          },
+          {
+            "target-index": "logs-241998",
+            "source-file": "documents-241998.unparsed.json.bz2",
+            "document-count": 181463624,
+            "compressed-bytes": 897719968,
+            "uncompressed-bytes": 20563705716
+          }
+        ]
+      }
+    {%- else %}
+      {
+        "name": "http_logs",
+        "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs",
+        "target-type": "type",
+        "documents": [
+          {
+            "target-index": "logs-181998",
+            "source-file": "documents-181998.json.bz2",
+            "document-count": 2708746,
+            "compressed-bytes": 13815456,
+            "uncompressed-bytes": 363512754
+          },
+          {
+            "target-index": "logs-191998",
+            "source-file": "documents-191998.json.bz2",
+            "document-count": 9697882,
+            "compressed-bytes": 49439633,
+            "uncompressed-bytes": 1301732149
+          },
+          {
+            "target-index": "logs-201998",
+            "source-file": "documents-201998.json.bz2",
+            "document-count": 13053463,
+            "compressed-bytes": 65623436,
+            "uncompressed-bytes": 1744012279
+          },
+          {
+            "target-index": "logs-211998",
+            "source-file": "documents-211998.json.bz2",
+            "document-count": 17647279,
+            "compressed-bytes": 88258230,
+            "uncompressed-bytes": 2364230815
+          },
+          {
+            "target-index": "logs-221998",
+            "source-file": "documents-221998.json.bz2",
+            "document-count": 10716760,
+            "compressed-bytes": 54160603,
+            "uncompressed-bytes": 1438320123
+          },
+          {
+            "target-index": "logs-231998",
+            "source-file": "documents-231998.json.bz2",
+            "document-count": 11961342,
+            "compressed-bytes": 60927822,
+            "uncompressed-bytes": 1597530673
+          },
+          {
+            "target-index": "logs-241998",
+            "source-file": "documents-241998.json.bz2",
+            "document-count": 181463624,
+            "compressed-bytes": 905378242,
+            "uncompressed-bytes": 24555905444
+          }
+        ]
+      }
+    {%- endif %}
   ],
   "operations": [
     {{ rally.collect(parts="operations/*.json") }}

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -142,8 +142,8 @@
           "target-index": "logs-231998",
           "source-file": "documents-231998.unparsed.json.bz2",
           "document-count": 11961342,
-          "compressed-bytes": 60705500,
-          "uncompressed-bytes": 1334381146
+          "compressed-bytes": 60705435,
+          "uncompressed-bytes": 1334381144
         },
         {
           "target-index": "logs-241998",

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -121,22 +121,22 @@
           "target-index": "logs-201998",
           "source-file": "documents-201998.unparsed.json.bz2",
           "document-count": 13053463,
-          "compressed-bytes": 63175082,
-          "uncompressed-bytes": 1456836091
+          "compressed-bytes": 63174979,
+          "uncompressed-bytes": 1456836090
         },
         {
           "target-index": "logs-211998",
           "source-file": "documents-211998.unparsed.json.bz2",
           "document-count": 17647279,
-          "compressed-bytes": 85607190,
+          "compressed-bytes": 85607179,
           "uncompressed-bytes": 1975990671
         },
         {
           "target-index": "logs-221998",
           "source-file": "documents-221998.unparsed.json.bz2",
           "document-count": 10716760,
-          "compressed-bytes": 53190588,
-          "uncompressed-bytes": 1202551385
+          "compressed-bytes": 53190976,
+          "uncompressed-bytes": 1202551382
         },
         {
           "target-index": "logs-231998",

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -97,6 +97,62 @@
           "uncompressed-bytes": 24555905444
         }
       ]
+    },
+    {
+      "name": "http_logs_unparsed",
+      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs",
+      "target-type": "type",
+      "documents": [
+        {
+          "target-index": "logs-181998",
+          "source-file": "documents-181998.unparsed.json.bz2",
+          "document-count": 2708746,
+          "compressed-bytes": 13064317,
+          "uncompressed-bytes": 303920342
+        },
+        {
+          "target-index": "logs-191998",
+          "source-file": "documents-191998.unparsed.json.bz2",
+          "document-count": 9697882,
+          "compressed-bytes": 47212456,
+          "uncompressed-bytes": 1088378739
+        },
+        {
+          "target-index": "logs-201998",
+          "source-file": "documents-201998.unparsed.json.bz2",
+          "document-count": 13053463,
+          "compressed-bytes": 63175082,
+          "uncompressed-bytes": 1456836091
+        },
+        {
+          "target-index": "logs-211998",
+          "source-file": "documents-211998.unparsed.json.bz2",
+          "document-count": 17647279,
+          "compressed-bytes": 85607190,
+          "uncompressed-bytes": 1975990671
+        },
+        {
+          "target-index": "logs-221998",
+          "source-file": "documents-221998.unparsed.json.bz2",
+          "document-count": 10716760,
+          "compressed-bytes": 53190588,
+          "uncompressed-bytes": 1202551385
+        },
+        {
+          "target-index": "logs-231998",
+          "source-file": "documents-231998.unparsed.json.bz2",
+          "document-count": 11961342,
+          "compressed-bytes": 60705500,
+          "uncompressed-bytes": 1334381146
+        },
+        {
+          "target-index": "logs-241998",
+          "source-file": "documents-241998.unparsed.json.bz2",
+          "document-count": 181463624,
+          "compressed-bytes": 897719968,
+          "uncompressed-bytes": 20563705716
+        }
+      ]
     }
   ],
   "operations": [

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -114,8 +114,8 @@
           "target-index": "logs-191998",
           "source-file": "documents-191998.unparsed.json.bz2",
           "document-count": 9697882,
-          "compressed-bytes": 47212456,
-          "uncompressed-bytes": 1088378739
+          "compressed-bytes": 47211781,
+          "uncompressed-bytes": 1088378738
         },
         {
           "target-index": "logs-201998",


### PR DESCRIPTION
This change introduces a new challenge `append-index-only-with-ingest-pipeline` and corresponding operation `index-append-with-ingest-pipeline` and an additional corpora that mirrors the existing corpora. This is intended to help test the performance of the ingest node. This challenge requires `--elasticsearch-plugins="ingest-geoip" ` 

* `append-index-only-with-ingest-pipeline` and `index-append-with-ingest-pipeline` - runs the documents through an ingest node pipeline with the `grok` and `geoip` processors. 
* corpora `http_logs_unparsed` - identical data set to http_logs, but pieced back together to allow grok to break it into it's parts, specifically reshaped the data here: https://github.com/jakelandis/sample-data/tree/master/rally_http_logs, and uploaded to same location as http_logs, but with .unparsed. in the name.  The source documents for unparsed look like: 
```
{"message" : "30.87.8.0 - - [1998-05-24T15:00:01-05:00] \"GET /images/info.gif HTTP/1.0\" 200 1251"}
{"message" : "28.87.8.0 - - [1998-05-24T15:00:01-05:00] \"GET /french/images/hm_official.gif HTTP/1.1\" 200 972"}
{"message" : "17.87.8.0 - - [1998-05-24T15:00:01-05:00] \"GET /french/hosts/cfo/images/cfo/cfophot3.jpg HTTP/1.0\" 200 6695"}
{"message" : "72.236.7.0 - - [1998-05-24T15:00:01-05:00] \"GET /images/s102380.gif HTTP/1.1\" 200 207"}
{"message" : "82.36.0.0 - - [1998-05-24T15:00:02-05:00] \"GET /images/nav_bg_bottom.jpg HTTP/1.0\" 200 8389"}
```

To test locally from source
```
./gradlew -p plugins/ingest-geoip run
esrally --track-path=~/workspace/rally-tracks/http_logs --target-hosts=localhost:9200 --pipeline=benchmark-only --challenge=append-index-only-with-ingest-pipeline  --elasticsearch-plugins="ingest-geoip" --test-mode
```
To test this PR:

in rally.ini - add `jake.url = https://github.com/jakelandis/rally-tracks` under `[tracks]`
```
esrally --track=http_logs --track-repository=jake --challenge=append-index-only-with-ingest-pipeline  --elasticsearch-plugins="ingest-geoip" --test-mode
```


