### PR TITLE
Use async runners if needed

### DIFF
--- a/http_logs/track.py
+++ b/http_logs/track.py
@@ -1,6 +1,16 @@
 def reindex(es, params):
-  result = es.reindex(body=params.get("body"), request_timeout=params.get("request_timeout"))
-  return result["total"], "docs"
+    result = es.reindex(body=params.get("body"), request_timeout=params.get("request_timeout"))
+    return result["total"], "docs"
+
+
+async def reindex_async(es, params):
+    result = await es.reindex(body=params.get("body"), request_timeout=params.get("request_timeout"))
+    return result["total"], "docs"
+
 
 def register(registry):
-  registry.register_runner("reindex", reindex)
+    async_runner = registry.meta_data.get("async_runner", False)
+    if async_runner:
+        registry.register_runner("reindex", reindex_async, async_runner=True)
+    else:
+        registry.register_runner("reindex", reindex)


### PR DESCRIPTION
Due to elastic/rally#852 we will implement a compatibility layer in the
current load generator that will also use the asyncio API and thus
requires custom runners to be registered differently (by specifying
`async_runner=True`). Rally's runner registry will also expose a new
attribute `async_runner` that is set to `True` if Rally requires runners
to be registered as described above.

With this commit we introduce a (temporary) compatibility layer for all
custom runners that allows older Rally versions to work with the classic
runners and newer Rally versions with the async runners.

Relates elastic/rally#852