### PR TITLE
Set cluster-settings via API

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -2,11 +2,18 @@
       "name": "append-no-conflicts",
       "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
       "default": true,
-      "#COMMENT": "We set indices.query.bool.max_clause_count in order to allow to run the large_terms queries (default is 1024, we need more than 45.000)",
-      "cluster-settings": {
-        "indices.query.bool.max_clause_count": 50000
-      },
       "schedule": [
+        {
+          "#COMMENT": "We set indices.query.bool.max_clause_count in order to allow to run the large_terms queries (default is 1024, we need more than 45.000)",
+          "operation": {
+            "operation-type": "put-settings",
+            "body": {
+              "transient": {
+                "indices.query.bool.max_clause_count": 50000
+              }
+            }
+          }
+        },
         {
           "operation": "delete-index"
         },

--- a/geonames/track.py
+++ b/geonames/track.py
@@ -117,7 +117,16 @@ def refresh(es, params):
     es.indices.refresh(index=params.get("index", "_all"))
 
 
+def put_settings(es, params):
+    es.cluster.put_settings(body=params["body"])
+
+
 def register(registry):
     registry.register_param_source("pure-terms-query-source", PureTermsQueryParamSource)
     registry.register_param_source("filtered-terms-query-source", FilteredTermsQueryParamSource)
     registry.register_param_source("prohibited-terms-query-source", ProhibitedTermsQueryParamSource)
+    # register a fallback for older Rally versions
+    try:
+        from esrally.driver.runner import PutSettings
+    except ImportError:
+        registry.register_runner("put-settings", put_settings)


### PR DESCRIPTION
With this commit we avoid the deprecated track property
`cluster-settings` and replace it with an explicit API call.

Relates #93
Relates elastic/rally#831
Relates elastic/rally#915