### PR TITLE
Adjust target throughput of distanceRange query

### DIFF
--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -79,7 +79,7 @@
           "operation": "distanceRange",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 0.6
+          "target-throughput": 0.5
         }
       ]
     },


### PR DESCRIPTION
With this commit we lower the target throughput for the query
`distanceRange` in the `geopoint` track from 0.6 ops/s to 0.5 ops/s to
account for a slight slowdown due to the switch to G1. Previously the
target throughput was already very close to the achievable throughput so
G1 was just pushing it over the edge into unstable territory. Lowering
the target throughput stabilizes it again.