### PR TITLE
Adjust to new parameter source API

### DIFF
--- a/geonames/track.py
+++ b/geonames/track.py
@@ -7,6 +7,7 @@ class QueryParamSource:
     # noinspection PyUnusedLocal
     def __init__(self, track, params, **kwargs):
         self._params = params
+        self.infinite = True
         cwd = os.path.dirname(__file__)
         # The terms.txt file has been generated with:
         # sed -n '13~250p' [path_to_rally_data]/geonames/documents.json | shuf | sed -e "s/.*name\": \"//;s/\",.*$//" > terms.txt
@@ -18,6 +19,7 @@ class QueryParamSource:
     def partition(self, partition_index, total_partitions):
         return self
 
+    # Deprecated - only there for BWC reasons with Rally < 1.4.0
     def size(self):
         return 1
 

--- a/nested/track.py
+++ b/nested/track.py
@@ -8,6 +8,7 @@ class QueryParamSource:
     # noinspection PyUnusedLocal
     def __init__(self, track, params, **kwargs):
         self._params = params
+        self.infinite = True
         # here we read the queries data file into arrays which we'll then later use randomly.
         self.tags = []
         self.dates = []
@@ -25,6 +26,7 @@ class QueryParamSource:
     def partition(self, partition_index, total_partitions):
         return self
 
+    # Deprecated - only there for BWC reasons with Rally < 1.4.0
     def size(self):
         return 1
 


### PR DESCRIPTION
With this commit we change the existing parameter sources to conform to
a new API for parameter sources in Rally. We also keep the old methods
for backwards compatibility with older releases of Rally.

Relates elastic/rally#763