### PR TITLE
Extend warmup period for noaa

### DIFF
--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -26,7 +26,7 @@
         {
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
-          "warmup-time-period": 10,
+          "warmup-time-period": 70,
           "clients": {{bulk_indexing_clients | default(8)}}
         },
         {

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -133,7 +133,7 @@
         {
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
-          "warmup-time-period": 10,
+          "warmup-time-period": 70,
           "clients": {{bulk_indexing_clients | default(8)}}
         },
         {
@@ -193,7 +193,7 @@
         {
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
-          "warmup-time-period": 10,
+          "warmup-time-period": 70,
           "clients": {{bulk_indexing_clients | default(8)}}
         },
         {


### PR DESCRIPTION
`Noaa` track warmup-time-period is to short for indexing operation resulting in min indexing throughput to be much different form median and max throughout:

```
|                                                 Min Throughput |  index |     63572.2 | docs/s |
|                                              Median Throughput |  index |     98192.9 | docs/s |
|                                                 Max Throughput |  index |      100845 | docs/s |
```
Updated warmup-time-period to 70 from 10:

```
|                                                 Min Throughput |  index |     96597.4 | docs/s |
|                                              Median Throughput |  index |     98331.2 | docs/s |
|                                                 Max Throughput |  index |      100864 | docs/s |
```