### PR TITLE
Prepare for types-removal in Elasticsearch

### DIFF
--- a/eventdata/index.json
+++ b/eventdata/index.json
@@ -4,7 +4,7 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "doc": {
+    "_doc": {
       "dynamic": "strict",
       "_source": {
         "enabled": {{ source_enabled | default(true) | tojson }}

--- a/eventdata/track.json
+++ b/eventdata/track.json
@@ -7,7 +7,7 @@
     {
       "name": "eventdata",
       "body": "index.json",
-      "types": ["doc"]
+      "types": ["_doc"]
     }
   ],
   "corpora": [

--- a/geonames/index.json
+++ b/geonames/index.json
@@ -4,7 +4,7 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "type": {
+    "_doc": {
       "dynamic": "strict",
       "_source": {
         "enabled": {{ source_enabled | default(true) | tojson }}

--- a/geonames/track.json
+++ b/geonames/track.json
@@ -7,7 +7,7 @@
     {
       "name": "geonames",
       "body": "index.json",
-      "types": [ "type" ]
+      "types": [ "_doc" ]
     }
   ],
   "corpora": [

--- a/geopoint/index.json
+++ b/geopoint/index.json
@@ -4,7 +4,7 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "type": {
+    "_doc": {
       "dynamic": "strict",
       "_source": {
         "enabled": {{ source_enabled | default(true) | tojson }}

--- a/geopoint/track.json
+++ b/geopoint/track.json
@@ -7,7 +7,7 @@
     {
       "name": "osmgeopoints",
       "body": "index.json",
-      "types": ["type"]
+      "types": ["_doc"]
     }
   ],
   "corpora": [

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -4,7 +4,7 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "type": {
+    "_doc": {
       "dynamic": "strict",
       "_source": {
         "enabled": {{ source_enabled | default(true) | tojson }}

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -8,37 +8,37 @@
     {
       "name": "logs-181998",
       "body": "index.json",
-      "types": ["type"]
+      "types": ["_doc"]
     },
     {
       "name": "logs-191998",
       "body": "index.json",
-      "types": ["type"]
+      "types": ["_doc"]
     },
     {
       "name": "logs-201998",
       "body": "index.json",
-      "types": ["type"]
+      "types": ["_doc"]
     },
     {
       "name": "logs-211998",
       "body": "index.json",
-      "types": ["type"]
+      "types": ["_doc"]
     },
     {
       "name": "logs-221998",
       "body": "index.json",
-      "types": ["type"]
+      "types": ["_doc"]
     },
     {
       "name": "logs-231998",
       "body": "index.json",
-      "types": ["type"]
+      "types": ["_doc"]
     },
     {
       "name": "logs-241998",
       "body": "index.json",
-      "types": ["type"]
+      "types": ["_doc"]
     }
   ],
   "corpora": [
@@ -46,7 +46,7 @@
         {
           "name": "http_logs_unparsed",
           "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs",
-          "target-type": "type",
+          "target-type": "_doc",
           "documents": [
           {
             "target-index": "logs-181998",
@@ -103,7 +103,7 @@
       {
         "name": "http_logs",
         "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs",
-        "target-type": "type",
+        "target-type": "_doc",
         "documents": [
           {
             "target-index": "logs-181998",

--- a/nested/index.json
+++ b/nested/index.json
@@ -4,7 +4,7 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "question": {
+    "_doc": {
       "dynamic": "strict",
       "_source": {
         "enabled": {{ source_enabled | default(true) | tojson }}

--- a/nested/track.json
+++ b/nested/track.json
@@ -7,7 +7,7 @@
     {
       "name": "sonested",
       "body": "index.json",
-      "types": ["question"]
+      "types": ["_doc"]
     }
   ],
   "corpora": [

--- a/noaa/index.json
+++ b/noaa/index.json
@@ -6,7 +6,7 @@
     "index.merge.policy.max_merged_segment": "100GB"
   },
   "mappings": {
-    "summary": {
+    "_doc": {
       "dynamic": "strict",
       "_source": {
         "enabled": {{ source_enabled | default(true) | tojson }}

--- a/noaa/track.json
+++ b/noaa/track.json
@@ -7,7 +7,7 @@
     {
       "name": "weather-data-2016",
       "body": "index.json",
-      "types": ["summary"]
+      "types": ["_doc"]
     }
   ],
   "corpora": [

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -4,7 +4,7 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "type": {
+    "_doc": {
       "_source": {
         "enabled": {{ source_enabled | default(true) | tojson }}
       },

--- a/nyc_taxis/track.json
+++ b/nyc_taxis/track.json
@@ -7,7 +7,7 @@
     {
       "name": "nyc_taxis",
       "body": "index.json",
-      "types": ["type"]
+      "types": ["_doc"]
     }
   ],
   "corpora": [

--- a/percolator/index.json
+++ b/percolator/index.json
@@ -5,7 +5,7 @@
     "index.queries.cache.enabled": false
   },
   "mappings": {
-    "content": {
+    "_doc": {
       "_source": {
         "enabled": {{ source_enabled | default(true) | tojson }}
       },

--- a/percolator/track.json
+++ b/percolator/track.json
@@ -7,7 +7,7 @@
     {
       "name": "queries",
       "body": "index.json",
-      "types": ["content"]
+      "types": ["_doc"]
     }
   ],
   "corpora": [

--- a/pmc/index.json
+++ b/pmc/index.json
@@ -4,7 +4,7 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "articles": {
+    "_doc": {
       "_source": {
         "enabled": {{ source_enabled | default(true) | tojson }}
       },

--- a/pmc/track.json
+++ b/pmc/track.json
@@ -7,7 +7,7 @@
     {
       "name": "pmc",
       "body": "index.json",
-      "types": ["articles"]
+      "types": ["_doc"]
     }
   ],
   "corpora": [

--- a/so/index.json
+++ b/so/index.json
@@ -4,7 +4,7 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "doc": {
+    "_doc": {
       "dynamic": "strict",
       "_source": {
         "enabled": {{ source_enabled | default(true) | tojson }}

--- a/so/track.json
+++ b/so/track.json
@@ -7,7 +7,7 @@
     {
       "name": "so",
       "body": "index.json",
-      "types": ["doc"]
+      "types": ["_doc"]
     }
   ],
   "corpora": [


### PR DESCRIPTION
With this commit we consistenly use `_doc` as the sole type name in all
our tracks as Elasticsearch 7.0.0 will use this as an allowed "pseudo"
type name.

See also
https://www.elastic.co/guide/en/elasticsearch/reference/master/removal-of-types.html#_schedule_for_removal_of_mapping_types.