### PR TITLE
Use keyword field for term query and terms agg

### DIFF
--- a/geonames/operations/default.json
+++ b/geonames/operations/default.json
@@ -29,7 +29,7 @@
       "body": {
         "query": {
           "term": {
-            "country_code": "AT"
+            "country_code.raw": "AT"
           }
         }
       }
@@ -53,7 +53,7 @@
         "aggs": {
           "country_population": {
             "terms": {
-              "field": "country_code"
+              "field": "country_code.raw"
             },
             "aggs": {
               "sum_population": {
@@ -75,7 +75,7 @@
         "aggs": {
           "country_population": {
             "terms": {
-              "field": "country_code"
+              "field": "country_code.raw"
             },
             "aggs": {
               "sum_population": {


### PR DESCRIPTION
With this commit we use the keyword subfield in the `geonames` track for
the `term` query and aggregations that aggregate on terms. While the
terms aggregation produces correct results on a `text` field, the `term`
query does not return any results (which is unintended).