### PR TITLE
Backwards-compatible implementation of ML lookback

### DIFF
--- a/nyc_taxis/track.py
+++ b/nyc_taxis/track.py
@@ -4,7 +4,7 @@ import time
 
 def wait_for_ml_lookback(es, params):
     while True:
-        response = es.xpack.ml.get_datafeed_stats(datafeed_id=params["datafeed-id"])
+        response = es.transport.perform_request("GET", "/_xpack/ml/datafeeds/%s/_stats" % params["datafeed-id"])
         if response["datafeeds"][0]["state"] == "stopped":
             break
         time.sleep(5)
@@ -12,7 +12,7 @@ def wait_for_ml_lookback(es, params):
 
 async def wait_for_ml_lookback_async(es, params):
     while True:
-        response = await es.xpack.ml.get_datafeed_stats(datafeed_id=params["datafeed-id"])
+        response = await es.transport.perform_request("GET", "/_xpack/ml/datafeeds/%s/_stats" % params["datafeed-id"])
         if response["datafeeds"][0]["state"] == "stopped":
             break
         await asyncio.sleep(5)


### PR DESCRIPTION
With this commit we implement the ML lookback for `nyc_taxis` in a
backwards-compatible way. As newer versions of Elasticsearch (and thus
the corresponding client) have dropped the `_xpack` path component we
are falling back to the raw transport API.

Relates elastic/rally#812