### PR TITLE
Remove size() method from parameter sources

### DIFF
--- a/geonames/track.py
+++ b/geonames/track.py
@@ -19,10 +19,6 @@ class QueryParamSource:
     def partition(self, partition_index, total_partitions):
         return self
 
-    # Deprecated - only there for BWC reasons with Rally < 1.4.0
-    def size(self):
-        return 1
-
 
 class PureTermsQueryParamSource(QueryParamSource):
     def params(self):

--- a/nested/track.py
+++ b/nested/track.py
@@ -26,10 +26,6 @@ class QueryParamSource:
     def partition(self, partition_index, total_partitions):
         return self
 
-    # Deprecated - only there for BWC reasons with Rally < 1.4.0
-    def size(self):
-        return 1
-
 
 class SortedTermQueryParamSource(QueryParamSource):
     def params(self):


### PR DESCRIPTION
With this commit we remove the outdated `#size()` method from all
parameter sources.

Closes #87