### PR TITLE
Adapt for asyncio

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -77,13 +77,13 @@
           "operation": "term",
           "warmup-iterations": 500,
           "iterations": 1000,
-          "target-throughput": 200
+          "target-throughput": 150
         },
         {
           "operation": "phrase",
           "warmup-iterations": 500,
           "iterations": 1000,
-          "target-throughput": 200
+          "target-throughput": 150
         },
         {
           "operation": "country_agg_uncached",

--- a/pmc/operations/default.json
+++ b/pmc/operations/default.json
@@ -81,6 +81,8 @@
       "operation-type": "search",
       "pages": 25,
       "results-per-page": 100,
+      "#COMMENT": "Large responses cause overhead on the client when decompressing the response. Disable to avoid the overhead",
+      "response-compression-enabled": false,
       "body": {
         "query": {
           "match_all": {}


### PR DESCRIPTION
With this commit we change some of our tracks to make sure nightly
Elasticsearch benchmarks continue to run smoothly with the new asyncio
load generator (see elastic/rally#935):

* We lower the target throughput of some queries
* We disable HTTP response compression for PMC scroll queries

Relates elastic/rally#935
Relates elastic/rally#941