### PR TITLE
Allow to override index settings in all cases

### DIFF
--- a/eventdata/README.md
+++ b/eventdata/README.md
@@ -43,7 +43,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index. 
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 
 ### License

--- a/geonames/README.md
+++ b/geonames/README.md
@@ -44,7 +44,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index. 
-* `index_settings` (unsupported and ineffective for the challenge `append-fast-with-conflicts`): A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 
 ### License

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -230,10 +230,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               "index.sort.field": ["country_code.raw", "admin1_code.raw"],
               "index.sort.order": ["asc", "asc"]
-            }
+            }{%- endif %}
           }
         },
         {
@@ -268,11 +268,11 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               "index.refresh_interval": "30s",
               "index.number_of_shards": {{number_of_shards | default(6)}},
               "index.translog.flush_threshold_size": "4g"
-            }
+            }{%- endif %}
           }
         },
         {

--- a/geopoint/README.md
+++ b/geopoint/README.md
@@ -26,7 +26,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 
 ### License

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -127,11 +127,11 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               "index.refresh_interval": "30s",
-              "index.number_of_shards": 6,
+              "index.number_of_shards": {{number_of_shards | default(6)}},
               "index.translog.flush_threshold_size": "4g"
-            }
+            }{%- endif %}
           }
         },
         {

--- a/geopointshape/README.md
+++ b/geopointshape/README.md
@@ -23,7 +23,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 
 ### License

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -113,11 +113,11 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               "index.refresh_interval": "30s",
-              "index.number_of_shards": 6,
+              "index.number_of_shards": {{number_of_shards | default(6)}},
               "index.translog.flush_threshold_size": "4g"
-            }
+            }{%- endif %}
           }
         },
         {

--- a/geoshape/README.md
+++ b/geoshape/README.md
@@ -22,7 +22,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 
 ### License

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -39,7 +39,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `ingest_pipeline`: Only applicable for `--challenge=append-index-only-with-ingest-pipeline`, selects which ingest
 node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'geoip'`. For example: `--challenge=append-index-only-with-ingest-pipeline --track-params="ingest_pipeline:'baseline'" `

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -135,10 +135,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               "index.sort.field": "@timestamp",
               "index.sort.order": "desc"
-            }
+            }{%- endif %}
           }
         },
         {

--- a/nested/README.md
+++ b/nested/README.md
@@ -56,7 +56,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 
 ### License

--- a/noaa/README.md
+++ b/noaa/README.md
@@ -50,7 +50,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 
 ### License

--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -66,7 +66,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 
 ### License

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -124,13 +124,13 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               "index.codec": "best_compression",
               "index.refresh_interval": "30s",
               "index.translog.flush_threshold_size": "4g",
               "index.sort.field": "pickup_datetime",
               "index.sort.order": "desc"
-            }
+            }{%- endif %}
           }
         },
         {

--- a/percolator/README.md
+++ b/percolator/README.md
@@ -26,7 +26,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 
 ### License

--- a/pmc/README.md
+++ b/pmc/README.md
@@ -35,7 +35,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * [`default_search_timeout`](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/search.html#global-search-timeout) (default: -1)
 * `cluster_health` (default: "green"): The minimum required cluster health.
 

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -192,11 +192,11 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               "index.refresh_interval": "30s",
-              "index.number_of_shards": 6,
+              "index.number_of_shards": {{number_of_shards | default(6)}},
               "index.translog.flush_threshold_size": "4g"
-            }
+            }{%- endif %}
           }
         },
         {

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -144,10 +144,10 @@
         {
           "operation": {
             "operation-type": "create-index",
-            "settings": {
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               "index.sort.field": "timestamp",
               "index.sort.order": "desc"
-            }
+            }{%- endif %}
           }
         },
         {

--- a/so/README.md
+++ b/so/README.md
@@ -49,7 +49,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
-* `index_settings`: A list of index settings. If it is defined, it replaces *all* other index settings (e.g. `number_of_replicas`).
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 
 ### License


### PR DESCRIPTION
With this commit we ensure that index settings can always be overridden
and also properties like the number of shards which are overridden
implicitly in some cases are properly overridable as well.

Relates #71