### PR TITLE
http_logs add force merge to 1 segment

### DIFF
--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -96,7 +96,8 @@
           "name": "force-merge-1-seg",
           "operation": {
             "operation-type": "force-merge",
-            "max-num-segments": 1
+            "max-num-segments": 1,
+            "request-timeout": 7200
           },
           "clients": 1
         },

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -91,6 +91,35 @@
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 0.5
+        },
+        {
+          "name": "force-merge-1-seg",
+          "operation": {
+            "operation-type": "force-merge",
+            "max-num-segments": 1
+          },
+          "clients": 1
+        },
+        {
+          "name": "refresh-after-force-merge-1-seg",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "name": "desc-sort-timestamp-after-force-merge-1-seg",
+          "operation": "desc_sort_timestamp",
+          "clients": 1,
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 0.5
+        },
+        {
+          "name": "asc-sort-timestamp-after-force-merge-1-seg",
+          "operation": "asc_sort_timestamp",
+          "clients": 1,
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 0.5
         }
       ]
     },


### PR DESCRIPTION
Measure the performance of sort operations
after force merging to 1 segment.

PR https://github.com/elastic/elasticsearch/pull/48533  adds a new merge policy that interleaves old and new
segments on force merge. This checks the sort
performance with this policy after docs are merged to
1 segment.