### PR TITLE
Allow _doc type in master

### DIFF
--- a/eventdata/challenges/default.json
+++ b/eventdata/challenges/default.json
@@ -9,7 +9,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -9,7 +9,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -195,7 +198,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -233,6 +239,9 @@
             "settings": {
               "index.sort.field": ["country_code.raw", "admin1_code.raw"],
               "index.sort.order": ["asc", "asc"]
+            },
+            "request-params": {
+              "include_type_name": "true"
             }
           }
         },
@@ -272,6 +281,9 @@
               "index.refresh_interval": "30s",
               "index.number_of_shards": 6,
               "index.translog.flush_threshold_size": "4g"
+            },
+            "request-params": {
+              "include_type_name": "true"
             }
           }
         },

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -9,7 +9,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -82,7 +85,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -131,6 +137,9 @@
               "index.refresh_interval": "30s",
               "index.number_of_shards": 6,
               "index.translog.flush_threshold_size": "4g"
+            },
+            "request-params": {
+              "include_type_name": "true"
             }
           }
         },

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -9,7 +9,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -90,7 +93,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -138,6 +144,9 @@
             "settings": {
               "index.sort.field": "@timestamp",
               "index.sort.order": "desc"
+            },
+            "request-params": {
+              "include_type_name": "true"
             }
           }
         },
@@ -183,7 +192,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -234,7 +246,10 @@
               "index.number_of_shards": {{number_of_shards | default(1)}},
               "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.store.type": "{{store_type | default('mmapfs')}}"
-            }{%- endif %}
+            }{%- endif %},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -9,7 +9,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -104,7 +107,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -9,7 +9,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -111,7 +114,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -13,7 +13,10 @@
               "index.codec": "best_compression",
               "index.refresh_interval": "30s",
               "index.translog.flush_threshold_size": "4g"
-            }{%- endif %}
+            }{%- endif %},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -88,7 +91,10 @@
               "index.codec": "best_compression",
               "index.refresh_interval": "30s",
               "index.translog.flush_threshold_size": "4g"
-            }{%- endif %}
+            }{%- endif %},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -130,6 +136,9 @@
               "index.translog.flush_threshold_size": "4g",
               "index.sort.field": "pickup_datetime",
               "index.sort.order": "desc"
+            },
+            "request-params": {
+              "include_type_name": "true"
             }
           }
         },
@@ -169,7 +178,10 @@
               "index.number_of_shards": {{number_of_shards | default(1)}},
               "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.store.type": "{{store_type | default('mmapfs')}}"
-            }{%- endif %}
+            }{%- endif %},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -220,7 +232,10 @@
               "index.codec": "best_compression",
               "index.refresh_interval": "30s",
               "index.translog.flush_threshold_size": "4g"
-            }{%- endif %}
+            }{%- endif %},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -9,7 +9,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -12,7 +12,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -99,7 +102,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {
@@ -147,6 +153,9 @@
             "settings": {
               "index.sort.field": "timestamp",
               "index.sort.order": "desc"
+            },
+            "request-params": {
+              "include_type_name": "true"
             }
           }
         },
@@ -196,6 +205,9 @@
               "index.refresh_interval": "30s",
               "index.number_of_shards": 6,
               "index.translog.flush_threshold_size": "4g"
+            },
+            "request-params": {
+              "include_type_name": "true"
             }
           }
         },

--- a/so/challenges/default.json
+++ b/so/challenges/default.json
@@ -9,7 +9,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}}
+            "settings": {{index_settings | default({}) | tojson}},
+            "request-params": {
+              "include_type_name": "true"
+            }
           }
         },
         {


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/38270 made current master
(7.0.0) reject mappings with type `_doc` unless
`?include_type_name=true` is passed during index creation.

Workaround the rejection for now by explicitly setting
`include_type_name` to `true` in every create_index operation.