### PR TITLE
Add update challenge to nyc_taxis

### DIFF
--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -60,6 +60,9 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_size` (default: 10000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
+* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective challenge.
+* `on_conflict` (default: "index"): Whether to use an "index" or an "update" action when simulating an id conflict.
+* `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Rally docs](http://esrally.readthedocs.io/en/latest/track.html#bulk) for the full definition of this parameter. This requires to run the respective challenge.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -156,6 +156,54 @@
         }
       ]
     },
+    {
+      "name": "update",
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
+              "index.number_of_shards": {{number_of_shards | default(1)}},
+              "index.number_of_replicas": {{number_of_replicas | default(0)}},
+              "index.store.type": "{{store_type | default('mmapfs')}}"
+            }{%- endif %}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "nyc_taxis",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "update",
+          "warmup-time-period": 240,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "clients": 1
+        }
+      ]
+    },
 {% set ml_job_id="benchmark_ml_job" %}
 {% set ml_feed_id="benchmark_nyc_taxis_feed" %}
     {

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -5,6 +5,16 @@
       "ingest-percentage": {{ingest_percentage | default(100)}}
     },
     {
+      "name": "update",
+      "operation-type": "bulk",
+      "bulk-size": {{bulk_size | default(10000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}},
+      "conflicts": "random",
+      "on-conflict": "{{on_conflict | default('update')}}",
+      "conflict-probability": {{conflict_probability | default(25)}},
+      "recency": {{recency | default(0)}}
+    },
+    {
       "name": "default",
       "operation-type": "search",
       "body": {


### PR DESCRIPTION
With this commit we add a new challenge `update` to the `nyc_taxis` track. We
also include a new track parameter `store_type` which is intentionally
undocumented because we intend to remove it again after an initial experimation
phase.