### PR TITLE
Adjust target throughput of large*term queries

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -162,19 +162,19 @@
           "operation": "large_terms",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 1.5
+          "target-throughput": 1.1
         },
         {
           "operation": "large_filtered_terms",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 1.5
+          "target-throughput": 1.1
         },
         {
           "operation": "large_prohibited_terms",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 1.5
+          "target-throughput": 1.1
         },
         {
           "operation": "desc_sort_population",


### PR DESCRIPTION
With this commit we lower the target throughput for the large term
queries in the `geonames` track from 1.5 ops/s to 1.1 ops/s to
account for a slight slowdown due to the switch to G1. Previously the
target throughput was already very close to the achievable throughput so
G1 was just pushing it over the edge into unstable territory. Lowering
the target throughput stabilizes it again.