### PR TITLE
Lower target-throughput for nyc_taxis range query

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -46,7 +46,7 @@
           "operation": "range",
           "warmup-iterations": 50,
           "iterations": 100,
-          "target-throughput": 1
+          "target-throughput": 0.7
         },
         {
           "operation": "distance_amount_agg",


### PR DESCRIPTION
From observation in the nightly environment we can see that occasionally
the range query may take >=1,133.274ms. This leads to unnecessary spikes
in the latency charts.

Lower target-throughput of nyc_taxis range from 1 to 0.7 aggs/sec.