### PR TITLE
Ensure http_logs sort query benchmarks are stable

### DIFF
--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -83,14 +83,14 @@
           "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 0.8
+          "target-throughput": 0.5
         },
         {
           "operation": "asc_sort_timestamp",
           "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 0.8
+          "target-throughput": 0.5
         }
       ]
     },


### PR DESCRIPTION
With this commit we lower the target througput for the queries
`asc_sort_timestamp` and `desc_sort_timestamp` in the `http_logs` track.
While we have already reduced the target throughput in
9c00dfc27d7d5ad51c0e45363de4bc0d73e69219 shortly after they have been
added in #77, this reduction was not sufficient and the benchmarks are
not stable (i.e. latency skyrockets). After investigating service times
for both queries over the previous months we have observed at most
~ 1700 ms service time so a target throughput of 0.5 (one query every
two seconds) should stabilize the benchmark on our nightly hardware.

Relates #77