### PR TITLE
Replace interval parameter with fixed_interval and calendar_interval

### DIFF
--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -89,7 +89,7 @@
           "by_hour": {
             "date_histogram": {
               "field": "@timestamp",
-              "interval": "hour"
+              "fixed_interval": "hour"
             }
           }
         }

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -89,7 +89,7 @@
           "by_hour": {
             "date_histogram": {
               "field": "@timestamp",
-              "fixed_interval": "hour"
+              "fixed_interval": "1h"
             }
           }
         }

--- a/metricbeat/operations/default.json
+++ b/metricbeat/operations/default.json
@@ -46,7 +46,7 @@
           "occurrences_over_time": {
             "date_histogram": {
               "field": "@timestamp",
-              "fixed_interval": "hour"
+              "fixed_interval": "1h"
             }
           }
         }

--- a/metricbeat/operations/default.json
+++ b/metricbeat/operations/default.json
@@ -46,7 +46,7 @@
           "occurrences_over_time": {
             "date_histogram": {
               "field": "@timestamp",
-              "interval": "hour"
+              "fixed_interval": "hour"
             }
           }
         }

--- a/nested/operations/default.json
+++ b/nested/operations/default.json
@@ -56,7 +56,7 @@
               "date_histo": {
                 "date_histogram": {
                   "field": "answers.date",
-                  "fixed_interval": "month"
+                  "calendar_interval": "month"
                 }
               }
             }

--- a/nested/operations/default.json
+++ b/nested/operations/default.json
@@ -56,7 +56,7 @@
               "date_histo": {
                 "date_histogram": {
                   "field": "answers.date",
-                  "interval": "month"
+                  "fixed_interval": "month"
                 }
               }
             }

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -287,7 +287,7 @@
                 "buckets": {
                   "date_histogram": {
                     "field": "pickup_datetime",
-                    "fixed_interval": 3600000,
+                    "fixed_interval": "3600000ms",
                     "offset": 0,
                     "order": {
                       "_key": "asc"

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -287,7 +287,7 @@
                 "buckets": {
                   "date_histogram": {
                     "field": "pickup_datetime",
-                    "interval": 3600000,
+                    "fixed_interval": 3600000,
                     "offset": 0,
                     "order": {
                       "_key": "asc"

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -101,7 +101,7 @@
           "dropoffs_over_time": {
             "date_histogram": {
               "field": "dropoff_datetime",
-              "interval": "day"
+              "fixed_interval": "day"
             }
           }
         }

--- a/pmc/operations/default.json
+++ b/pmc/operations/default.json
@@ -54,7 +54,7 @@
           "articles_over_time": {
             "date_histogram": {
               "field": "timestamp",
-              "fixed_interval": "month"
+              "calendar_interval": "month"
             }
           }
         }
@@ -70,7 +70,7 @@
           "articles_over_time": {
             "date_histogram": {
               "field": "timestamp",
-              "fixed_interval": "month"
+              "calendar_interval": "month"
             }
           }
         }

--- a/pmc/operations/default.json
+++ b/pmc/operations/default.json
@@ -54,7 +54,7 @@
           "articles_over_time": {
             "date_histogram": {
               "field": "timestamp",
-              "interval": "month"
+              "fixed_interval": "month"
             }
           }
         }
@@ -70,7 +70,7 @@
           "articles_over_time": {
             "date_histogram": {
               "field": "timestamp",
-              "interval": "month"
+              "fixed_interval": "month"
             }
           }
         }


### PR DESCRIPTION
The `interval` parameter is now deprecated, so we must now use `fixed_interval` or `calendar_interval` in our queries.