### PR TITLE
Add challenge for top_hits

### DIFF
--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -149,7 +149,7 @@
     },
     {
       "name": "top_metrics",
-      "description": "dsfadfasdfsadf NOCOMMIT",
+      "description": "Compares the performance of top_metrics and top_hits",
       "default": false,
       "schedule": [
         {
@@ -157,7 +157,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 4
         },
         {
@@ -165,7 +164,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 4
         },
         {
@@ -173,7 +171,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 4
         },
         {
@@ -181,7 +178,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 2
         },
         {
@@ -189,7 +185,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 2
         },
         {
@@ -197,7 +192,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 2
         },
         {
@@ -205,7 +199,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 2
         },
         {
@@ -213,7 +206,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 1
         },
         {
@@ -221,7 +213,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 1
         },
         {
@@ -229,7 +220,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 1
         },
         {
@@ -237,7 +227,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 1
         },
         {
@@ -245,7 +234,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 1
         },
         {
@@ -253,7 +241,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 1
         },
         {
@@ -261,7 +248,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
-          "#COMMENT": "the numbers above are super low",
           "target-throughput": 1
         }
       ]

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -195,6 +195,13 @@
           "target-throughput": 2
         },
         {
+          "operation": "last_min_and_max_temp_per_station_top_metrics_10",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "target-throughput": 2
+        },
+        {
           "operation": "last_five_max_temp_per_station_top_metrics_10",
           "clients": 1,
           "warmup-iterations": 10,
@@ -252,6 +259,13 @@
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_5000",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-throughput": 1
+        },
+        {
+          "operation": "last_min_and_max_temp_per_station_top_metrics_5000",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -195,6 +195,13 @@
           "target-throughput": 2
         },
         {
+          "operation": "last_five_max_temp_per_station_top_metrics_10",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "target-throughput": 2
+        },
+        {
           "operation": "max_temp_per_station_10_depth_first",
           "clients": 1,
           "warmup-iterations": 10,
@@ -245,6 +252,13 @@
         },
         {
           "operation": "last_max_temp_per_station_top_metrics_5000",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-throughput": 1
+        },
+        {
+          "operation": "last_five_max_temp_per_station_top_metrics_5000",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -146,4 +146,123 @@
           "clients": 1
         }
       ]
+    },
+    {
+      "name": "top_metrics",
+      "description": "dsfadfasdfsadf NOCOMMIT",
+      "default": false,
+      "schedule": [
+        {
+          "operation": "max_temp",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 4
+        },
+        {
+          "operation": "last_max_temp_top_hits",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 4
+        },
+        {
+          "operation": "last_max_temp_top_metrics",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 4
+        },
+        {
+          "operation": "max_temp_per_station_10",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 2
+        },
+        {
+          "operation": "last_max_temp_per_station_top_hits_10",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 2
+        },
+        {
+          "operation": "last_max_temp_per_station_top_metrics_10",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 2
+        },
+        {
+          "operation": "max_temp_per_station_10_depth_first",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 2
+        },
+        {
+          "operation": "last_max_temp_per_station_top_hits_10_depth_first",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 1
+        },
+        {
+          "operation": "last_max_temp_per_station_top_metrics_10_depth_first",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 1
+        },
+        {
+          "operation": "last_max_temp_per_station_top_metrics_10_sort_by",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 1
+        },
+        {
+          "operation": "max_temp_per_station_5000",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 1
+        },
+        {
+          "operation": "last_max_temp_per_station_top_hits_5000",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 1
+        },
+        {
+          "operation": "last_max_temp_per_station_top_hits_5000_via_source",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 1
+        },
+        {
+          "operation": "last_max_temp_per_station_top_metrics_5000",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "#COMMENT": "the numbers above are super low",
+          "target-throughput": 1
+        }
+      ]
     }

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -153,6 +153,46 @@
       "default": false,
       "schedule": [
         {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "weather-data-2016",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "index",
+          "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
+          "warmup-time-period": 10,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
           "operation": "max_temp",
           "clients": 1,
           "warmup-iterations": 10,

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -243,7 +243,7 @@
           "last_temp": {
             "top_metrics": {
               "sort": {"date": "desc"},
-              "metric": {"field": "TMAX"}
+              "metrics": {"field": "TMAX"}
             }
           }
         }
@@ -332,7 +332,40 @@
               "last_temp": {
                 "top_metrics": {
                   "sort": {"date": "desc"},
-                  "metric": {"field": "TMAX"}
+                  "metrics": {"field": "TMAX"}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_min_and_max_temp_per_station_top_metrics_10",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 10
+            },
+            "aggs": {
+              "last_temp": {
+                "top_metrics": {
+                  "sort": {"date": "desc"},
+                  "metrics": [
+                    {"field": "TMIN"},
+                    {"field": "TMAX"}
+                  ]
                 }
               }
             }
@@ -363,7 +396,7 @@
                 "top_metrics": {
                   "size": 5,
                   "sort": {"date": "desc"},
-                  "metric": {"field": "TMAX"}
+                  "metrics": {"field": "TMAX"}
                 }
               }
             }
@@ -457,7 +490,7 @@
               "last_temp": {
                 "top_metrics": {
                   "sort": {"date": "desc"},
-                  "metric": {"field": "TMAX"}
+                  "metrics": {"field": "TMAX"}
                 }
               }
             }
@@ -488,7 +521,7 @@
               "last_temp": {
                 "top_metrics": {
                   "sort": {"date": "desc"},
-                  "metric": {"field": "TMAX"}
+                  "metrics": {"field": "TMAX"}
                 }
               }
             }
@@ -609,7 +642,40 @@
               "last_temp": {
                 "top_metrics": {
                   "sort": {"date": "desc"},
-                  "metric": {"field": "TMAX"}
+                  "metrics": {"field": "TMAX"}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_min_and_max_temp_per_station_top_metrics_5000",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 5000
+            },
+            "aggs": {
+              "last_temp": {
+                "top_metrics": {
+                  "sort": {"date": "desc"},
+                  "metrics": [
+                    {"field": "TMIN"},
+                    {"field": "TMAX"}
+                  ]
                 }
               }
             }
@@ -640,7 +706,7 @@
                 "top_metrics": {
                   "size": 5,
                   "sort": {"date": "desc"},
-                  "metric": {"field": "TMAX"}
+                  "metrics": {"field": "TMAX"}
                 }
               }
             }

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -181,5 +181,409 @@
           }
         }
       }
+    },
+    {
+      "name": "max_temp",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "max_temp": {
+            "max": {
+              "field": "TMAX"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_max_temp_top_hits",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "last_temp": {
+            "top_hits": {
+              "size": 1,
+              "sort": {"date": "desc"},
+              "stored_fields": "_none_",
+              "docvalue_fields": ["TMAX"]
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_max_temp_top_metrics",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "last_temp": {
+            "top_metrics": {
+              "sort": {"date": "desc"},
+              "metric": {"field": "TMAX"}
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "max_temp_per_station_10",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 10
+            },
+            "aggs": {
+              "max_temp": {
+                "max": {
+                  "field": "TMAX"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_max_temp_per_station_top_hits_10",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 10
+            },
+            "aggs": {
+              "last_temp": {
+                "top_hits": {
+                  "size": 1,
+                  "sort": {"date": "desc"},
+                  "stored_fields": "_none_",
+                  "docvalue_fields": ["TMAX"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_max_temp_per_station_top_metrics_10",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 10
+            },
+            "aggs": {
+              "last_temp": {
+                "top_metrics": {
+                  "sort": {"date": "desc"},
+                  "metric": {"field": "TMAX"}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "max_temp_per_station_10_depth_first",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 10,
+              "collect_mode" : "depth_first"
+            },
+            "aggs": {
+              "max_temp": {
+                "max": {
+                  "field": "TMAX"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_max_temp_per_station_top_hits_10_depth_first",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 10,
+              "collect_mode" : "depth_first"
+            },
+            "aggs": {
+              "last_temp": {
+                "top_hits": {
+                  "size": 1,
+                  "sort": {"date": "desc"},
+                  "stored_fields": "_none_",
+                  "docvalue_fields": ["TMAX"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_max_temp_per_station_top_metrics_10_depth_first",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 10,
+              "collect_mode" : "depth_first"
+            },
+            "aggs": {
+              "last_temp": {
+                "top_metrics": {
+                  "sort": {"date": "desc"},
+                  "metric": {"field": "TMAX"}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_max_temp_per_station_top_metrics_10_sort_by",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 10,
+              "order": { "last_temp.TMAX": "desc" }
+            },
+            "aggs": {
+              "last_temp": {
+                "top_metrics": {
+                  "sort": {"date": "desc"},
+                  "metric": {"field": "TMAX"}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "max_temp_per_station_5000",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 5000
+            },
+            "aggs": {
+              "max_temp": {
+                "max": {
+                  "field": "TMAX"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_max_temp_per_station_top_hits_5000",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 5000
+            },
+            "aggs": {
+              "last_temp": {
+                "top_hits": {
+                  "size": 1,
+                  "sort": {"date": "desc"},
+                  "stored_fields": "_none_",
+                  "docvalue_fields": ["TMAX"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_max_temp_per_station_top_hits_5000_via_source",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 5000
+            },
+            "aggs": {
+              "last_temp": {
+                "top_hits": {
+                  "size": 1,
+                  "sort": {"date": "desc"}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_max_temp_per_station_top_metrics_5000",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 5000
+            },
+            "aggs": {
+              "last_temp": {
+                "top_metrics": {
+                  "sort": {"date": "desc"},
+                  "metric": {"field": "TMAX"}
+                }
+              }
+            }
+          }
+        }
+      }
     }
     

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -341,6 +341,37 @@
       }
     },
     {
+      "name": "last_five_max_temp_per_station_top_metrics_10",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 10
+            },
+            "aggs": {
+              "last_temp": {
+                "top_metrics": {
+                  "size": 5,
+                  "sort": {"date": "desc"},
+                  "metric": {"field": "TMAX"}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "max_temp_per_station_10_depth_first",
       "operation-type": "search",
       "body": {
@@ -577,6 +608,37 @@
             "aggs": {
               "last_temp": {
                 "top_metrics": {
+                  "sort": {"date": "desc"},
+                  "metric": {"field": "TMAX"}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "last_five_max_temp_per_station_top_metrics_5000",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+          "range": {
+            "station.elevation": {
+              "gt": 1000
+            }
+          }
+        },
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 5000
+            },
+            "aggs": {
+              "last_temp": {
+                "top_metrics": {
+                  "size": 5,
                   "sort": {"date": "desc"},
                   "metric": {"field": "TMAX"}
                 }


### PR DESCRIPTION
This adds a rally track to compare `top_hits` and `top_metrics`. It was
useful for me when writing `top_metrics` but I've not added it to the
nightly runs because those are already busy enough and I'm the only
doing work in this area.