### PR TITLE
Ensure segments are merged

### DIFF
--- a/eventdata/challenges/default.json
+++ b/eventdata/challenges/default.json
@@ -29,8 +29,10 @@
           "clients": {{bulk_indexing_clients | default(8)}}
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         }
       ]
     }

--- a/eventdata/challenges/default.json
+++ b/eventdata/challenges/default.json
@@ -33,6 +33,19 @@
             "operation-type": "force-merge",
             "request-timeout": 7200
           }
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     }

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -45,6 +45,19 @@
           "clients": 1
         },
         {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
           "operation": "index-stats",
           "clients": 1,
           "warmup-iterations": 500,
@@ -249,6 +262,19 @@
             "operation-type": "force-merge",
             "request-timeout": 7200
           }
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     },
@@ -288,6 +314,19 @@
           "operation": {
             "operation-type": "force-merge",
             "request-timeout": 7200
+          }
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
           }
         }
       ]
@@ -329,6 +368,19 @@
           "operation": {
             "operation-type": "force-merge",
             "request-timeout": 7200
+          }
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
           }
         }
       ]

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -34,8 +34,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -243,8 +245,10 @@
           "clients": {{bulk_indexing_clients | default(8)}}
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         }
       ]
     },
@@ -281,8 +285,10 @@
           "clients": {{bulk_indexing_clients | default(8)}}
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         }
       ]
     },
@@ -320,8 +326,10 @@
           "clients": {{bulk_indexing_clients | default(8)}}
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         }
       ]
     }

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -47,6 +47,19 @@
           "clients": 1
         },
         {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
           "operation": "polygon",
           "clients": 1,
           "warmup-iterations": 200,
@@ -122,6 +135,19 @@
         "name": "refresh-after-force-merge",
         "operation": "refresh",
         "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     },
@@ -175,6 +201,19 @@
         "name": "refresh-after-force-merge",
         "operation": "refresh",
         "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     }

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -35,11 +35,11 @@
         },
         {
           "operation": {
-            "operation-type": "force-merge"{%- if max_num_segments is defined %},
+            "operation-type": "force-merge",
+            "request-timeout": 7200{%- if max_num_segments is defined %},
             "max-num-segments": {{max_num_segments}}
              {%- endif %}
-          },
-          "clients": 1
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -112,11 +112,11 @@
         },
         {
           "operation": {
-            "operation-type": "force-merge"{%- if max_num_segments is defined %},
+            "operation-type": "force-merge",
+            "request-timeout": 7200{%- if max_num_segments is defined %},
             "max-num-segments": {{max_num_segments}}
              {%- endif %}
-          },
-          "clients": 1
+          }
         },
         {
         "name": "refresh-after-force-merge",
@@ -165,11 +165,11 @@
         },
         {
           "operation": {
-            "operation-type": "force-merge"{%- if max_num_segments is defined %},
+            "operation-type": "force-merge",
+            "request-timeout": 7200{%- if max_num_segments is defined %},
             "max-num-segments": {{max_num_segments}}
              {%- endif %}
-          },
-          "clients": 1
+          }
         },
         {
         "name": "refresh-after-force-merge",

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -34,8 +34,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -93,8 +95,10 @@
         "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
         "name": "refresh-after-force-merge",
@@ -142,8 +146,10 @@
         "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
         "name": "refresh-after-force-merge",

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -45,6 +45,19 @@
           "clients": 1
         },
         {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
           "operation": "polygon",
           "clients": 1,
           "warmup-iterations": 200,
@@ -104,6 +117,19 @@
         "name": "refresh-after-force-merge",
         "operation": "refresh",
         "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     },
@@ -155,6 +181,19 @@
         "name": "refresh-after-force-merge",
         "operation": "refresh",
         "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     }

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -43,6 +43,19 @@
           }
         },
         {
+          "name": "wait-until-linestrings-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
           "operation": "index-append-multilinestrings",
           "warmup-time-period": 120,
           "clients": {{bulk_indexing_clients | default(8)}}
@@ -59,6 +72,19 @@
             "operation-type": "force-merge",
             "index": "osmmultilinestrings",
             "request-timeout": 7200
+          }
+        },
+        {
+          "name": "wait-until-multilinestrings-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
           }
         },
         {
@@ -84,6 +110,19 @@
           "name": "refresh-after-all-indices",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-polygon-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         },
         {
           "operation": "polygon",

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -36,9 +36,11 @@
         },
         {
           "name": "force-merge-linestrings",
-          "operation": "force-merge",
-          "index": "osmlinestrings",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "index": "osmlinestrings",
+            "request-timeout": 7200
+          }
         },
         {
           "operation": "index-append-multilinestrings",
@@ -53,9 +55,11 @@
         },
         {
           "name": "force-merge-multilinestrings",
-          "operation": "force-merge",
-          "index": "osmmultilinestrings",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "index": "osmmultilinestrings",
+            "request-timeout": 7200
+          }
         },
         {
           "operation": "index-append-polygons",
@@ -70,9 +74,11 @@
         },
         {
           "name": "force-merge-polygons",
-          "operation": "force-merge",
-          "index": "osmpolygons",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "index": "osmpolygons",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-all-indices",

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -45,6 +45,19 @@
           "clients": 1
         },
         {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
           "operation": "default",
           "clients": 1,
           "warmup-iterations": 500,
@@ -108,6 +121,19 @@
           "clients": 1
         },
         {
+          "name": "wait-until-merges-1-seg-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
           "name": "desc-sort-timestamp-after-force-merge-1-seg",
           "operation": "desc_sort_timestamp",
           "clients": 1,
@@ -169,6 +195,19 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     },
@@ -219,6 +258,19 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     },
@@ -269,6 +321,19 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     },
@@ -319,6 +384,19 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     },
@@ -366,6 +444,19 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         },
         {
           "name": "reindex",

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -34,8 +34,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -98,8 +100,7 @@
             "operation-type": "force-merge",
             "max-num-segments": 1,
             "request-timeout": 7200
-          },
-          "clients": 1
+          }
         },
         {
           "name": "refresh-after-force-merge-1-seg",
@@ -159,8 +160,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -207,8 +210,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -255,8 +260,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -303,8 +310,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -348,8 +357,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",

--- a/metricbeat/challenges/default.json
+++ b/metricbeat/challenges/default.json
@@ -45,6 +45,19 @@
           "clients": 1
         },
         {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
           "operation": "autohisto_agg",
           "clients": 1,
           "warmup-iterations": 50,

--- a/metricbeat/challenges/default.json
+++ b/metricbeat/challenges/default.json
@@ -34,8 +34,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -46,6 +46,19 @@
           "clients": 1
         },
         {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
           "operation": "randomized-nested-queries",
           "clients": 2,
           "target-throughput": 20,
@@ -141,6 +154,19 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     }

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -35,8 +35,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -130,8 +132,10 @@
         "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -35,8 +35,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -137,8 +139,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -46,6 +46,19 @@
           "clients": 1
         },
         {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
           "operation": "range_field_big_range",
           "clients": 1,
           "warmup-iterations": 100,
@@ -148,6 +161,19 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     }

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -203,6 +203,19 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     },
@@ -343,6 +356,19 @@
         {
           "name": "refresh-after-force-merge",
           "operation": "refresh"
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         },
 	    {
           "operation": {

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -194,8 +194,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -333,7 +335,10 @@
           "operation": "refresh"
         },
         {
-          "operation": "force-merge"
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -46,6 +46,19 @@
           "clients": 1
         },
         {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
           "operation": "percolator_with_content_president_bush",
           "clients": 1,
           "warmup-iterations": 100,

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -35,8 +35,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -55,6 +55,19 @@
           "clients": 1
         },
         {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
           "operation": "default",
           "clients": 1,
           "warmup-iterations": 500,
@@ -142,6 +155,19 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     },
@@ -192,6 +218,19 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     },
@@ -243,6 +282,19 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh",
           "clients": 1
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     }

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -44,8 +44,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -131,8 +133,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -179,8 +183,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -228,8 +234,10 @@
           "clients": 1
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         },
         {
           "name": "refresh-after-force-merge",

--- a/so/challenges/default.json
+++ b/so/challenges/default.json
@@ -29,8 +29,10 @@
           "clients": {{bulk_indexing_clients | default(8)}}
         },
         {
-          "operation": "force-merge",
-          "clients": 1
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
         }
       ]
     }

--- a/so/challenges/default.json
+++ b/so/challenges/default.json
@@ -33,6 +33,19 @@
             "operation-type": "force-merge",
             "request-timeout": 7200
           }
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
         }
       ]
     }


### PR DESCRIPTION
With this commit we change all tracks to increase the request timeout of the
`force-merge` task to ensure the force merge finishes before we move on. We also
include another task that waits until all ongoing segment merges finish. Older
Rally versions will entirely rely on the increased request timeout for force
merges but newer Rally versions (every version including elastic/rally#925) will
evaluate the condition and wait accordingly until the system is quiet.

Relates elastic/rally#925