### PR TITLE
Update http_logs and geonames target throughput

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -202,14 +202,14 @@
           "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 1.5
+          "target-throughput": 6
         },
         {
           "operation": "asc_sort_geonameid",
           "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 1.5
+          "target-throughput": 6
         }
       ]
     },

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -112,7 +112,7 @@
           "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 0.5
+          "target-throughput": 2
         },
         {
           "name": "asc-sort-timestamp-after-force-merge-1-seg",
@@ -120,7 +120,7 @@
           "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 0.5
+          "target-throughput": 2
         }
       ]
     },


### PR DESCRIPTION
Update target throughput for some sort queries to reflect speed
improvement for sorting numeric long and date fields queries.

Relates to:
https://github.com/elastic/elasticsearch/commit/fa8b48deefbec1eb58161252552628a1a0866e5f

Closes: https://github.com/elastic/night-rally/issues/151