### PR TITLE
Fix benchmarks for scripting queries

### DIFF
--- a/geonames/operations/default.json
+++ b/geonames/operations/default.json
@@ -113,7 +113,7 @@
               {
                 "script_score": {
                   "script": {
-                    "source": "(ln(abs(doc['population']) + 1) + doc['location'].lon + doc['location'].lat) * _score",
+                    "source": "abs(ln(abs(doc['population']) + 1) + doc['location'].lon + doc['location'].lat) * _score",
                     "lang": "expression"
                   }
                 }
@@ -136,7 +136,7 @@
               {
                 "script_score": {
                   "script": {
-                    "source": "(Math.log(Math.abs((int)((List)doc.population).get(0)) + 1) + (double)(doc.location.lon) * (double)(doc.location.lat))/_score",
+                    "source": "Math.abs(Math.log(Math.abs((int)((List)doc.population).get(0)) + 1) + (double)(doc.location.lon) * (double)(doc.location.lat))/_score",
                     "lang": "painless"
                   }
                 }
@@ -159,7 +159,7 @@
               {
                 "script_score": {
                   "script": {
-                    "source": "(Math.log(Math.abs(doc['population'].value) + 1) + doc['location'].lon * doc['location'].lat)/_score",
+                    "source": "Math.abs(Math.log(Math.abs(doc['population'].value) + 1) + doc['location'].lon * doc['location'].lat)/_score",
                     "lang": "painless"
                   }
                 }


### PR DESCRIPTION
Fix benchmarks for expression, painless-static, painless-dynamic
so that they always return positive scores, as returning negative
scores is forbidden from 7.0