### PR TITLE
Add reindex operation

### DIFF
--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -121,22 +121,6 @@
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 0.5
-        },
-        {
-          "name": "reindex",
-          "operation": {
-            "operation-type": "reindex",
-            "body": {
-              "source": {
-                "index": "logs-*"
-              },
-              "dest": {
-                "index": "reindexed-logs"
-              }
-            },
-            "request_timeout": 7200
-          },
-          "clients": 1
         }
       ]
     },
@@ -331,7 +315,7 @@
     },
     {
       "name": "append-no-conflicts-index-reindex-only",
-      "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After indexing, same data are reindexed",
+      "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After indexing, same data are reindexed.",
       "schedule": [
         {
           "operation": "delete-index"

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -121,6 +121,22 @@
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 0.5
+        },
+        {
+          "name": "reindex",
+          "operation": {
+            "operation-type": "reindex",
+            "body": {
+              "source": {
+                "index": "logs-*"
+              },
+              "dest": {
+                "index": "reindexed-logs"
+              }
+            },
+            "request_timeout": 7200
+          },
+          "clients": 1
         }
       ]
     },
@@ -309,6 +325,67 @@
         {
           "name": "refresh-after-force-merge",
           "operation": "refresh",
+          "clients": 1
+        }
+      ]
+    },
+    {
+      "name": "append-no-conflicts-index-reindex-only",
+      "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After indexing, same data are reindexed",
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "logs-*",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "index-append",
+          "warmup-time-period": 240,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "name": "reindex",
+          "operation": {
+            "operation-type": "reindex",
+            "body": {
+              "source": {
+                "index": "logs-*"
+              },
+              "dest": {
+                "index": "reindexed-logs"
+              }
+            },
+            "request_timeout": 7200
+          },
           "clients": 1
         }
       ]

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -32,6 +32,10 @@
     {
       "name": "logs-241998",
       "body": "index.json"
+    },
+    {
+      "name": "reindexed-logs",
+      "body": "index.json"
     }
   ],
   "corpora": [

--- a/http_logs/track.py
+++ b/http_logs/track.py
@@ -1,0 +1,5 @@
+def reindex(es, params):
+  es.reindex(body=params.get("body"), request_timeout=params.get("request_timeout"))
+
+def register(registry):
+  registry.register_runner("reindex", reindex)

--- a/http_logs/track.py
+++ b/http_logs/track.py
@@ -1,5 +1,6 @@
 def reindex(es, params):
-  es.reindex(body=params.get("body"), request_timeout=params.get("request_timeout"))
+  result = es.reindex(body=params.get("body"), request_timeout=params.get("request_timeout"))
+  return result["total"], "docs"
 
 def register(registry):
   registry.register_runner("reindex", reindex)


### PR DESCRIPTION
Add reindex operation to http_logs track in order to
verify reindex performance before and after resilient
reindex implementation as well as keep an eye on it
for the future.

Relates elastic/elasticsearch#42612