### PR TITLE
Adds a track that indices geopoints as geoshapes (backport to 6)

### DIFF
--- a/geopointshape/README.md
+++ b/geopointshape/README.md
@@ -1,0 +1,31 @@
+## Geopoint track
+
+This track is based on [PlanetOSM](http://wiki.openstreetmap.org/wiki/Planet.osm) data. It contains the same data as the geopoint track but indexes all points as geoshapes.
+
+### Example Document
+
+```json
+{
+  "location": "POINT (-0.1485188 51.5250666)"
+}
+```
+
+### Parameters
+
+This track allows to overwrite the following parameters with Rally 0.8.0+ using `--track-params`:
+
+* `bulk_size` (default: 5000)
+* `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
+* `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
+* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective challenge.
+* `on_conflict` (default: "index"): Whether to use an "index" or an "update" action when simulating an id conflict.
+* `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Rally docs](http://esrally.readthedocs.io/en/latest/track.html#bulk) for the full definition of this parameter. This requires to run the respective challenge.
+* `number_of_replicas` (default: 0)
+* `number_of_shards` (default: 5)
+* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
+* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `cluster_health` (default: "green"): The minimum required cluster health.
+
+### License
+
+Same license as the original data from PlanetOSM: [Open Database License](http://wiki.openstreetmap.org/wiki/Open_Database_License).

--- a/geopointshape/_tools/parse.py
+++ b/geopointshape/_tools/parse.py
@@ -1,0 +1,23 @@
+import json
+import csv
+import sys
+import re
+
+def to_json(f):
+  for line in f:
+    try:
+      point = json.loads(line)["location"]
+      d = {}
+      d["location"] = "POINT (" + str(point[0]) + " " + str(point[1]) + ")"
+      print(json.dumps(d))
+    except KeyboardInterrupt:
+      break
+    except Exception as e:
+      print("Skipping malformed entry '%s' because of %s" %(line, str(e)), file=sys.stderr)
+
+if sys.argv[1] == "json":
+  for file_name in sys.argv[2:]:
+    with open(file_name) as f:
+      to_json(f)
+else:
+  raise Exception("Expected 'json' but got %s" %sys.argv[1])

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -1,0 +1,154 @@
+    {
+      "name": "append-no-conflicts",
+      "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
+      "default": true,
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "osmgeopoints",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "index-append",
+          "warmup-time-period": 120,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "polygon",
+          "clients": 1,
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 2
+        },
+        {
+          "operation": "bbox",
+          "clients": 1,
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 2
+        }
+      ]
+    },
+    {
+      "name": "append-no-conflicts-index-only",
+      "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "osmgeopoints",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "index-append",
+          "warmup-time-period": 120,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+        "name": "refresh-after-index",
+        "operation": "refresh",
+        "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+        "name": "refresh-after-force-merge",
+        "operation": "refresh",
+        "clients": 1
+        }
+      ]
+    },
+    {
+      "name": "append-fast-with-conflicts",
+      "description": "Indexes the whole document corpus using a setup that will lead to a larger indexing throughput than the default settings. Rally will produce duplicate ids in 25% of all documents (not configurable) so we can simulate a scenario with appends most of the time and some updates in between.",
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {
+              "index.refresh_interval": "30s",
+              "index.number_of_shards": 6,
+              "index.translog.flush_threshold_size": "4g"
+            }
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "osmgeopoints",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "index-update",
+          "warmup-time-period": 120,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+        "name": "refresh-after-index",
+        "operation": "refresh",
+        "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+        "name": "refresh-after-force-merge",
+        "operation": "refresh",
+        "clients": 1
+        }
+      ]
+    }

--- a/geopointshape/files.txt
+++ b/geopointshape/files.txt
@@ -1,0 +1,2 @@
+documents.json.bz2
+documents-1k.json.bz2

--- a/geopointshape/index.json
+++ b/geopointshape/index.json
@@ -1,0 +1,19 @@
+{
+  "settings": {
+    "index.number_of_shards": {{number_of_shards | default(5)}},
+    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+  },
+  "mappings": {
+    "_doc": {
+      "dynamic": "strict",
+      "_source": {
+        "enabled": {{ source_enabled | default(true) | tojson }}
+      },
+      "properties": {
+        "location": {
+          "type": "geo_shape"
+        }
+      }
+    }
+  }
+}

--- a/geopointshape/operations/default.json
+++ b/geopointshape/operations/default.json
@@ -1,0 +1,55 @@
+    {
+      "name": "index-append",
+      "operation-type": "bulk",
+      "bulk-size": {{bulk_size | default(5000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}}
+    },
+    {
+      "name": "index-update",
+      "operation-type": "bulk",
+      "bulk-size": {{bulk_size | default(5000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}},
+      "conflicts": "random",
+      "on-conflict": "{{on_conflict | default('index')}}",
+      "conflict-probability": {{conflict_probability | default(25)}},
+      "recency": {{recency | default(0)}}
+    },
+    {
+      "name": "polygon",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "geo_shape": {
+            "location": {
+               "shape": {
+                  "type": "polygon",
+                  "coordinates" : [[
+                    [-0.1, 49.0],
+                    [5.0, 48.0],
+                    [15.0, 49.0],
+                    [14.0, 60.0],
+                    [-0.1, 61.0],
+                    [-0.1, 49.0]
+                  ]]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "bbox",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "geo_shape": {
+            "location": {
+              "shape": {
+                 "type": "envelope",
+                 "coordinates" : [[-0.1, 61.0], [15.0, 48.0]]
+              }
+            }
+          }
+        }
+      }
+    }

--- a/geopointshape/track.json
+++ b/geopointshape/track.json
@@ -1,0 +1,33 @@
+{% import "rally.helpers" as rally with context %}
+
+{
+  "version": 2,
+  "description": "Point coordinates from PlanetOSM indexed as geoshapes",
+  "indices": [
+    {
+      "name": "osmgeopoints",
+      "body": "index.json",
+      "types": ["_doc"]
+    }
+  ],
+  "corpora": [
+    {
+      "name": "geopointshapes",
+      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/geopointshape",
+      "documents": [
+        {
+          "source-file": "documents.json.bz2",
+          "document-count": 60844404,
+          "compressed-bytes": 493367095,
+          "uncompressed-bytes": 2780550484
+        }
+      ]
+    }
+  ],
+  "operations": [
+    {{ rally.collect(parts="operations/*.json") }}
+  ],
+  "challenges": [
+    {{ rally.collect(parts="challenges/*.json") }}
+  ]
+}


### PR DESCRIPTION
This track contains the same data as the geopoint
track and performs the same operations (when they
are supported) except it indexes points as
geoshapes.

Relates #60