### PR TITLE
Add operation for sub-string-terms

### DIFF
--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -405,6 +405,48 @@
           "target-interval": 3
         },
         {
+          "operation": "date-histo-string-terms-via-map",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 17
+        },
+        {
+          "operation": "date-histo-string-terms-via-global-ords",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 6
+        },
+        {
+          "operation": "date-histo-string-terms-via-default-strategy",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 6
+        },
+        {
+          "operation": "date-histo-string-significant-terms-via-map",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 30
+        },
+        {
+          "operation": "date-histo-string-significant-terms-via-global-ords",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 15
+        },
+        {
+          "operation": "date-histo-string-significant-terms-via-default-strategy",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "target-interval": 15
+        },
+        {
           "operation": "date-histo-histo",
           "clients": 1,
           "warmup-iterations": 10,

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -787,6 +787,142 @@
       }
     },
     {
+      "name": "date-histo-string-terms-via-map",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "date",
+              "calendar_interval": "1w"
+            },
+            "aggs": {
+              "country": {
+                "terms": {
+                  "field": "station.country",
+                  "execution_hint": "map"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "date-histo-string-terms-via-global-ords",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "date",
+              "calendar_interval": "1w"
+            },
+            "aggs": {
+              "country": {
+                "terms": {
+                  "field": "station.country",
+                  "execution_hint": "global_ordinals"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "date-histo-string-terms-via-default-strategy",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "date",
+              "calendar_interval": "1w"
+            },
+            "aggs": {
+              "country": {
+                "terms": {
+                  "field": "station.country"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "date-histo-string-significant-terms-via-map",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "date",
+              "calendar_interval": "1w"
+            },
+            "aggs": {
+              "country": {
+                "significant_terms": {
+                  "field": "station.country",
+                  "execution_hint": "map"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "date-histo-string-significant-terms-via-global-ords",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "date",
+              "calendar_interval": "1w"
+            },
+            "aggs": {
+              "country": {
+                "significant_terms": {
+                  "field": "station.country",
+                  "execution_hint": "global_ordinals"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "date-histo-string-significant-terms-via-default-strategy",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "date",
+              "calendar_interval": "1w"
+            },
+            "aggs": {
+              "country": {
+                "significant_terms": {
+                  "field": "station.country"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "date-histo-histo",
       "operation-type": "search",
       "body": {


### PR DESCRIPTION
Adds two operations to compare the speed of the `terms` agg run on
strings as a sub-aggregation to test https://github.com/elastic/elasticsearch/pull/57758