### PR TITLE
Allow to override number of shards for updates

### DIFF
--- a/geonames/README.md
+++ b/geonames/README.md
@@ -44,7 +44,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index. 
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings` (unsupported and ineffective for the challenge `append-fast-with-conflicts`): A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
 * `cluster_health` (default: "green"): The minimum required cluster health.
 
 ### License

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -270,7 +270,7 @@
             "operation-type": "create-index",
             "settings": {
               "index.refresh_interval": "30s",
-              "index.number_of_shards": 6,
+              "index.number_of_shards": {{number_of_shards | default(6)}},
               "index.translog.flush_threshold_size": "4g"
             }
           }


### PR DESCRIPTION
With this commit we allow to override the number of shards even for
the challenge `append-fast-with-conflicts` in `geonames`.