### PR TITLE
Add optional force-merge operations to nyc_taxis challenges

### DIFF
--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -55,7 +55,7 @@ bzip2 -k documents.json
 
 ### Parameters
 
-This track allows to overwrite the following parameters with Rally 0.8.0+ using `--track-params`:
+This track allows to overwrite the following parameters using `--track-params`:
 
 * `bulk_size` (default: 10000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
@@ -67,6 +67,8 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
+* `force_merge` (default: false): A boolean defining whether a force-merge operation should be run after refresh. Only applies to the `append-no-conflicts`, `append-no-conflicts-index-only` and `append-sorted-no-conflicts-index-only` challenges. 
+* `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use. Only applies to the `append-no-conflicts`, `append-no-conflicts-index-only`, `append-sorted-no-conflicts-index-only`, `update` and `append-ml` challenges. Use of this parameter implies `force_merge:true`.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 

--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -67,8 +67,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
-* `force_merge` (default: false): A boolean defining whether a force-merge operation should be run after refresh. Only applies to the `append-no-conflicts`, `append-no-conflicts-index-only` and `append-sorted-no-conflicts-index-only` challenges. 
-* `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use. Only applies to the `append-no-conflicts`, `append-no-conflicts-index-only`, `append-sorted-no-conflicts-index-only`, `update` and `append-ml` challenges. Use of this parameter implies `force_merge:true`.
+* `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -35,7 +35,26 @@
         {
           "name": "refresh-after-index",
           "operation": "refresh"
+        },{%- if force_merge is defined or force_merge_max_num_segments is defined %}
+        {
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
+            "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+            {%- endif %}
+          },
+          "include-in-reporting": true
         },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "include-in-reporting": true
+        },
+        {
+          "operation": "wait-until-merges-finish",
+          "retry-until-success": true,
+          "include-in-reporting": true
+        },{%- endif %}
         {
           "operation": "default",
           "warmup-iterations": 50,
@@ -104,7 +123,26 @@
         {
           "name": "refresh-after-index",
           "operation": "refresh"
-        }
+        }{%- if force_merge is defined or force_merge_max_num_segments is defined %},
+        {
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
+            "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+            {%- endif %}
+          },
+          "include-in-reporting": true
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "include-in-reporting": true
+        },
+        {
+          "operation": "wait-until-merges-finish",
+          "retry-until-success": true,
+          "include-in-reporting": true
+        }{%- endif %}
       ]
     },
     {
@@ -145,7 +183,26 @@
         {
           "name": "refresh-after-index",
           "operation": "refresh"
-        }
+        }{%- if force_merge is defined or force_merge_max_num_segments is defined %},
+        {
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
+            "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+            {%- endif %}
+          },
+          "include-in-reporting": true
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "include-in-reporting": true
+        },
+        {
+          "operation": "wait-until-merges-finish",
+          "retry-until-success": true,
+          "include-in-reporting": true
+        }{%- endif %}
       ]
     },
     {
@@ -187,7 +244,9 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200
+            "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
+            "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+            {%- endif %}
           }
         },
         {
@@ -195,17 +254,9 @@
           "operation": "refresh"
         },
         {
-          "name": "wait-until-merges-finish",
-          "operation": {
-            "operation-type": "index-stats",
-            "index": "_all",
-            "condition": {
-              "path": "_all.total.merges.current",
-              "expected-value": 0
-            },
-            "retry-until-success": true,
-            "include-in-reporting": false
-          }
+          "operation": "wait-until-merges-finish",
+          "retry-until-success": true,
+          "include-in-reporting": false
         }
       ]
     },
@@ -418,7 +469,9 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200
+            "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
+            "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+            {%- endif %}
           }
         },
         {
@@ -426,17 +479,9 @@
           "operation": "refresh"
         },
         {
-          "name": "wait-until-merges-finish",
-          "operation": {
-            "operation-type": "index-stats",
-            "index": "_all",
-            "condition": {
-              "path": "_all.total.merges.current",
-              "expected-value": 0
-            },
-            "retry-until-success": true,
-            "include-in-reporting": false
-          }
+          "operation": "wait-until-merges-finish",
+          "retry-until-success": true,
+          "include-in-reporting": false
         },
         {
           "operation": {

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -35,15 +35,14 @@
         {
           "name": "refresh-after-index",
           "operation": "refresh"
-        },{%- if force_merge is defined or force_merge_max_num_segments is defined %}
+        },
         {
           "operation": {
             "operation-type": "force-merge",
             "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
             "max-num-segments": {{ force_merge_max_num_segments | tojson }}
             {%- endif %}
-          },
-          "include-in-reporting": true
+          }
         },
         {
           "name": "refresh-after-force-merge",
@@ -53,7 +52,7 @@
         {
           "operation": "wait-until-merges-finish",
           "include-in-reporting": true
-        },{%- endif %}
+        },
         {
           "operation": "default",
           "warmup-iterations": 50,
@@ -122,20 +121,18 @@
         {
           "name": "refresh-after-index",
           "operation": "refresh"
-        }{%- if force_merge is defined or force_merge_max_num_segments is defined %},
+        },
         {
           "operation": {
             "operation-type": "force-merge",
             "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
             "max-num-segments": {{ force_merge_max_num_segments | tojson }}
             {%- endif %}
-          },
-          "include-in-reporting": true
+          }
         },
         {
           "name": "refresh-after-force-merge",
           "operation": "refresh",
-          "include-in-reporting": true
         },
         {
           "operation": "wait-until-merges-finish",
@@ -181,20 +178,18 @@
         {
           "name": "refresh-after-index",
           "operation": "refresh"
-        }{%- if force_merge is defined or force_merge_max_num_segments is defined %},
+        },
         {
           "operation": {
             "operation-type": "force-merge",
             "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
             "max-num-segments": {{ force_merge_max_num_segments | tojson }}
             {%- endif %}
-          },
-          "include-in-reporting": true
+          }
         },
         {
           "name": "refresh-after-force-merge",
           "operation": "refresh",
-          "include-in-reporting": true
         },
         {
           "operation": "wait-until-merges-finish",

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -50,8 +50,7 @@
           "include-in-reporting": true
         },
         {
-          "operation": "wait-until-merges-finish",
-          "include-in-reporting": true
+          "operation": "wait-until-merges-finish"
         },
         {
           "operation": "default",
@@ -135,9 +134,8 @@
           "operation": "refresh",
         },
         {
-          "operation": "wait-until-merges-finish",
-          "include-in-reporting": true
-        }{%- endif %}
+          "operation": "wait-until-merges-finish"
+        }
       ]
     },
     {
@@ -192,9 +190,8 @@
           "operation": "refresh",
         },
         {
-          "operation": "wait-until-merges-finish",
-          "include-in-reporting": true
-        }{%- endif %}
+          "operation": "wait-until-merges-finish"
+        }
       ]
     },
     {
@@ -246,8 +243,7 @@
           "operation": "refresh"
         },
         {
-          "operation": "wait-until-merges-finish",
-          "include-in-reporting": false
+          "operation": "wait-until-merges-finish"
         }
       ]
     },
@@ -471,7 +467,6 @@
         },
         {
           "operation": "wait-until-merges-finish",
-          "include-in-reporting": false
         },
         {
           "operation": {

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -46,7 +46,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
+          "operation": "refresh"
         },
         {
           "operation": "wait-until-merges-finish"
@@ -130,7 +130,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
+          "operation": "refresh"
         },
         {
           "operation": "wait-until-merges-finish"
@@ -186,7 +186,7 @@
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh",
+          "operation": "refresh"
         },
         {
           "operation": "wait-until-merges-finish"
@@ -465,7 +465,7 @@
           "operation": "refresh"
         },
         {
-          "operation": "wait-until-merges-finish",
+          "operation": "wait-until-merges-finish"
         },
         {
           "operation": {

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -47,7 +47,6 @@
         {
           "name": "refresh-after-force-merge",
           "operation": "refresh",
-          "include-in-reporting": true
         },
         {
           "operation": "wait-until-merges-finish"

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -52,7 +52,6 @@
         },
         {
           "operation": "wait-until-merges-finish",
-          "retry-until-success": true,
           "include-in-reporting": true
         },{%- endif %}
         {
@@ -140,7 +139,6 @@
         },
         {
           "operation": "wait-until-merges-finish",
-          "retry-until-success": true,
           "include-in-reporting": true
         }{%- endif %}
       ]
@@ -200,7 +198,6 @@
         },
         {
           "operation": "wait-until-merges-finish",
-          "retry-until-success": true,
           "include-in-reporting": true
         }{%- endif %}
       ]
@@ -255,7 +252,6 @@
         },
         {
           "operation": "wait-until-merges-finish",
-          "retry-until-success": true,
           "include-in-reporting": false
         }
       ]
@@ -480,7 +476,6 @@
         },
         {
           "operation": "wait-until-merges-finish",
-          "retry-until-success": true,
           "include-in-reporting": false
         },
         {

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -22,7 +22,8 @@
         "path": "_all.total.merges.current",
         "expected-value": 0
       },
-      "retry-until-success": true
+      "retry-until-success": true,
+      "include-in-reporting": false
     },
     {
       "name": "default",

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -21,7 +21,8 @@
       "condition": {
         "path": "_all.total.merges.current",
         "expected-value": 0
-      }
+      },
+      "retry-until-success": true
     },
     {
       "name": "default",

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -15,6 +15,15 @@
       "recency": {{recency | default(0)}}
     },
     {
+      "name": "wait-until-merges-finish",
+      "operation-type": "index-stats",
+      "index": "_all",
+      "condition": {
+        "path": "_all.total.merges.current",
+        "expected-value": 0
+      }
+    },
+    {
       "name": "default",
       "operation-type": "search",
       "body": {


### PR DESCRIPTION
To help benchmarking the effect of force-merge down to 1 segment, add
optional force-merge/refresh-after-force-merge/
wait-until-merges-finish operations in a number of nyc_taxis challenges.

Also add optional max-num-segments to force-merge down to.