### PR TITLE
Set cluster-settings via API

### DIFF
--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -2,10 +2,17 @@
       "name": "append-no-conflicts",
       "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
       "default": true,
-      "cluster-settings": {
-        "search.default_search_timeout": "{{default_search_timeout | default(-1)}}"
-      },
       "schedule": [
+        {
+          "operation": {
+            "operation-type": "put-settings",
+            "body": {
+              "transient": {
+                  "search.default_search_timeout": "{{default_search_timeout | default(-1)}}"
+              }
+            }
+          }
+        },
         {
           "operation": "delete-index"
         },

--- a/pmc/track.py
+++ b/pmc/track.py
@@ -1,0 +1,10 @@
+def put_settings(es, params):
+    es.cluster.put_settings(body=params["body"])
+
+
+def register(registry):
+    # register a fallback for older Rally versions
+    try:
+        from esrally.driver.runner import PutSettings
+    except ImportError:
+        registry.register_runner("put-settings", put_settings)


### PR DESCRIPTION
With this commit we avoid the soon to be deprecated track property
`cluster-settings` in the `pmc` track and instead implement a fallback
using the update cluster settings API. Newer versions of Rally will
expose this API via a runner but for older versions we need to implement
it in the track.