### PR TITLE
Disable shard request cache on index level

### DIFF
--- a/eventdata/index.json
+++ b/eventdata/index.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
-    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.requests.cache.enable": false
   },
   "mappings": {
     "dynamic": "strict",

--- a/geonames/index.json
+++ b/geonames/index.json
@@ -2,7 +2,8 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.store.type": "{{store_type | default('hybridfs')}}"
+    "index.store.type": "{{store_type | default('hybridfs')}}",
+    "index.requests.cache.enable": false
   },
   "mappings": {
     "dynamic": "strict",

--- a/geonames/operations/default.json
+++ b/geonames/operations/default.json
@@ -48,7 +48,6 @@
     {
       "name": "country_agg_uncached",
       "operation-type": "search",
-      "cache": false,
       "body": {
         "size": 0,
         "aggs": {

--- a/geonames/track.py
+++ b/geonames/track.py
@@ -35,9 +35,7 @@ class PureTermsQueryParamSource(QueryParamSource):
                 }
             },
             "index": None,
-            # This is the old name (before Rally 0.10.0). Remove after some grace period.
-            "use_request_cache": self._params.get("cache", False),
-            "cache": self._params.get("cache", False)
+            "cache": self._params.get("cache")
         }
         return result
 
@@ -68,9 +66,7 @@ class FilteredTermsQueryParamSource(QueryParamSource):
                 }
             },
             "index": None,
-            # This is the old name (before Rally 0.10.0). Remove after some grace period.
-            "use_request_cache": self._params.get("cache", False),
-            "cache": self._params.get("cache", False)
+            "cache": self._params.get("cache")
         }
         return result
 
@@ -101,9 +97,7 @@ class ProhibitedTermsQueryParamSource(QueryParamSource):
                 }
             },
             "index": None,
-            # This is the old name (before Rally 0.10.0). Remove after some grace period.
-            "use_request_cache": self._params.get("cache", False),
-            "cache": self._params.get("cache", False)
+            "cache": self._params.get("cache")
         }
         return result
 

--- a/geopoint/index.json
+++ b/geopoint/index.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
-    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.requests.cache.enable": false
   },
   "mappings": {
     "dynamic": "strict",

--- a/geopointshape/index.json
+++ b/geopointshape/index.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
-    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.requests.cache.enable": false
   },
   "mappings": {
     "dynamic": "strict",

--- a/geoshape/index.json
+++ b/geoshape/index.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
-    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.requests.cache.enable": false
   },
   "mappings": {
     "dynamic": "strict",

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
-    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.requests.cache.enable": false
   },
   "mappings": {
     "dynamic": "strict",

--- a/metricbeat/index.json
+++ b/metricbeat/index.json
@@ -2,6 +2,7 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.requests.cache.enable": false,
     "index.mapping.total_fields.limit": 20000,
     "index.search.slowlog.level" : "debug",
     "index.search.slowlog.threshold.fetch.debug" : "0s",

--- a/metricbeat/operations/default.json
+++ b/metricbeat/operations/default.json
@@ -7,7 +7,6 @@
     {
       "name": "autohisto_agg",
       "operation-type": "search",
-      "cache": false,
       "body": {
         "size": 0,
         "query": {
@@ -32,7 +31,6 @@
     {
       "name": "date_histogram_agg",
       "operation-type": "search",
-      "cache": false,
       "body": {
         "size": 0,
         "query": {

--- a/nested/index.json
+++ b/nested/index.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
-    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.requests.cache.enable": false
   },
   "mappings": {
     "dynamic": "strict",

--- a/nested/operations/default.json
+++ b/nested/operations/default.json
@@ -7,14 +7,12 @@
     {
       "name": "randomized-nested-queries",
       "operation-type": "search",
-      "param-source": "nested-query-source",
-      "cache": false
+      "param-source": "nested-query-source"
     },
     {
       "name": "randomized-nested-queries-with-inner-hits_default",
       "operation-type": "search",
       "param-source": "nested-query-source-with-inner-hits",
-      "cache": false,
       "size" : 10,
       "inner_hits_size" : 3
     },
@@ -22,21 +20,18 @@
       "name": "randomized-nested-queries-with-inner-hits_default_big_size",
       "operation-type": "search",
       "param-source": "nested-query-source-with-inner-hits",
-      "cache": false,
       "size" : 100,
       "inner_hits_size" : 100
     },
     {
       "name": "randomized-term-queries",
       "operation-type": "search",
-      "param-source": "term-query-source",
-      "cache": false
+      "param-source": "term-query-source"
     },
     {
       "name": "randomized-sorted-term-queries",
       "operation-type": "search",
-      "param-source": "sorted-term-query-source",
-      "cache": false
+      "param-source": "sorted-term-query-source"
     },
     {
       "name": "match-all",
@@ -45,8 +40,7 @@
         "query": {
           "match_all": {}
         }
-      },
-      "cache": false
+      }
     },
     {
       "name": "nested-date-histo",
@@ -68,6 +62,5 @@
             }
           }
         }
-      },
-      "cache": false
+      }
     }

--- a/nested/track.py
+++ b/nested/track.py
@@ -51,9 +51,7 @@ class SortedTermQueryParamSource(QueryParamSource):
                 ]
             },
             "index": None,
-            # This is the old name (before Rally 0.10.0). Remove after some grace period.
-            "use_request_cache": self._params["cache"],
-            "cache": self._params["cache"]
+            "cache": self._params.get("cache")
         }
         return result
 
@@ -69,9 +67,7 @@ class TermQueryParamSource(QueryParamSource):
                 }
             },
             "index": None,
-            # This is the old name (before Rally 0.10.0). Remove after some grace period.
-            "use_request_cache": self._params["cache"],
-            "cache": self._params["cache"]
+            "cache": self._params.get("cache")
         }
         return result
 
@@ -105,9 +101,7 @@ class NestedQueryParamSource(QueryParamSource):
                 }
             },
             "index": None,
-            # This is the old name (before Rally 0.10.0). Remove after some grace period.
-            "use_request_cache": self._params["cache"],
-            "cache": self._params["cache"]
+            "cache": self._params.get("cache")
         }
         return result
 
@@ -145,9 +139,7 @@ class NestedQueryParamSourceWithInnerHits(QueryParamSource):
                 "size": self._params["size"]
             },
             "index": None,
-            # This is the old name (before Rally 0.10.0). Remove after some grace period.
-            "use_request_cache": self._params["cache"],
-            "cache": self._params["cache"]
+            "cache": self._params.get("cache")
         }
         return result
 

--- a/noaa/index.json
+++ b/noaa/index.json
@@ -3,6 +3,7 @@
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
     "index.queries.cache.enabled": false,
+    "index.requests.cache.enable": false,
     "index.merge.policy.max_merged_segment": "100GB"
   },
   "mappings": {

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(1)}},
-    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.requests.cache.enable": false
   },
   "mappings": {
     "_source": {

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -40,7 +40,6 @@
     {
       "name": "distance_amount_agg",
       "operation-type": "search",
-      "cache": false,
       "body": {
         "size": 0,
         "aggs": {
@@ -63,7 +62,6 @@
     {
       "name": "autohisto_agg",
       "operation-type": "search",
-      "cache": false,
       "body": {
         "size": 0,
         "query": {
@@ -88,7 +86,6 @@
     {
       "name": "date_histogram_agg",
       "operation-type": "search",
-      "cache": false,
       "body": {
         "size": 0,
         "query": {

--- a/percolator/index.json
+++ b/percolator/index.json
@@ -2,7 +2,8 @@
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
-    "index.queries.cache.enabled": false
+    "index.queries.cache.enabled": false,
+    "index.requests.cache.enable": false
   },
   "mappings": {
     "_source": {

--- a/pmc/index.json
+++ b/pmc/index.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
-    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.requests.cache.enable": false
   },
   "mappings": {
     "_source": {

--- a/pmc/operations/default.json
+++ b/pmc/operations/default.json
@@ -48,7 +48,6 @@
     {
       "name": "articles_monthly_agg_uncached",
       "operation-type": "search",
-      "cache": false,
       "body": {
         "size": 0,
         "aggs": {

--- a/so/index.json
+++ b/so/index.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index.number_of_shards": {{number_of_shards | default(5)}},
-    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.requests.cache.enable": false
   },
   "mappings": {
     "dynamic": "strict",


### PR DESCRIPTION
With this commit we disable the shard request cache on index level.
Previously, Rally implicitly always disabled the shard request cache per
request. This behavior is wrong because it does not allow the user to
rely on the index-level setting and consequently, Rally needs to allow
this behavior. In order to avoid breaking existing benchmarks, we
instead disable the shard request cache now for all indices.

Relates elastic/rally#596