### PR TITLE
Remove documents with negative population from geonames

### DIFF
--- a/geonames/track.json
+++ b/geonames/track.json
@@ -16,9 +16,9 @@
       "documents": [
         {
           "source-file": "documents-2.json.bz2",
-          "document-count": 11396505,
-          "compressed-bytes": 264698741,
-          "uncompressed-bytes": 3547614383
+          "document-count": 11396503,
+          "compressed-bytes": 265208777,
+          "uncompressed-bytes": 3547613828
         }
       ]
     }


### PR DESCRIPTION
As per #100 we need to remove the two docs with negative population from the
geonames track.

Closes #100