### PR TITLE
Add track for sub-bucket-aggs

### DIFF
--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -403,6 +403,13 @@
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 5
+        },
+        {
+          "operation": "range_numeric_significant_terms",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 18
         }
       ]
     }

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -405,6 +405,13 @@
           "target-interval": 3
         },
         {
+          "operation": "date_histo_histo",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 3
+        },
+        {
           "operation": "range_numeric_significant_terms",
           "clients": 1,
           "warmup-iterations": 10,

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -337,4 +337,72 @@
           "target-throughput": 1
         }
       ]
+    },
+    {
+      "name": "terms",
+      "description": "Checks the performance of terms aggregations",
+      "default": false,
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "weather-data-2016",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "index",
+          "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
+          "warmup-time-period": 10,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "keyword_terms_numeric_terms",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 4
+        },
+        {
+          "operation": "numeric_terms_numeric_terms",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 3
+        },
+        {
+          "operation": "date_histo_numeric_terms",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 5
+        }
+      ]
     }

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -339,8 +339,8 @@
       ]
     },
     {
-      "name": "terms",
-      "description": "Checks the performance of terms aggregations",
+      "name": "sub-bucket-aggs",
+      "description": "Checks the performance of bucket aggregations under bucket aggregations",
       "default": false,
       "schedule": [
         {
@@ -410,6 +410,20 @@
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 18
+        },
+        {
+          "operation": "histo_date_histo",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 4
+        },
+        {
+          "operation": "histo_date_histo_with_metrics",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 6
         }
       ]
     }

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -388,7 +388,7 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
-          "target-interval": 4
+          "target-interval": 5
         },
         {
           "operation": "numeric_terms_numeric_terms",
@@ -402,28 +402,49 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
-          "target-interval": 5
+          "target-interval": 3
         },
         {
           "operation": "range_numeric_significant_terms",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
-          "target-interval": 18
+          "target-interval": 16
         },
         {
-          "operation": "histo_date_histo",
+          "operation": "range_date_histo",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
-          "target-interval": 4
+          "target-interval": 3
         },
         {
-          "operation": "histo_date_histo_with_metrics",
+          "operation": "range_date_histo_with_metrics",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 6
+        },
+        {
+          "operation": "range_auto_date_histo",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 3
+        },
+        {
+          "operation": "range_auto_date_histo_with_metrics",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 6
+        },
+        {
+          "operation": "range_auto_date_histo_with_time_zone",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 7
         }
       ]
     }

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -384,70 +384,70 @@
           "clients": 1
         },
         {
-          "operation": "keyword_terms_numeric_terms",
+          "operation": "keyword-terms-numeric-terms",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 5
         },
         {
-          "operation": "numeric_terms_numeric_terms",
+          "operation": "numeric-terms-numeric-terms",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 3
         },
         {
-          "operation": "date_histo_numeric_terms",
+          "operation": "date-histo-numeric-terms",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 3
         },
         {
-          "operation": "date_histo_histo",
+          "operation": "date-histo-histo",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 3
         },
         {
-          "operation": "range_numeric_significant_terms",
+          "operation": "range-numeric-significant-terms",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 16
         },
         {
-          "operation": "range_date_histo",
+          "operation": "range-date-histo",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 3
         },
         {
-          "operation": "range_date_histo_with_metrics",
+          "operation": "range-date-histo-with-metrics",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 6
         },
         {
-          "operation": "range_auto_date_histo",
+          "operation": "range-auto-date-histo",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 3
         },
         {
-          "operation": "range_auto_date_histo_with_metrics",
+          "operation": "range-auto-date-histo-with-metrics",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,
           "target-interval": 6
         },
         {
-          "operation": "range_auto_date_histo_with_time_zone",
+          "operation": "range-auto-date-histo-with-time-zone",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50,

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -785,4 +785,33 @@
           }
         }
       }
+    },
+    {
+      "name": "range_numeric_significant_terms",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "range": {
+              "field": "TMAX",
+              "ranges": [
+                {"to":   -10},
+                {"from": -10, "to":  0},
+                {"from":   0, "to": 10},
+                {"from":  10, "to": 20},
+                {"from":  20, "to": 30},
+                {"from":  30}
+              ]
+            },
+            "aggs": {
+              "tavg": {
+                "significant_terms": {
+                  "field": "date"
+                }
+              }
+            }
+          }
+        }
+      }
     }

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -787,6 +787,29 @@
       }
     },
     {
+      "name": "date_histo_histo",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "date",
+              "calendar_interval": "1w"
+            },
+            "aggs": {
+              "tavg": {
+                "histogram": {
+                  "field": "TAVG",
+                  "interval": 10
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "range_numeric_significant_terms",
       "operation-type": "search",
       "body": {

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -816,15 +816,22 @@
       }
     },
     {
-      "name": "histo_date_histo",
+      "name": "range_date_histo",
       "operation-type": "search",
       "body": {
         "size": 0,
         "aggs": {
           "tmax": {
-            "histogram": {
+            "range": {
               "field": "TMAX",
-              "interval": 4
+              "ranges": [
+                {"to":   -10},
+                {"from": -10, "to":  0},
+                {"from":   0, "to": 10},
+                {"from":  10, "to": 20},
+                {"from":  20, "to": 30},
+                {"from":  30}
+              ]
             },
             "aggs": {
               "date": {
@@ -839,15 +846,22 @@
       }
     },
     {
-      "name": "histo_date_histo_with_metrics",
+      "name": "range_date_histo_with_metrics",
       "operation-type": "search",
       "body": {
         "size": 0,
         "aggs": {
           "tmax": {
-            "histogram": {
+            "range": {
               "field": "TMAX",
-              "interval": 4
+              "ranges": [
+                {"to":   -10},
+                {"from": -10, "to":  0},
+                {"from":   0, "to": 10},
+                {"from":  10, "to": 20},
+                {"from":  20, "to": 30},
+                {"from":  30}
+              ]
             },
             "aggs": {
               "date": {
@@ -871,6 +885,114 @@
                       "field": "TMAX"
                     }
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "range_auto_date_histo",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "tmax": {
+            "range": {
+              "field": "TMAX",
+              "ranges": [
+                {"to":   -10},
+                {"from": -10, "to":  0},
+                {"from":   0, "to": 10},
+                {"from":  10, "to": 20},
+                {"from":  20, "to": 30},
+                {"from":  30}
+              ]
+            },
+            "aggs": {
+              "date": {
+                "auto_date_histogram": {
+                  "field": "date",
+                  "buckets": 20
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "range_auto_date_histo_with_metrics",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "tmax": {
+            "range": {
+              "field": "TMAX",
+              "ranges": [
+                {"to":   -10},
+                {"from": -10, "to":  0},
+                {"from":   0, "to": 10},
+                {"from":  10, "to": 20},
+                {"from":  20, "to": 30},
+                {"from":  30}
+              ]
+            },
+            "aggs": {
+              "date": {
+                "auto_date_histogram": {
+                  "field": "date",
+                  "buckets": 20
+                },
+                "aggs": {
+                  "tmin": {
+                    "min": {
+                      "field": "TMIN"
+                    }
+                  },
+                  "tavg": {
+                    "avg": {
+                      "field": "TAVG"
+                    }
+                  },
+                  "tmax": {
+                    "max": {
+                      "field": "TMAX"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "range_auto_date_histo_with_time_zone",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "tmax": {
+            "range": {
+              "field": "TMAX",
+              "ranges": [
+                {"to":   -10},
+                {"from": -10, "to":  0},
+                {"from":   0, "to": 10},
+                {"from":  10, "to": 20},
+                {"from":  20, "to": 30},
+                {"from":  30}
+              ]
+            },
+            "aggs": {
+              "date": {
+                "auto_date_histogram": {
+                  "field": "date",
+                  "buckets": 20,
+                  "time_zone": "America/New_York"
                 }
               }
             }

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -715,7 +715,7 @@
       }
     },
     {
-      "name": "keyword_terms_numeric_terms",
+      "name": "keyword-terms-numeric-terms",
       "operation-type": "search",
       "body": {
         "size": 0,
@@ -743,7 +743,7 @@
       }
     },
     {
-      "name": "numeric_terms_numeric_terms",
+      "name": "numeric-terms-numeric-terms",
       "operation-type": "search",
       "body": {
         "size": 0,
@@ -765,7 +765,7 @@
       }
     },
     {
-      "name": "date_histo_numeric_terms",
+      "name": "date-histo-numeric-terms",
       "operation-type": "search",
       "body": {
         "size": 0,
@@ -787,7 +787,7 @@
       }
     },
     {
-      "name": "date_histo_histo",
+      "name": "date-histo-histo",
       "operation-type": "search",
       "body": {
         "size": 0,
@@ -810,7 +810,7 @@
       }
     },
     {
-      "name": "range_numeric_significant_terms",
+      "name": "range-numeric-significant-terms",
       "operation-type": "search",
       "body": {
         "size": 0,
@@ -839,7 +839,7 @@
       }
     },
     {
-      "name": "range_date_histo",
+      "name": "range-date-histo",
       "operation-type": "search",
       "body": {
         "size": 0,
@@ -869,7 +869,7 @@
       }
     },
     {
-      "name": "range_date_histo_with_metrics",
+      "name": "range-date-histo-with-metrics",
       "operation-type": "search",
       "body": {
         "size": 0,
@@ -916,7 +916,7 @@
       }
     },
     {
-      "name": "range_auto_date_histo",
+      "name": "range-auto-date-histo",
       "operation-type": "search",
       "body": {
         "size": 0,
@@ -946,7 +946,7 @@
       }
     },
     {
-      "name": "range_auto_date_histo_with_metrics",
+      "name": "range-auto-date-histo-with-metrics",
       "operation-type": "search",
       "body": {
         "size": 0,
@@ -993,7 +993,7 @@
       }
     },
     {
-      "name": "range_auto_date_histo_with_time_zone",
+      "name": "range-auto-date-histo-with-time-zone",
       "operation-type": "search",
       "body": {
         "size": 0,

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -713,5 +713,76 @@
           }
         }
       }
+    },
+    {
+      "name": "keyword_terms_numeric_terms",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "station": {
+            "terms": {
+              "field": "station.id",
+              "size": 500
+            },
+            "aggs": {
+              "date": {
+                "terms": {
+                  "field": "date",
+                  "size": 1
+                },
+                "aggs": {
+                  "max": {
+                    "max": { "field": "tmax" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "numeric_terms_numeric_terms",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "tmax": {
+            "terms": {
+              "field": "TMAX",
+              "size": 100
+            },
+            "aggs": {
+              "tavg": {
+                "terms": {
+                  "field": "TAVG"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "date_histo_numeric_terms",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "date",
+              "calendar_interval": "1w"
+            },
+            "aggs": {
+              "tavg": {
+                "terms": {
+                  "field": "TAVG"
+                }
+              }
+            }
+          }
+        }
+      }
     }
-    

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -792,7 +792,7 @@
       "body": {
         "size": 0,
         "aggs": {
-          "date": {
+          "tmax": {
             "range": {
               "field": "TMAX",
               "ranges": [
@@ -805,9 +805,72 @@
               ]
             },
             "aggs": {
-              "tavg": {
+              "date": {
                 "significant_terms": {
                   "field": "date"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "histo_date_histo",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "tmax": {
+            "histogram": {
+              "field": "TMAX",
+              "interval": 4
+            },
+            "aggs": {
+              "date": {
+                "date_histogram": {
+                  "field": "date",
+                  "calendar_interval": "1w"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "histo_date_histo_with_metrics",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "tmax": {
+            "histogram": {
+              "field": "TMAX",
+              "interval": 4
+            },
+            "aggs": {
+              "date": {
+                "date_histogram": {
+                  "field": "date",
+                  "calendar_interval": "1w"
+                },
+                "aggs": {
+                  "tmin": {
+                    "min": {
+                      "field": "TMIN"
+                    }
+                  },
+                  "tavg": {
+                    "avg": {
+                      "field": "TAVG"
+                    }
+                  },
+                  "tmax": {
+                    "max": {
+                      "field": "TMAX"
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
Adds a rally track specifically for testing the performance of the terms
agg as I'll be doing some work on it. In particular this focuses on
numeric terms because the first phase of my work only touches them.

Relates to https://github.com/elastic/elasticsearch/pull/55873