### PR TITLE
Update target throughout for nested randomized-sorted-term-queries

### DIFF
--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -61,7 +61,7 @@
           "operation": "randomized-sorted-term-queries",
           "clients": 2,
           "warmup-iterations": 500,
-          "target-throughput": 18,
+          "target-throughput": 16
           "iterations": 200
         },
         {


### PR DESCRIPTION
Address high latency spikes for the query on the new env, as never reach
the target throughput.