### PR TITLE
Add pipeline support for Eventdata track

### DIFF
--- a/eventdata/README.md
+++ b/eventdata/README.md
@@ -45,6 +45,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index. 
 * `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `ingest_pipeline_name` (default: "baseline"): The name of the ingest pipeline to be used, values values are ("baseline", "geoip", "useragent", "combined")
 
 ### License
 

--- a/eventdata/challenges/default.json
+++ b/eventdata/challenges/default.json
@@ -33,4 +33,43 @@
           "clients": 1
         }
       ]
+    },
+    {
+      "name": "append-no-conflicts-with-ingest-pipeline",
+      "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. Runs the documents through an ingest node pipeline. May require --elasticsearch-plugins='ingest-geoip,ingest-user-agent' ",
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}},
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "logs-*",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+        "operation": "create-{{ ingest_pipeline_name | default('baseline')}}-pipeline"
+        },
+        {
+          "operation": "index-append-with-pipeline",
+          "warmup-time-period": 120,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        }
+      ]
     }
+

--- a/eventdata/index.json
+++ b/eventdata/index.json
@@ -24,12 +24,37 @@
           "location" : { "type": "geo_point" }
         }
       },
+      "geoip_pipeline" : {
+        "properties" : {
+          "country_name" : { "type": "keyword" },
+          "continent_name": { "type": "keyword" },
+          "country_iso_code": { "type": "keyword" },
+          "region_iso_code": { "type": "keyword" },
+          "region_name": { "type": "keyword" },
+          "city_name": { "type": "keyword" },
+          "location" : { "type": "geo_point" }
+        }
+      },
       "useragent": {
         "properties": {
           "name": { "type": "keyword", "ignore_above": 256 },
           "os": { "type": "keyword", "ignore_above": 256 },
           "os_name": { "type": "keyword", "ignore_above": 256 }
         }
+      },
+      "useragent_pipeline": {
+        "properties": {
+          "name": { "type": "keyword", "ignore_above": 256 },
+          "os": { "type": "keyword", "ignore_above": 256 },
+          "os_name": { "type": "keyword", "ignore_above": 256 },
+          "major": { "type": "keyword", "ignore_above": 256 },
+          "minor": { "type": "keyword", "ignore_above": 256 },
+          "patch": { "type": "keyword", "ignore_above": 256 },
+          "build": { "type": "keyword", "ignore_above": 256 },
+          "os_major": { "type": "keyword", "ignore_above":256 },
+          "os_minor": { "type": "keyword", "ignore_above":256 },
+          "device": { "type": "keyword", "ignore_above":256 }
+         }
       },
       "request": {
         "norms": false,

--- a/eventdata/operations/default.json
+++ b/eventdata/operations/default.json
@@ -3,5 +3,81 @@
       "operation-type": "bulk",
       "bulk-size": {{bulk_size | default(5000)}},
       "ingest-percentage": {{ingest_percentage | default(100)}}
+    },
+    {
+      "name": "index-append-with-pipeline",
+      "operation-type": "bulk",
+      "bulk-size": {{bulk_size | default(5000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}},
+      "pipeline": "{{ingest_pipeline_name | default('baseline')}}",
+      "corpora": "eventdata"
+    },
+    {
+      "name": "create-baseline-pipeline",
+      "operation-type": "put-pipeline",
+      "id": "baseline",
+      "body": {
+        "description": "Process the documents with a processor that does nothing. Baseline for overhead of pipeline.",
+        "processors": [
+          {
+            "uppercase": {
+              "field": "doesnotexist",
+              "ignore_missing": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "create-geoip-pipeline",
+      "operation-type": "put-pipeline",
+      "id": "geoip",
+      "body": {
+          "description": "Enrich the data with the geo-ip filter. Requires --elasticsearch-plugins='ingest-geoip'",
+          "processors": [
+              {
+                  "geoip": {
+                      "field": "clientip",
+                      "target_field": "geoip_pipeline"
+                  }
+              }
+          ]
+      }
+    },
+    {
+      "name": "create-useragent-pipeline",
+      "operation-type": "put-pipeline",
+      "id": "useragent",
+      "body": {
+          "description": "Enrich the data with the useragent filter. Requires --elasticsearch-plugins='ingest-user-agent'",
+          "processors": [
+              {
+                  "user_agent": {
+                      "field": "agent",
+                      "target_field": "useragent_pipeline"
+                  }
+              }
+          ]
+      }
+    },
+    {
+      "name": "create-combined-pipeline",
+      "operation-type": "put-pipeline",
+      "id": "combined",
+      "body": {
+          "description": "Enrich the data with the useragent and geo-ip filter. Requires --elasticsearch-plugins='ingest-user-agent,ingest-geoip'",
+          "processors": [
+              {
+                  "geoip":{
+                      "field":"clientip",
+                      "target_field": "geoip_pipeline"
+                  },
+                  "user_agent": {
+                      "field": "agent",
+                      "target_field": "useragent_pipeline"
+                  }
+              }
+          ]
+      }
     }
-    
+


### PR DESCRIPTION
This change introduces the option to allow the eventdata track to be ingested
with the use of the pipeline plugins geo-ip and user-agent.

To start using pippeline with this track you should use the new challenge
`append-no-conflicts-with-ingest-pipeline` and set the appropriate track param
`ingest_pipeline_name` to use of the baseline, geoip, useragent, combined
pipelines.