### PR TITLE
Remove obsolete default client count

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -30,8 +30,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -41,8 +40,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -59,56 +57,48 @@
         },
         {
           "operation": "index-stats",
-          "clients": 1,
           "warmup-iterations": 500,
           "iterations": 1000,
           "target-throughput": 90
         },
         {
           "operation": "node-stats",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 1000,
           "target-throughput": 90
         },
         {
           "operation": "default",
-          "clients": 1,
           "warmup-iterations": 500,
           "iterations": 1000,
           "target-throughput": 50
         },
         {
           "operation": "term",
-          "clients": 1,
           "warmup-iterations": 500,
           "iterations": 1000,
           "target-throughput": 200
         },
         {
           "operation": "phrase",
-          "clients": 1,
           "warmup-iterations": 500,
           "iterations": 1000,
           "target-throughput": 200
         },
         {
           "operation": "country_agg_uncached",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 4
         },
         {
           "operation": "country_agg_cached",
-          "clients": 1,
           "warmup-iterations": 1000,
           "iterations": 1000,
           "target-throughput": 100
         },
         {
           "operation": "scroll",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages",
@@ -116,112 +106,96 @@
         },
         {
           "operation": "expression",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
         },
         {
           "operation": "painless_static",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "painless_dynamic",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "decay_geo_gauss_function_score",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1
         },
         {
           "operation": "decay_geo_gauss_script_score",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1
         },
         {
           "operation": "field_value_function_score",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "field_value_script_score",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "random_function_score",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "random_script_score",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "large_terms",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "large_filtered_terms",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "large_prohibited_terms",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "desc_sort_population",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "asc_sort_population",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "desc_sort_geonameid",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 6
         },
         {
           "operation": "asc_sort_geonameid",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 6

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -30,8 +30,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -43,8 +42,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -61,28 +59,24 @@
         },
         {
           "operation": "polygon",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
         },
         {
           "operation": "bbox",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
         },
         {
           "operation": "distance",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 5
         },
         {
           "operation": "distanceRange",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 0.6
@@ -120,8 +114,7 @@
         },
         {
         "name": "refresh-after-index",
-        "operation": "refresh",
-        "clients": 1
+        "operation": "refresh"
         },
         {
           "operation": {
@@ -133,8 +126,7 @@
         },
         {
         "name": "refresh-after-force-merge",
-        "operation": "refresh",
-        "clients": 1
+        "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -186,8 +178,7 @@
         },
         {
         "name": "refresh-after-index",
-        "operation": "refresh",
-        "clients": 1
+        "operation": "refresh"
         },
         {
           "operation": {
@@ -199,8 +190,7 @@
         },
         {
         "name": "refresh-after-force-merge",
-        "operation": "refresh",
-        "clients": 1
+        "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -30,8 +30,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -41,8 +40,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -59,14 +57,12 @@
         },
         {
           "operation": "polygon",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
         },
         {
           "operation": "bbox",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
@@ -104,8 +100,7 @@
         },
         {
         "name": "refresh-after-index",
-        "operation": "refresh",
-        "clients": 1
+        "operation": "refresh"
         },
         {
           "operation": {
@@ -115,8 +110,7 @@
         },
         {
         "name": "refresh-after-force-merge",
-        "operation": "refresh",
-        "clients": 1
+        "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -168,8 +162,7 @@
         },
         {
         "name": "refresh-after-index",
-        "operation": "refresh",
-        "clients": 1
+        "operation": "refresh"
         },
         {
           "operation": {
@@ -179,8 +172,7 @@
         },
         {
         "name": "refresh-after-force-merge",
-        "operation": "refresh",
-        "clients": 1
+        "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -31,8 +31,7 @@
         {
           "name": "refresh-after-linestrings-index",
           "operation": "refresh",
-          "index": "osmlinestrings",
-          "clients": 1
+          "index": "osmlinestrings"
         },
         {
           "name": "force-merge-linestrings",
@@ -63,8 +62,7 @@
         {
           "name": "refresh-after-multilinestrings-index",
           "operation": "refresh",
-          "index": "osmmultilinestrings",
-          "clients": 1
+          "index": "osmmultilinestrings"
         },
         {
           "name": "force-merge-multilinestrings",
@@ -95,8 +93,7 @@
         {
           "name": "refresh-after-polygons-index",
           "operation": "refresh",
-          "index": "osmpolygons",
-          "clients": 1
+          "index": "osmpolygons"
         },
         {
           "name": "force-merge-polygons",
@@ -108,8 +105,7 @@
         },
         {
           "name": "refresh-after-all-indices",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-polygon-merges-finish",
@@ -126,14 +122,12 @@
         },
         {
           "operation": "polygon",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 0.3
         },
         {
           "operation": "bbox",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 0.25

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -30,8 +30,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -41,8 +40,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -59,35 +57,30 @@
         },
         {
           "operation": "default",
-          "clients": 1,
           "warmup-iterations": 500,
           "iterations": 100,
           "target-throughput": 8
         },
         {
           "operation": "term",
-          "clients": 1,
           "warmup-iterations": 500,
           "iterations": 100,
           "target-throughput": 50
         },
         {
           "operation": "range",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 100,
           "target-throughput": 1
         },
         {
           "operation": "hourly_agg",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 100,
           "target-throughput": 0.2
         },
         {
           "operation": "scroll",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 200,
           "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages",
@@ -95,14 +88,12 @@
         },
         {
           "operation": "desc_sort_timestamp",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 0.5
         },
         {
           "operation": "asc_sort_timestamp",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 0.5
@@ -117,8 +108,7 @@
         },
         {
           "name": "refresh-after-force-merge-1-seg",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-1-seg-finish",
@@ -136,7 +126,6 @@
         {
           "name": "desc-sort-timestamp-after-force-merge-1-seg",
           "operation": "desc_sort_timestamp",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
@@ -144,7 +133,6 @@
         {
           "name": "asc-sort-timestamp-after-force-merge-1-seg",
           "operation": "asc_sort_timestamp",
-          "clients": 1,
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
@@ -182,8 +170,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -193,8 +180,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -245,8 +231,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -256,8 +241,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -308,8 +292,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -319,8 +302,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -371,8 +353,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -382,8 +363,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -431,8 +411,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -442,8 +421,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -471,8 +449,7 @@
               }
             },
             "request_timeout": 7200
-          },
-          "clients": 1
+          }
         }
       ]
     }

--- a/metricbeat/challenges/default.json
+++ b/metricbeat/challenges/default.json
@@ -30,8 +30,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -41,8 +40,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -59,14 +57,12 @@
         },
         {
           "operation": "autohisto_agg",
-          "clients": 1,
           "warmup-iterations": 50,
           "iterations": 100,
           "target-throughput": 2
         },
         {
           "operation": "date_histogram_agg",
-          "clients": 1,
           "warmup-iterations": 50,
           "iterations": 100,
           "target-throughput": 2

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -31,8 +31,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -42,8 +41,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -141,8 +139,7 @@
         },
         {
         "name": "refresh-after-index",
-        "operation": "refresh",
-        "clients": 1
+        "operation": "refresh"
         },
         {
           "operation": {
@@ -152,8 +149,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -31,8 +31,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -42,8 +41,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -60,56 +58,48 @@
         },
         {
           "operation": "range_field_big_range",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 500,
           "target-throughput": 8
         },
         {
           "operation": "range_field_small_range",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 500,
           "target-throughput": 10
         },
         {
           "operation": "range_field_conjunction_big_range_small_term_query",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 500,
           "target-throughput": 10
         },
         {
           "operation": "range_field_conjunction_small_range_small_term_query",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 500,
           "target-throughput": 10
         },
         {
           "operation": "range_field_conjunction_small_range_big_term_query",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 500,
           "target-throughput": 4
         },
         {
           "operation": "range_field_conjunction_big_range_big_term_query",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 500,
           "target-throughput": 1
         },
         {
           "operation": "range_field_disjunction_small_range_small_term_query",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 500,
           "target-throughput": 10
         },
         {
           "operation": "range_field_disjunction_big_range_small_term_query",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 500,
           "target-throughput": 6
@@ -148,8 +138,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -159,8 +148,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -34,40 +34,34 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": "default",
-          "clients": 1,
           "warmup-iterations": 50,
           "iterations": 100,
           "target-throughput": 3
         },
         {
           "operation": "range",
-          "clients": 1,
           "warmup-iterations": 50,
           "iterations": 100,
           "target-throughput": 1
         },
         {
           "operation": "distance_amount_agg",
-          "clients": 1,
           "warmup-iterations": 50,
           "iterations": 100,
           "target-throughput": 2
         },
         {
           "operation": "autohisto_agg",
-          "clients": 1,
           "warmup-iterations": 50,
           "iterations": 100,
           "target-throughput": 1.5
         },
         {
           "operation": "date_histogram_agg",
-          "clients": 1,
           "warmup-iterations": 50,
           "iterations": 100,
           "target-throughput": 1.5
@@ -109,8 +103,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         }
       ]
     },
@@ -151,8 +144,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         }
       ]
     },
@@ -190,8 +182,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -201,8 +192,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -31,8 +31,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -42,8 +41,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -60,49 +58,42 @@
         },
         {
           "operation": "percolator_with_content_president_bush",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 100,
           "target-throughput": 50
         },
         {
           "operation": "percolator_with_content_saddam_hussein",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 100,
           "target-throughput": 50
         },
         {
           "operation": "percolator_with_content_hurricane_katrina",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 100,
           "target-throughput": 50
         },
         {
           "operation": "percolator_with_content_google",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 100,
           "target-throughput": 35
         },
         {
           "operation": "percolator_no_score_with_content_google",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 100,
           "target-throughput": 100
         },
         {
           "operation": "percolator_with_highlighting",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 100,
           "target-throughput": 50
         },
         {
           "operation": "percolator_with_content_ignore_me",
-          "clients": 1,
           "warmup-iterations": 10,
           "iterations": 100,
           "#COMMENT": "Be aware that we specify *target-interval* here! This means we issue one query every 12 seconds",
@@ -110,7 +101,6 @@
         },
         {
           "operation": "percolator_no_score_with_content_ignore_me",
-          "clients": 1,
           "warmup-iterations": 100,
           "iterations": 100,
           "target-throughput": 15

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -40,8 +40,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -51,8 +50,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -69,42 +67,36 @@
         },
         {
           "operation": "default",
-          "clients": 1,
           "warmup-iterations": 500,
           "iterations": 200,
           "target-throughput": 20
         },
         {
           "operation": "term",
-          "clients": 1,
           "warmup-iterations": 500,
           "iterations": 200,
           "target-throughput": 20
         },
         {
           "operation": "phrase",
-          "clients": 1,
           "warmup-iterations": 500,
           "iterations": 200,
           "target-throughput": 20
         },
         {
           "operation": "articles_monthly_agg_uncached",
-          "clients": 1,
           "warmup-iterations": 500,
           "iterations": 200,
           "target-throughput": 20
         },
         {
           "operation": "articles_monthly_agg_cached",
-          "clients": 1,
           "warmup-iterations": 500,
           "iterations": 200,
           "target-throughput": 20
         },
         {
           "operation": "scroll",
-          "clients": 1,
           "warmup-iterations": 50,
           "iterations": 100,
           "target-throughput": 0.5
@@ -142,8 +134,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -153,8 +144,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -205,8 +195,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -216,8 +205,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
@@ -269,8 +257,7 @@
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "operation": {
@@ -280,8 +267,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
-          "clients": 1
+          "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",


### PR DESCRIPTION
With this commit we remove all `client` properties from tasks where it
is set to `1` as this is the default anyway.

Relates #104