### PR TITLE
Lower target-throughput for geonames country uncached agg

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -89,7 +89,7 @@
           "operation": "country_agg_uncached",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 4
+          "target-throughput": 3.6
         },
         {
           "operation": "country_agg_cached",


### PR DESCRIPTION
From observation in the nightly environment we can see that occasionally
the country-uncached aggregation may take >=250ms (up to 265ms). This
leads to unnecessary spikes in the latency charts.

Lower target-throughput of geonames country_agg_uncached from 4 to
3.6 aggs/sec.

Relates https://github.com/elastic/elasticsearch/issues/57407