### PR TITLE
Ensure proper warmup for country_agg_cached

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -87,7 +87,7 @@
         {
           "operation": "country_agg_cached",
           "clients": 1,
-          "warmup-iterations": 500,
+          "warmup-iterations": 1000,
           "iterations": 1000,
           "target-throughput": 100
         },


### PR DESCRIPTION
With this commit we bump the number of warmup iterations for the
`country_agg_cached` task in geonames to account for proper warmup.