### PR TITLE
Add search_after to geonames and http_logs

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -189,13 +189,31 @@
           "target-throughput": 1.5
         },
         {
+          "operation": "asc_sort_with_after_population",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 1.5
+        },
+        {
           "operation": "desc_sort_geonameid",
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 6
         },
         {
+          "operation": "desc_sort_with_after_geonameid",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 6
+        },
+        {
           "operation": "asc_sort_geonameid",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 6
+        },
+        {
+          "operation": "asc_sort_with_after_geonameid",
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 6

--- a/geonames/operations/default.json
+++ b/geonames/operations/default.json
@@ -346,6 +346,7 @@
       "name": "desc_sort_with_after_geonameid",
       "operation-type": "search",
       "body": {
+        "track_total_hits": false,
         "query": {
           "match_all": {}
         },
@@ -371,6 +372,7 @@
       "name": "asc_sort_with_after_geonameid",
       "operation-type": "search",
       "body": {
+        "track_total_hits": false,
         "query": {
           "match_all": {}
         },

--- a/geonames/operations/default.json
+++ b/geonames/operations/default.json
@@ -318,6 +318,19 @@
       }
     },
     {
+      "name": "asc_sort_with_after_population",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"population" : "asc"}
+        ],
+        "search_after" : [1000000]
+      }
+    },
+    {
       "name": "desc_sort_geonameid",
       "operation-type": "search",
       "body": {
@@ -330,6 +343,19 @@
       }
     },
     {
+      "name": "desc_sort_with_after_geonameid",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"geonameid" : "desc"}
+        ],
+        "search_after": [5000000]
+      }
+    },
+    {
       "name": "asc_sort_geonameid",
       "operation-type": "search",
       "body": {
@@ -339,5 +365,18 @@
         "sort" : [
           {"geonameid" : "asc"}
         ]
+      }
+    },
+    {
+      "name": "asc_sort_with_after_geonameid",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"geonameid" : "asc"}
+        ],
+        "search_after": [5000000]
       }
     }

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -99,6 +99,18 @@
           "target-throughput": 0.5
         },
         {
+          "operation": "desc_sort_with_after_timestamp",
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "target-throughput": 0.5
+        },
+        {
+          "operation": "asc_sort_with_after_timestamp",
+          "warmup-iterations": 10,
+          "iterations": 100,
+          "target-throughput": 0.5
+        },
+        {
           "name": "force-merge-1-seg",
           "operation": {
             "operation-type": "force-merge",
@@ -140,16 +152,16 @@
         {
           "name": "desc-sort-with-after-timestamp-after-force-merge-1-seg",
           "operation": "desc_sort_with_after_timestamp",
-          "warmup-iterations": 200,
+          "warmup-iterations": 10,
           "iterations": 100,
-          "target-throughput": 2
+          "target-throughput": 0.5
         },
         {
           "name": "asc-sort-with-after-timestamp-after-force-merge-1-seg",
           "operation": "asc_sort_with_after_timestamp",
-          "warmup-iterations": 200,
+          "warmup-iterations": 10,
           "iterations": 100,
-          "target-throughput": 2
+          "target-throughput": 0.5
         }
       ]
     },

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -136,6 +136,20 @@
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
+        },
+        {
+          "name": "desc-sort-with-after-timestamp-after-force-merge-1-seg",
+          "operation": "desc_sort_with_after_timestamp",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 2
+        },
+        {
+          "name": "asc-sort-with-after-timestamp-after-force-merge-1-seg",
+          "operation": "asc_sort_with_after_timestamp",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 2
         }
       ]
     },

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -125,6 +125,7 @@
       "operation-type": "search",
       "index": "logs-*",
       "body": {
+        "track_total_hits": false,
         "query": {
           "match_all": {}
         },
@@ -152,6 +153,7 @@
       "operation-type": "search",
       "index": "logs-*",
       "body": {
+        "track_total_hits": false,
         "query": {
           "match_all": {}
         },

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -121,6 +121,20 @@
       }
     },
     {
+      "name": "desc_sort_with_after_timestamp",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"@timestamp" : "desc"}
+        ],
+        "search_after": ["1998-06-10"]
+      }
+    },
+    {
       "name": "asc_sort_timestamp",
       "operation-type": "search",
       "index": "logs-*",
@@ -131,6 +145,20 @@
         "sort" : [
           {"@timestamp" : "asc"}
         ]
+      }
+    },
+    {
+      "name": "asc_sort_with_after_timestamp",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"@timestamp" : "asc"}
+        ],
+        "search_after": ["1998-06-10"]
       }
     },
     {


### PR DESCRIPTION
As we are optimizing "search_after" performance, we would like to
measure it. This adds "search_after" operation to geonames
and http_logs with a big enough value for "search_after".

1. geonames
- "population" field. As most documents have 0 value for this field,
search_after was added to asc sort.
- "geonameid" field has unique values for each document.
"search_after" was set to 5000000, as an approximate medium
value.

2. http_logs
- "@timestamp" field, "search_after" was set to "1998-06-10"
for desc and asc sorts, which is a medium value.