### PR TITLE
Lower target-throughput for scored percolator query

### DIFF
--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -78,7 +78,7 @@
           "operation": "percolator_with_content_google",
           "warmup-iterations": 100,
           "iterations": 100,
-          "target-throughput": 35
+          "target-throughput": 30
         },
         {
           "operation": "percolator_no_score_with_content_google",


### PR DESCRIPTION
Latency results on nightly benchmarks show instability due to
target-throughput set to a higher value than what is achievable
by nightly hardware.

This commit lowers the target-throughput to 30 for the
percolator_with_content_google (scored) query.