### PR TITLE
Add ML-related challenge

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -141,4 +141,163 @@
           "clients": 1
         }
       ]
+    },
+{% set ml_job_id="benchmark_ml_job" %}
+{% set ml_feed_id="benchmark_nyc_taxis_feed" %}
+    {
+      "name": "append-ml",
+      "description": "Indexes the whole document corpus and executes a machine learning job",
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
+              "index.codec": "best_compression",
+              "index.refresh_interval": "30s",
+              "index.translog.flush_threshold_size": "4g"
+            }{%- endif %}
+          }
+        },
+        {
+          "operation": {
+            "operation-type": "delete-ml-datafeed",
+            "datafeed-id": "{{ml_feed_id}}",
+            "force": true
+          }
+        },
+        {
+          "operation": {
+            "operation-type": "delete-ml-job",
+            "job-id": "{{ml_job_id}}",
+            "force": true
+          }
+        },
+        {
+          "operation": {
+            "operation-type": "create-ml-job",
+            "job-id": "{{ml_job_id}}",
+            "body": {
+              "description": "NYC Taxis (count)",
+              "analysis_config": {
+                "bucket_span": "1h",
+                "summary_count_field_name": "doc_count",
+                "detectors": [
+                  {
+                    "detector_description": "count",
+                    "function": "count"
+                  }
+                ]
+              },
+              "data_description": {
+                "time_field": "pickup_datetime",
+                "time_format": "epoch_ms"
+              },
+              "model_plot_config": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "operation": {
+            "operation-type": "open-ml-job",
+            "job-id": "{{ml_job_id}}"
+          }
+        },
+        {
+          "operation": {
+            "operation-type": "create-ml-datafeed",
+            "datafeed-id": "{{ml_feed_id}}",
+            "body": {
+              "job_id": "{{ml_job_id}}",
+              "indices": [
+                "nyc_taxis"
+              ],
+              "query": {
+                "match_all": {
+                  "boost": 1
+                }
+              },
+              "aggregations": {
+                "buckets": {
+                  "date_histogram": {
+                    "field": "pickup_datetime",
+                    "interval": 3600000,
+                    "offset": 0,
+                    "order": {
+                      "_key": "asc"
+                    },
+                    "keyed": false,
+                    "min_doc_count": 0
+                  },
+                  "aggregations": {
+                    "pickup_datetime": {
+                      "max": {
+                        "field": "pickup_datetime"
+                      }
+                    }
+                  }
+                }
+              },
+              "scroll_size": 1000,
+              "chunking_config": {
+                "mode": "manual",
+                "time_span": "3600000000ms"
+              }
+            }
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "nyc_taxis",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "index",
+          "warmup-time-period": 240,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh"
+        },
+        {
+          "operation": "force-merge"
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh"
+        },
+	    {
+          "operation": {
+            "operation-type": "start-ml-datafeed",
+            "datafeed-id": "{{ml_feed_id}}",
+            "body": {
+              "end": "now"
+            }
+          }
+        },
+        {
+          "operation": {
+            "operation-type": "wait-for-ml-lookback",
+            "include-in-reporting": false,
+            "datafeed-id": "{{ml_feed_id}}"
+          }
+        },
+        {
+          "operation": {
+            "operation-type": "close-ml-job",
+            "job-id": "{{ml_job_id}}"
+          }
+        }
+      ]
     }

--- a/nyc_taxis/track.py
+++ b/nyc_taxis/track.py
@@ -1,0 +1,13 @@
+import time
+
+
+def wait_for_ml_lookback(es, params):
+    while True:
+        response = es.xpack.ml.get_datafeed_stats(datafeed_id=params["datafeed-id"])
+        if response["datafeeds"][0]["state"] == "stopped":
+            break
+        time.sleep(5)
+
+
+def register(registry):
+    registry.register_runner("wait-for-ml-lookback", wait_for_ml_lookback)


### PR DESCRIPTION
With this commit we add a new challenge `append-ml` to the `nyc_taxis`
track that can be used to benchmark the machine learning module in
Elasticsearch. The challenge requires that Rally is invoked
appropriately so it will activate ML in Elasticsearch.