### PR TITLE
Adapt geopointshape track to track conventions

### DIFF
--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -16,7 +16,7 @@
           "name": "check-cluster-health",
           "operation": {
             "operation-type": "cluster-health",
-            "index": "osmgeopoints",
+            "index": "osmgeoshapes",
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
@@ -75,7 +75,7 @@
           "name": "check-cluster-health",
           "operation": {
             "operation-type": "cluster-health",
-            "index": "osmgeopoints",
+            "index": "osmgeoshapes",
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
@@ -124,7 +124,7 @@
           "name": "check-cluster-health",
           "operation": {
             "operation-type": "cluster-health",
-            "index": "osmgeopoints",
+            "index": "osmgeoshapes",
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"

--- a/geopointshape/track.json
+++ b/geopointshape/track.json
@@ -5,13 +5,13 @@
   "description": "Point coordinates from PlanetOSM indexed as geoshapes",
   "indices": [
     {
-      "name": "osmgeopoints",
+      "name": "osmgeoshapes",
       "body": "index.json"
     }
   ],
   "corpora": [
     {
-      "name": "geopointshapes",
+      "name": "geopointshape",
       "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/geopointshape",
       "documents": [
         {


### PR DESCRIPTION
With this commit we align the name of the corpus in the track
`geopointshape` with the track's name. We also define a unique index
name across all our tracks (previously the index name in that track was
identical with the index name in the `geopoint` track which could lead
to problematic situations).

Closes #68