### PR TITLE
Allow configure `conflicts` for updates

### DIFF
--- a/geonames/README.md
+++ b/geonames/README.md
@@ -38,7 +38,8 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
-* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective challenge.
+* `conflicts` (default: "random"): Type of id conflicts to simulate. Valid values are: 'sequential' (A document id is replaced with a document id with a sequentially increasing id), 'random' (A document id is replaced with a document id with a random other id).
+* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective challenge. Combining ``conflicts=sequential`` and ``conflict-probability=0`` makes Rally generate index ids by itself, instead of relying on Elasticsearch's `automatic id generation <https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_automatic_id_generation>`_.
 * `on_conflict` (default: "index"): Whether to use an "index" or an "update" action when simulating an id conflict.
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Rally docs](http://esrally.readthedocs.io/en/latest/track.html#bulk) for the full definition of this parameter. This requires to run the respective challenge.
 * `number_of_replicas` (default: 0)

--- a/geonames/operations/default.json
+++ b/geonames/operations/default.json
@@ -9,7 +9,7 @@
       "operation-type": "bulk",
       "bulk-size": {{bulk_size | default(5000)}},
       "ingest-percentage": {{ingest_percentage | default(100)}},
-      "conflicts": "random",
+      "conflicts": "{{conflicts | default('random')}}",
       "on-conflict": "{{on_conflict | default('index')}}",
       "conflict-probability": {{conflict_probability | default(25)}},
       "recency": {{recency | default(0)}}

--- a/geopoint/README.md
+++ b/geopoint/README.md
@@ -20,7 +20,8 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
-* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective challenge.
+* `conflicts` (default: "random"): Type of id conflicts to simulate. Valid values are: 'sequential' (A document id is replaced with a document id with a sequentially increasing id), 'random' (A document id is replaced with a document id with a random other id).
+* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective challenge. Combining ``conflicts=sequential`` and ``conflict-probability=0`` makes Rally generate index ids by itself, instead of relying on Elasticsearch's `automatic id generation <https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_automatic_id_generation>`_.
 * `on_conflict` (default: "index"): Whether to use an "index" or an "update" action when simulating an id conflict.
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Rally docs](http://esrally.readthedocs.io/en/latest/track.html#bulk) for the full definition of this parameter. This requires to run the respective challenge.
 * `number_of_replicas` (default: 0)

--- a/geopoint/operations/default.json
+++ b/geopoint/operations/default.json
@@ -9,7 +9,7 @@
       "operation-type": "bulk",
       "bulk-size": {{bulk_size | default(5000)}},
       "ingest-percentage": {{ingest_percentage | default(100)}},
-      "conflicts": "random",
+      "conflicts": "{{conflicts | default('random')}}",
       "on-conflict": "{{on_conflict | default('index')}}",
       "conflict-probability": {{conflict_probability | default(25)}},
       "recency": {{recency | default(0)}}

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -36,6 +36,8 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
+* `conflicts` (default: "random"): Type of id conflicts to simulate. Valid values are: 'sequential' (A document id is replaced with a document id with a sequentially increasing id), 'random' (A document id is replaced with a document id with a random other id).
+* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective challenge. Combining ``conflicts=sequential`` and ``conflict-probability=0`` makes Rally generate index ids by itself, instead of relying on Elasticsearch's `automatic id generation <https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_automatic_id_generation>`_.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -34,7 +34,7 @@
       "operation-type": "bulk",
       "bulk-size": {{bulk_size | default(5000)}},
       "ingest-percentage": {{ingest_percentage | default(100)}},
-      "conflicts": "random",
+      "conflicts": "{{conflicts | default('random')}}",
       "on-conflict": "{{on_conflict | default('update')}}",
       "conflict-probability": {{conflict_probability | default(25)}},
       "recency": {{recency | default(0)}},

--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -60,7 +60,8 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_size` (default: 10000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
-* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. Only used by the `update` challenge.
+* `conflicts` (default: "random"): Type of id conflicts to simulate. Valid values are: 'sequential' (A document id is replaced with a document id with a sequentially increasing id), 'random' (A document id is replaced with a document id with a random other id).
+* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. Only used by the `update` challenge. Combining ``conflicts=sequential`` and ``conflict-probability=0`` makes Rally generate index ids by itself, instead of relying on Elasticsearch's `automatic id generation <https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_automatic_id_generation>`_.
 * `on_conflict` (default: "index"): Whether to use an "index" or an "update" action when simulating an id conflict. Only used by the `update` challenge.
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Rally docs](http://esrally.readthedocs.io/en/latest/track.html#bulk) for the full definition of this parameter. Only used by the `update` challenge.
 * `number_of_replicas` (default: 0)

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -9,7 +9,7 @@
       "operation-type": "bulk",
       "bulk-size": {{bulk_size | default(10000)}},
       "ingest-percentage": {{ingest_percentage | default(100)}},
-      "conflicts": "random",
+      "conflicts": "{{conflicts | default('random')}}",
       "on-conflict": "{{on_conflict | default('update')}}",
       "conflict-probability": {{conflict_probability | default(25)}},
       "recency": {{recency | default(0)}}

--- a/pmc/README.md
+++ b/pmc/README.md
@@ -29,7 +29,8 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `bulk_size` (default: 500)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
-* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective challenge.
+* `conflicts` (default: "random"): Type of id conflicts to simulate. Valid values are: 'sequential' (A document id is replaced with a document id with a sequentially increasing id), 'random' (A document id is replaced with a document id with a random other id).
+* `conflict_probability` (default: 25): A number between 0 and 100 that defines the probability of id conflicts. This requires to run the respective challenge. Combining ``conflicts=sequential`` and ``conflict-probability=0`` makes Rally generate index ids by itself, instead of relying on Elasticsearch's `automatic id generation <https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_automatic_id_generation>`_.
 * `on_conflict` (default: "index"): Whether to use an "index" or an "update" action when simulating an id conflict.
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Rally docs](http://esrally.readthedocs.io/en/latest/track.html#bulk) for the full definition of this parameter. This requires to run the respective challenge.
 * `number_of_replicas` (default: 0)

--- a/pmc/operations/default.json
+++ b/pmc/operations/default.json
@@ -9,7 +9,7 @@
       "operation-type": "bulk",
       "bulk-size": {{bulk_size | default(500)}},
       "ingest-percentage": {{ingest_percentage | default(100)}},
-      "conflicts": "random",
+      "conflicts": "{{conflicts | default('random')}}",
       "on-conflict": "{{on_conflict | default('index')}}",
       "conflict-probability": {{conflict_probability | default(25)}},
       "recency": {{recency | default(0)}}


### PR DESCRIPTION
With this commit, we allow overriding the conflict type for update challenge of some tracks. One use case is to pass `sequential` for `conflicts` and `0` for `conflict_probability` to disable Elasticsearch's auto-generated id for append-only indices.