### PR TITLE
Remove document types

### DIFF
--- a/eventdata/challenges/default.json
+++ b/eventdata/challenges/default.json
@@ -9,10 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {

--- a/eventdata/index.json
+++ b/eventdata/index.json
@@ -4,47 +4,45 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "_doc": {
-      "dynamic": "strict",
-      "_source": {
-        "enabled": {{ source_enabled | default(true) | tojson }}
+    "dynamic": "strict",
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "properties": {
+      "@timestamp": { "type": "date" },
+      "message": { "type": "text", "index": false },
+      "agent": { "type": "keyword", "ignore_above": 256 },
+      "bytes": { "type": "integer" },
+      "clientip": { "type": "ip" },
+      "httpversion": { "type": "keyword", "ignore_above": 256 },
+      "response": { "type": "short" },
+      "verb": { "type": "keyword", "ignore_above": 256 },
+      "tags": { "type": "keyword", "ignore_above": 256 },
+      "geoip" : {
+        "properties" : {
+          "country_name" : { "type": "keyword" },
+          "location" : { "type": "geo_point" }
+        }
       },
-      "properties": {
-        "@timestamp": { "type": "date" },
-        "message": { "type": "text", "index": false },
-        "agent": { "type": "keyword", "ignore_above": 256 },
-        "bytes": { "type": "integer" },
-        "clientip": { "type": "ip" },
-        "httpversion": { "type": "keyword", "ignore_above": 256 },
-        "response": { "type": "short" },
-        "verb": { "type": "keyword", "ignore_above": 256 },
-        "tags": { "type": "keyword", "ignore_above": 256 },
-        "geoip" : {
-          "properties" : {
-            "country_name" : { "type": "keyword" },
-            "location" : { "type": "geo_point" }
-          }
-        },
-        "useragent": {
-          "properties": {
-            "name": { "type": "keyword", "ignore_above": 256 },
-            "os": { "type": "keyword", "ignore_above": 256 },
-            "os_name": { "type": "keyword", "ignore_above": 256 }
-          }
-        },
-        "request": {
-          "norms": false,
-          "type": "text",
-          "fields": {
-            "keyword": { "ignore_above": 256, "type": "keyword" }
-          }
-        },
-        "referrer": {
-          "norms": false,
-          "type": "text",
-          "fields": {
-            "keyword": { "ignore_above": 256, "type": "keyword" }
-          }
+      "useragent": {
+        "properties": {
+          "name": { "type": "keyword", "ignore_above": 256 },
+          "os": { "type": "keyword", "ignore_above": 256 },
+          "os_name": { "type": "keyword", "ignore_above": 256 }
+        }
+      },
+      "request": {
+        "norms": false,
+        "type": "text",
+        "fields": {
+          "keyword": { "ignore_above": 256, "type": "keyword" }
+        }
+      },
+      "referrer": {
+        "norms": false,
+        "type": "text",
+        "fields": {
+          "keyword": { "ignore_above": 256, "type": "keyword" }
         }
       }
     }

--- a/eventdata/track.json
+++ b/eventdata/track.json
@@ -6,8 +6,7 @@
   "indices": [
     {
       "name": "eventdata",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     }
   ],
   "corpora": [

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -9,10 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -198,10 +195,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -239,9 +233,6 @@
             "settings": {
               "index.sort.field": ["country_code.raw", "admin1_code.raw"],
               "index.sort.order": ["asc", "asc"]
-            },
-            "request-params": {
-              "include_type_name": "true"
             }
           }
         },
@@ -281,9 +272,6 @@
               "index.refresh_interval": "30s",
               "index.number_of_shards": 6,
               "index.translog.flush_threshold_size": "4g"
-            },
-            "request-params": {
-              "include_type_name": "true"
             }
           }
         },

--- a/geonames/index.json
+++ b/geonames/index.json
@@ -5,129 +5,127 @@
     "index.store.type": "{{store_type | default('hybridfs')}}"
   },
   "mappings": {
-    "_doc": {
-      "dynamic": "strict",
-      "_source": {
-        "enabled": {{ source_enabled | default(true) | tojson }}
+    "dynamic": "strict",
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "properties": {
+      "elevation": {
+        "type": "integer"
       },
-      "properties": {
-        "elevation": {
-          "type": "integer"
-        },
-        "name": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
+      "name": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
           }
-        },
-        "geonameid": {
-          "type": "long"
-        },
-        "feature_class": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "location": {
-          "type": "geo_point"
-        },
-        "cc2": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "timezone": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "dem": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "country_code": {
-          "type": "text",
-          "fielddata": true,
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "admin1_code": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "admin2_code": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "admin3_code": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "admin4_code": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "feature_code": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "alternatenames": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "asciiname": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "population": {
-          "type": "long"
         }
+      },
+      "geonameid": {
+        "type": "long"
+      },
+      "feature_class": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "location": {
+        "type": "geo_point"
+      },
+      "cc2": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "timezone": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "dem": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "country_code": {
+        "type": "text",
+        "fielddata": true,
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "admin1_code": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "admin2_code": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "admin3_code": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "admin4_code": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "feature_code": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "alternatenames": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "asciiname": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "type": "keyword"
+          }
+        }
+      },
+      "population": {
+        "type": "long"
       }
     }
   }

--- a/geonames/track.json
+++ b/geonames/track.json
@@ -6,8 +6,7 @@
   "indices": [
     {
       "name": "geonames",
-      "body": "index.json",
-      "types": [ "_doc" ]
+      "body": "index.json"
     }
   ],
   "corpora": [

--- a/geonames/track.py
+++ b/geonames/track.py
@@ -35,7 +35,6 @@ class PureTermsQueryParamSource(QueryParamSource):
                 }
             },
             "index": None,
-            "type": None,
             # This is the old name (before Rally 0.10.0). Remove after some grace period.
             "use_request_cache": self._params.get("cache", False),
             "cache": self._params.get("cache", False)
@@ -69,7 +68,6 @@ class FilteredTermsQueryParamSource(QueryParamSource):
                 }
             },
             "index": None,
-            "type": None,
             # This is the old name (before Rally 0.10.0). Remove after some grace period.
             "use_request_cache": self._params.get("cache", False),
             "cache": self._params.get("cache", False)
@@ -103,7 +101,6 @@ class ProhibitedTermsQueryParamSource(QueryParamSource):
                 }
             },
             "index": None,
-            "type": None,
             # This is the old name (before Rally 0.10.0). Remove after some grace period.
             "use_request_cache": self._params.get("cache", False),
             "cache": self._params.get("cache", False)

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -9,10 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -85,10 +82,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -137,9 +131,6 @@
               "index.refresh_interval": "30s",
               "index.number_of_shards": 6,
               "index.translog.flush_threshold_size": "4g"
-            },
-            "request-params": {
-              "include_type_name": "true"
             }
           }
         },

--- a/geopoint/index.json
+++ b/geopoint/index.json
@@ -4,15 +4,13 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "_doc": {
-      "dynamic": "strict",
-      "_source": {
-        "enabled": {{ source_enabled | default(true) | tojson }}
-      },
-      "properties": {
-        "location": {
-          "type": "geo_point"
-        }
+    "dynamic": "strict",
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "properties": {
+      "location": {
+        "type": "geo_point"
       }
     }
   }

--- a/geopoint/track.json
+++ b/geopoint/track.json
@@ -6,8 +6,7 @@
   "indices": [
     {
       "name": "osmgeopoints",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     }
   ],
   "corpora": [

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -9,10 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -71,10 +68,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -123,9 +117,6 @@
               "index.refresh_interval": "30s",
               "index.number_of_shards": 6,
               "index.translog.flush_threshold_size": "4g"
-            },
-            "request-params": {
-              "include_type_name": "true"
             }
           }
         },

--- a/geopointshape/index.json
+++ b/geopointshape/index.json
@@ -4,15 +4,13 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "_doc": {
-      "dynamic": "strict",
-      "_source": {
-        "enabled": {{ source_enabled | default(true) | tojson }}
-      },
-      "properties": {
-        "location": {
-          "type": "geo_shape"
-        }
+    "dynamic": "strict",
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "properties": {
+      "location": {
+        "type": "geo_shape"
       }
     }
   }

--- a/geopointshape/track.json
+++ b/geopointshape/track.json
@@ -6,8 +6,7 @@
   "indices": [
     {
       "name": "osmgeopoints",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     }
   ],
   "corpora": [

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -9,10 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -93,10 +90,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -144,9 +138,6 @@
             "settings": {
               "index.sort.field": "@timestamp",
               "index.sort.order": "desc"
-            },
-            "request-params": {
-              "include_type_name": "true"
             }
           }
         },
@@ -192,10 +183,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -246,10 +234,7 @@
               "index.number_of_shards": {{number_of_shards | default(1)}},
               "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.store.type": "{{store_type | default('mmapfs')}}"
-            }{%- endif %},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            }{%- endif %}
           }
         },
         {

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -4,45 +4,43 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "_doc": {
-      "dynamic": "strict",
-      "_source": {
-        "enabled": {{ source_enabled | default(true) | tojson }}
+    "dynamic": "strict",
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "properties": {
+      "@timestamp": {
+        "format": "strict_date_optional_time||epoch_second",
+        "type": "date"
       },
-      "properties": {
-        "@timestamp": {
-          "format": "strict_date_optional_time||epoch_second",
-          "type": "date"
-        },
-        "clientip": {
-          "type": "ip"
-        },
-        "message": {
-          "type": "keyword",
-          "index": false,
-          "doc_values": false
-        },
-        "request": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "ignore_above": 256,
-              "type": "keyword"
-            }
+      "clientip": {
+        "type": "ip"
+      },
+      "message": {
+        "type": "keyword",
+        "index": false,
+        "doc_values": false
+      },
+      "request": {
+        "type": "text",
+        "fields": {
+          "raw": {
+            "ignore_above": 256,
+            "type": "keyword"
           }
-        },
-        "status": {
-          "type": "integer"
-        },
-        "size": {
-          "type": "integer"
-        },
-        "geoip" : {
-          "properties" : {
-             "country_name": { "type": "keyword" },
-             "city_name": { "type": "keyword" },
-             "location" : { "type" : "geo_point" }
-          }
+        }
+      },
+      "status": {
+        "type": "integer"
+      },
+      "size": {
+        "type": "integer"
+      },
+      "geoip" : {
+        "properties" : {
+           "country_name": { "type": "keyword" },
+           "city_name": { "type": "keyword" },
+           "location" : { "type" : "geo_point" }
         }
       }
     }

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -7,38 +7,31 @@
   "indices": [
     {
       "name": "logs-181998",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     },
     {
       "name": "logs-191998",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     },
     {
       "name": "logs-201998",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     },
     {
       "name": "logs-211998",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     },
     {
       "name": "logs-221998",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     },
     {
       "name": "logs-231998",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     },
     {
       "name": "logs-241998",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     }
   ],
   "corpora": [
@@ -46,7 +39,6 @@
         {
           "name": "http_logs_unparsed",
           "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs",
-          "target-type": "_doc",
           "documents": [
           {
             "target-index": "logs-181998",
@@ -103,7 +95,6 @@
       {
         "name": "http_logs",
         "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs",
-        "target-type": "_doc",
         "documents": [
           {
             "target-index": "logs-181998",

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -9,10 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -107,10 +104,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {

--- a/nested/index.json
+++ b/nested/index.json
@@ -4,39 +4,37 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "_doc": {
-      "dynamic": "strict",
-      "_source": {
-        "enabled": {{ source_enabled | default(true) | tojson }}
+    "dynamic": "strict",
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "properties": {
+      "user": {
+        "type": "keyword"
       },
-      "properties": {
-        "user": {
-          "type": "keyword"
-        },
-        "creationDate": {
-          "type": "date"
-        },
-        "title": {
-          "type": "text"
-        },
-        "qid": {
-          "type": "keyword"
-        },
-        "tag": {
-          "type": "keyword"
-        },
-        "answer_count": {
-          "type": "integer"
-        },
-        "answers": {
-          "type": "nested",
-          "properties": {
-            "user": {
-              "type": "keyword"
-            },
-            "date": {
-              "type": "date"
-            }
+      "creationDate": {
+        "type": "date"
+      },
+      "title": {
+        "type": "text"
+      },
+      "qid": {
+        "type": "keyword"
+      },
+      "tag": {
+        "type": "keyword"
+      },
+      "answer_count": {
+        "type": "integer"
+      },
+      "answers": {
+        "type": "nested",
+        "properties": {
+          "user": {
+            "type": "keyword"
+          },
+          "date": {
+            "type": "date"
           }
         }
       }

--- a/nested/track.json
+++ b/nested/track.json
@@ -6,8 +6,7 @@
   "indices": [
     {
       "name": "sonested",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     }
   ],
   "corpora": [

--- a/nested/track.py
+++ b/nested/track.py
@@ -51,7 +51,6 @@ class SortedTermQueryParamSource(QueryParamSource):
                 ]
             },
             "index": None,
-            "type": None,
             # This is the old name (before Rally 0.10.0). Remove after some grace period.
             "use_request_cache": self._params["cache"],
             "cache": self._params["cache"]
@@ -70,7 +69,6 @@ class TermQueryParamSource(QueryParamSource):
                 }
             },
             "index": None,
-            "type": None,
             # This is the old name (before Rally 0.10.0). Remove after some grace period.
             "use_request_cache": self._params["cache"],
             "cache": self._params["cache"]
@@ -107,7 +105,6 @@ class NestedQueryParamSource(QueryParamSource):
                 }
             },
             "index": None,
-            "type": None,
             # This is the old name (before Rally 0.10.0). Remove after some grace period.
             "use_request_cache": self._params["cache"],
             "cache": self._params["cache"]
@@ -148,7 +145,6 @@ class NestedQueryParamSourceWithInnerHits(QueryParamSource):
                 "size": self._params["size"]
             },
             "index": None,
-            "type": None,
             # This is the old name (before Rally 0.10.0). Remove after some grace period.
             "use_request_cache": self._params["cache"],
             "cache": self._params["cache"]

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -9,10 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -114,10 +111,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {

--- a/noaa/index.json
+++ b/noaa/index.json
@@ -6,266 +6,264 @@
     "index.merge.policy.max_merged_segment": "100GB"
   },
   "mappings": {
-    "_doc": {
-      "dynamic": "strict",
-      "_source": {
-        "enabled": {{ source_enabled | default(true) | tojson }}
+    "dynamic": "strict",
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "properties": {
+      "AWDR": {
+        "type": "keyword"
       },
-      "properties": {
-        "AWDR": {
-          "type": "keyword"
-        },
-        "AWND": {
-          "type": "float"
-        },
-        "DAPR": {
-          "type": "keyword"
-        },
-        "DASF": {
-          "type": "keyword"
-        },
-        "DATN": {
-          "type": "keyword"
-        },
-        "DATX": {
-          "type": "keyword"
-        },
-        "DWPR": {
-          "type": "keyword"
-        },
-        "EVAP": {
-          "type": "float"
-        },
-        "MDPR": {
-          "type": "float"
-        },
-        "MDSF": {
-          "type": "keyword"
-        },
-        "MDTN": {
-          "type": "float"
-        },
-        "MDTRANGE": {
-          "type": "double_range"
-        },
-        "MDTX": {
-          "type": "float"
-        },
-        "MNPN": {
-          "type": "float"
-        },
-        "MXPN": {
-          "type": "float"
-        },
-        "PGTM": {
-          "type": "keyword"
-        },
-        "PRCP": {
-          "type": "float"
-        },
-        "PSUN": {
-          "type": "keyword"
-        },
-        "SN31": {
-          "type": "keyword"
-        },
-        "SN32": {
-          "type": "keyword"
-        },
-        "SN33": {
-          "type": "keyword"
-        },
-        "SN35": {
-          "type": "keyword"
-        },
-        "SN36": {
-          "type": "keyword"
-        },
-        "SN51": {
-          "type": "keyword"
-        },
-        "SN52": {
-          "type": "keyword"
-        },
-        "SN53": {
-          "type": "keyword"
-        },
-        "SN55": {
-          "type": "keyword"
-        },
-        "SN56": {
-          "type": "keyword"
-        },
-        "SN57": {
-          "type": "keyword"
-        },
-        "SNOW": {
-          "type": "keyword"
-        },
-        "SNWD": {
-          "type": "keyword"
-        },
-        "SX31": {
-          "type": "keyword"
-        },
-        "SX32": {
-          "type": "keyword"
-        },
-        "SX33": {
-          "type": "keyword"
-        },
-        "SX35": {
-          "type": "keyword"
-        },
-        "SX36": {
-          "type": "keyword"
-        },
-        "SX51": {
-          "type": "keyword"
-        },
-        "SX52": {
-          "type": "keyword"
-        },
-        "SX53": {
-          "type": "keyword"
-        },
-        "SX55": {
-          "type": "keyword"
-        },
-        "SX56": {
-          "type": "keyword"
-        },
-        "SX57": {
-          "type": "keyword"
-        },
-        "TAVG": {
-          "type": "float"
-        },
-        "THIC": {
-          "type": "float"
-        },
-        "TMAX": {
-          "type": "float"
-        },
-        "TMIN": {
-          "type": "float"
-        },
-        "TOBS": {
-          "type": "float"
-        },
-        "TRANGE": {
-          "type": "double_range"
-        },
-        "TSUN": {
-          "type": "keyword"
-        },
-        "WDF2": {
-          "type": "keyword"
-        },
-        "WDF5": {
-          "type": "keyword"
-        },
-        "WDFG": {
-          "type": "keyword"
-        },
-        "WDMV": {
-          "type": "keyword"
-        },
-        "WESD": {
-          "type": "float"
-        },
-        "WESF": {
-          "type": "float"
-        },
-        "WSF2": {
-          "type": "float"
-        },
-        "WSF5": {
-          "type": "float"
-        },
-        "WSFG": {
-          "type": "float"
-        },
-        "WSFI": {
-          "type": "float"
-        },
-        "WT01": {
-          "type": "keyword"
-        },
-        "WT02": {
-          "type": "keyword"
-        },
-        "WT03": {
-          "type": "keyword"
-        },
-        "WT04": {
-          "type": "keyword"
-        },
-        "WT05": {
-          "type": "keyword"
-        },
-        "WT06": {
-          "type": "keyword"
-        },
-        "WT07": {
-          "type": "keyword"
-        },
-        "WT08": {
-          "type": "keyword"
-        },
-        "WT09": {
-          "type": "keyword"
-        },
-        "WT10": {
-          "type": "keyword"
-        },
-        "WT11": {
-          "type": "keyword"
-        },
-        "WT17": {
-          "type": "keyword"
-        },
-        "WT18": {
-          "type": "keyword"
-        },
-        "date": {
-          "type": "date"
-        },
-        "station": {
-          "properties": {
-            "country": {
-              "type": "keyword"
-            },
-            "country_code": {
-              "type": "keyword"
-            },
-            "elevation": {
-              "type": "float"
-            },
-            "gsn_flag": {
-              "type": "keyword"
-            },
-            "hcn_crn_flag": {
-              "type": "keyword"
-            },
-            "id": {
-              "type": "keyword"
-            },
-            "location": {
-              "type": "geo_point"
-            },
-            "name": {
-              "type": "keyword"
-            },
-            "state": {
-              "type": "keyword"
-            },
-            "state_code": {
-              "type": "keyword"
-            },
-            "wmo_id": {
-              "type": "keyword"
-            }
+      "AWND": {
+        "type": "float"
+      },
+      "DAPR": {
+        "type": "keyword"
+      },
+      "DASF": {
+        "type": "keyword"
+      },
+      "DATN": {
+        "type": "keyword"
+      },
+      "DATX": {
+        "type": "keyword"
+      },
+      "DWPR": {
+        "type": "keyword"
+      },
+      "EVAP": {
+        "type": "float"
+      },
+      "MDPR": {
+        "type": "float"
+      },
+      "MDSF": {
+        "type": "keyword"
+      },
+      "MDTN": {
+        "type": "float"
+      },
+      "MDTRANGE": {
+        "type": "double_range"
+      },
+      "MDTX": {
+        "type": "float"
+      },
+      "MNPN": {
+        "type": "float"
+      },
+      "MXPN": {
+        "type": "float"
+      },
+      "PGTM": {
+        "type": "keyword"
+      },
+      "PRCP": {
+        "type": "float"
+      },
+      "PSUN": {
+        "type": "keyword"
+      },
+      "SN31": {
+        "type": "keyword"
+      },
+      "SN32": {
+        "type": "keyword"
+      },
+      "SN33": {
+        "type": "keyword"
+      },
+      "SN35": {
+        "type": "keyword"
+      },
+      "SN36": {
+        "type": "keyword"
+      },
+      "SN51": {
+        "type": "keyword"
+      },
+      "SN52": {
+        "type": "keyword"
+      },
+      "SN53": {
+        "type": "keyword"
+      },
+      "SN55": {
+        "type": "keyword"
+      },
+      "SN56": {
+        "type": "keyword"
+      },
+      "SN57": {
+        "type": "keyword"
+      },
+      "SNOW": {
+        "type": "keyword"
+      },
+      "SNWD": {
+        "type": "keyword"
+      },
+      "SX31": {
+        "type": "keyword"
+      },
+      "SX32": {
+        "type": "keyword"
+      },
+      "SX33": {
+        "type": "keyword"
+      },
+      "SX35": {
+        "type": "keyword"
+      },
+      "SX36": {
+        "type": "keyword"
+      },
+      "SX51": {
+        "type": "keyword"
+      },
+      "SX52": {
+        "type": "keyword"
+      },
+      "SX53": {
+        "type": "keyword"
+      },
+      "SX55": {
+        "type": "keyword"
+      },
+      "SX56": {
+        "type": "keyword"
+      },
+      "SX57": {
+        "type": "keyword"
+      },
+      "TAVG": {
+        "type": "float"
+      },
+      "THIC": {
+        "type": "float"
+      },
+      "TMAX": {
+        "type": "float"
+      },
+      "TMIN": {
+        "type": "float"
+      },
+      "TOBS": {
+        "type": "float"
+      },
+      "TRANGE": {
+        "type": "double_range"
+      },
+      "TSUN": {
+        "type": "keyword"
+      },
+      "WDF2": {
+        "type": "keyword"
+      },
+      "WDF5": {
+        "type": "keyword"
+      },
+      "WDFG": {
+        "type": "keyword"
+      },
+      "WDMV": {
+        "type": "keyword"
+      },
+      "WESD": {
+        "type": "float"
+      },
+      "WESF": {
+        "type": "float"
+      },
+      "WSF2": {
+        "type": "float"
+      },
+      "WSF5": {
+        "type": "float"
+      },
+      "WSFG": {
+        "type": "float"
+      },
+      "WSFI": {
+        "type": "float"
+      },
+      "WT01": {
+        "type": "keyword"
+      },
+      "WT02": {
+        "type": "keyword"
+      },
+      "WT03": {
+        "type": "keyword"
+      },
+      "WT04": {
+        "type": "keyword"
+      },
+      "WT05": {
+        "type": "keyword"
+      },
+      "WT06": {
+        "type": "keyword"
+      },
+      "WT07": {
+        "type": "keyword"
+      },
+      "WT08": {
+        "type": "keyword"
+      },
+      "WT09": {
+        "type": "keyword"
+      },
+      "WT10": {
+        "type": "keyword"
+      },
+      "WT11": {
+        "type": "keyword"
+      },
+      "WT17": {
+        "type": "keyword"
+      },
+      "WT18": {
+        "type": "keyword"
+      },
+      "date": {
+        "type": "date"
+      },
+      "station": {
+        "properties": {
+          "country": {
+            "type": "keyword"
+          },
+          "country_code": {
+            "type": "keyword"
+          },
+          "elevation": {
+            "type": "float"
+          },
+          "gsn_flag": {
+            "type": "keyword"
+          },
+          "hcn_crn_flag": {
+            "type": "keyword"
+          },
+          "id": {
+            "type": "keyword"
+          },
+          "location": {
+            "type": "geo_point"
+          },
+          "name": {
+            "type": "keyword"
+          },
+          "state": {
+            "type": "keyword"
+          },
+          "state_code": {
+            "type": "keyword"
+          },
+          "wmo_id": {
+            "type": "keyword"
           }
         }
       }

--- a/noaa/track.json
+++ b/noaa/track.json
@@ -6,8 +6,7 @@
   "indices": [
     {
       "name": "weather-data-2016",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     }
   ],
   "corpora": [

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -13,10 +13,7 @@
               "index.codec": "best_compression",
               "index.refresh_interval": "30s",
               "index.translog.flush_threshold_size": "4g"
-            }{%- endif %},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            }{%- endif %}
           }
         },
         {
@@ -91,10 +88,7 @@
               "index.codec": "best_compression",
               "index.refresh_interval": "30s",
               "index.translog.flush_threshold_size": "4g"
-            }{%- endif %},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            }{%- endif %}
           }
         },
         {
@@ -136,9 +130,6 @@
               "index.translog.flush_threshold_size": "4g",
               "index.sort.field": "pickup_datetime",
               "index.sort.order": "desc"
-            },
-            "request-params": {
-              "include_type_name": "true"
             }
           }
         },
@@ -178,10 +169,7 @@
               "index.number_of_shards": {{number_of_shards | default(1)}},
               "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.store.type": "{{store_type | default('mmapfs')}}"
-            }{%- endif %},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            }{%- endif %}
           }
         },
         {
@@ -232,10 +220,7 @@
               "index.codec": "best_compression",
               "index.refresh_interval": "30s",
               "index.translog.flush_threshold_size": "4g"
-            }{%- endif %},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            }{%- endif %}
           }
         },
         {

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -4,91 +4,89 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "_doc": {
-      "_source": {
-        "enabled": {{ source_enabled | default(true) | tojson }}
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "properties": {
+      "surcharge": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
       },
-      "properties": {
-        "surcharge": {
-          "scaling_factor": 100,
-          "type": "scaled_float"
-        },
-        "dropoff_datetime": {
-          "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss"
-        },
-        "trip_type": {
-          "type": "keyword"
-        },
-        "mta_tax": {
-          "scaling_factor": 100,
-          "type": "scaled_float"
-        },
-        "rate_code_id": {
-          "type": "keyword"
-        },
-        "passenger_count": {
-          "type": "integer"
-        },
-        "pickup_datetime": {
-          "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss"
-        },
-        "tolls_amount": {
-          "scaling_factor": 100,
-          "type": "scaled_float"
-        },
-        "tip_amount": {
-          "scaling_factor": 100,
-          "type": "scaled_float"
-        },
-        "payment_type": {
-          "type": "keyword"
-        },
-        "extra": {
-          "scaling_factor": 100,
-          "type": "scaled_float"
-        },
-        "vendor_id": {
-          "type": "keyword"
-        },
-        "store_and_fwd_flag": {
-          "type": "keyword"
-        },
-        "improvement_surcharge": {
-          "scaling_factor": 100,
-          "type": "scaled_float"
-        },
-        "fare_amount": {
-          "scaling_factor": 100,
-          "type": "scaled_float"
-        },
-        "ehail_fee": {
-          "scaling_factor": 100,
-          "type": "scaled_float"
-        },
-        "cab_color": {
-          "type": "keyword"
-        },
-        "dropoff_location": {
-          "type": "geo_point"
-        },
-        "vendor_name": {
-          "type": "text"
-        },
-        "total_amount": {
-          "scaling_factor": 100,
-          "type": "scaled_float"
-        },
-        "trip_distance": {
-          "scaling_factor": 100,
-          "type": "scaled_float"
-        },
-        "pickup_location": {
-          "type": "geo_point"
-        }
+      "dropoff_datetime": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss"
       },
-      "dynamic": "strict"
-    }
+      "trip_type": {
+        "type": "keyword"
+      },
+      "mta_tax": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
+      },
+      "rate_code_id": {
+        "type": "keyword"
+      },
+      "passenger_count": {
+        "type": "integer"
+      },
+      "pickup_datetime": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss"
+      },
+      "tolls_amount": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
+      },
+      "tip_amount": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
+      },
+      "payment_type": {
+        "type": "keyword"
+      },
+      "extra": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
+      },
+      "vendor_id": {
+        "type": "keyword"
+      },
+      "store_and_fwd_flag": {
+        "type": "keyword"
+      },
+      "improvement_surcharge": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
+      },
+      "fare_amount": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
+      },
+      "ehail_fee": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
+      },
+      "cab_color": {
+        "type": "keyword"
+      },
+      "dropoff_location": {
+        "type": "geo_point"
+      },
+      "vendor_name": {
+        "type": "text"
+      },
+      "total_amount": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
+      },
+      "trip_distance": {
+        "scaling_factor": 100,
+        "type": "scaled_float"
+      },
+      "pickup_location": {
+        "type": "geo_point"
+      }
+    },
+    "dynamic": "strict"
   }
 }

--- a/nyc_taxis/track.json
+++ b/nyc_taxis/track.json
@@ -6,8 +6,7 @@
   "indices": [
     {
       "name": "nyc_taxis",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     }
   ],
   "corpora": [

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -9,10 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {

--- a/percolator/index.json
+++ b/percolator/index.json
@@ -5,19 +5,17 @@
     "index.queries.cache.enabled": false
   },
   "mappings": {
-    "_doc": {
-      "_source": {
-        "enabled": {{ source_enabled | default(true) | tojson }}
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "dynamic": "strict",
+    "properties": {
+      "body": {
+        "type": "text",
+        "analyzer": "english"
       },
-      "dynamic": "strict",
-      "properties": {
-        "body": {
-          "type": "text",
-          "analyzer": "english"
-        },
-        "query": {
-          "type": "percolator"
-        }
+      "query": {
+        "type": "percolator"
       }
     }
   }

--- a/percolator/track.json
+++ b/percolator/track.json
@@ -6,8 +6,7 @@
   "indices": [
     {
       "name": "queries",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     }
   ],
   "corpora": [

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -12,10 +12,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -102,10 +99,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {
@@ -153,9 +147,6 @@
             "settings": {
               "index.sort.field": "timestamp",
               "index.sort.order": "desc"
-            },
-            "request-params": {
-              "include_type_name": "true"
             }
           }
         },
@@ -205,9 +196,6 @@
               "index.refresh_interval": "30s",
               "index.number_of_shards": 6,
               "index.translog.flush_threshold_size": "4g"
-            },
-            "request-params": {
-              "include_type_name": "true"
             }
           }
         },

--- a/pmc/index.json
+++ b/pmc/index.json
@@ -4,40 +4,38 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "_doc": {
-      "_source": {
-        "enabled": {{ source_enabled | default(true) | tojson }}
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "dynamic": "strict",
+    "properties": {
+      "name": {
+        "type": "keyword"
       },
-      "dynamic": "strict",
-      "properties": {
-        "name": {
-          "type": "keyword"
-        },
-        "journal": {
-          "type": "text"
-        },
-        "date": {
-          "type": "text"
-        },
-        "volume": {
-          "type": "text"
-        },
-        "issue": {
-          "type": "text"
-        },
-        "accession": {
-          "type": "keyword"
-        },
-        "timestamp": {
-          "type": "date",
-          "format": "yyyy-MM-dd HH:mm:ss"
-        },
-        "pmid": {
-          "type": "integer"
-        },
-        "body": {
-          "type": "text"
-        }
+      "journal": {
+        "type": "text"
+      },
+      "date": {
+        "type": "text"
+      },
+      "volume": {
+        "type": "text"
+      },
+      "issue": {
+        "type": "text"
+      },
+      "accession": {
+        "type": "keyword"
+      },
+      "timestamp": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss"
+      },
+      "pmid": {
+        "type": "integer"
+      },
+      "body": {
+        "type": "text"
       }
     }
   }

--- a/pmc/track.json
+++ b/pmc/track.json
@@ -6,8 +6,7 @@
   "indices": [
     {
       "name": "pmc",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     }
   ],
   "corpora": [

--- a/so/challenges/default.json
+++ b/so/challenges/default.json
@@ -9,10 +9,7 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {{index_settings | default({}) | tojson}},
-            "request-params": {
-              "include_type_name": "true"
-            }
+            "settings": {{index_settings | default({}) | tojson}}
           }
         },
         {

--- a/so/index.json
+++ b/so/index.json
@@ -4,39 +4,37 @@
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
   },
   "mappings": {
-    "_doc": {
-      "dynamic": "strict",
-      "_source": {
-        "enabled": {{ source_enabled | default(true) | tojson }}
+    "dynamic": "strict",
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "properties": {
+      "user": {
+        "type": "keyword"
       },
-      "properties": {
-      	"user": {
-          "type": "keyword"
-        },
-        "creationDate": {
-          "type": "date"
-        },
-        "title": {
-          "type": "text"
-        },
-        "questionId": {
-          "type": "keyword"
-        },
-        "answerId": {
-          "type": "keyword"
-        },
-        "acceptedAnswerId": {
-          "type": "keyword"
-        },
-        "tags": {
-          "type": "keyword"
-        },
-        "body": {
-          "type": "text"
-        },
-        "type": {
-          "type": "keyword"
-        }
+      "creationDate": {
+        "type": "date"
+      },
+      "title": {
+        "type": "text"
+      },
+      "questionId": {
+        "type": "keyword"
+      },
+      "answerId": {
+        "type": "keyword"
+      },
+      "acceptedAnswerId": {
+        "type": "keyword"
+      },
+      "tags": {
+        "type": "keyword"
+      },
+      "body": {
+        "type": "text"
+      },
+      "type": {
+        "type": "keyword"
       }
     }
   }

--- a/so/track.json
+++ b/so/track.json
@@ -6,8 +6,7 @@
   "indices": [
     {
       "name": "so",
-      "body": "index.json",
-      "types": ["_doc"]
+      "body": "index.json"
     }
   ],
   "corpora": [


### PR DESCRIPTION
With this commit we remove document types from all Rally tracks as they
have been removed with Elasticsearch 7.0.0.

Relates elastic/rally#647