### PR TITLE
WIP: Add runtime field operations to http_logs

### DIFF
--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -74,6 +74,12 @@
           "target-throughput": 1
         },
         {
+          "operation": "runtime-field-source",
+          "warmup-iterations": 100,
+          "iterations": 100,
+          "target-throughput": 1
+        },
+        {
           "operation": "hourly_agg",
           "warmup-iterations": 100,
           "iterations": 100,
@@ -84,6 +90,12 @@
           "warmup-iterations": 100,
           "iterations": 200,
           "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages",
+          "target-throughput": 1
+        },
+        {
+          "operation": "search-term-runtime-field",
+          "warmup-iterations": 100,
+          "iterations": 100,
           "target-throughput": 1
         },
         {

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -99,6 +99,12 @@
           "target-throughput": 1
         },
         {
+          "operation": "agg-term-runtime-field",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "target-throughput": 1
+        },
+        {
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
           "iterations": 100,

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -75,8 +75,8 @@
         },
         {
           "operation": "runtime-field-source",
-          "warmup-iterations": 100,
-          "iterations": 100,
+          "warmup-iterations": 50,
+          "iterations": 50,
           "target-throughput": 1
         },
         {
@@ -94,8 +94,8 @@
         },
         {
           "operation": "search-term-runtime-field",
-          "warmup-iterations": 100,
-          "iterations": 100,
+          "warmup-iterations": 50,
+          "iterations": 50,
           "target-throughput": 1
         },
         {

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -43,6 +43,11 @@
            "city_name": { "type": "keyword" },
            "location" : { "type" : "geo_point" }
         }
+      },
+      "runtime_request_is_get" : {
+	"type" : "runtime",
+        "runtime_type": "boolean",
+        "script" : "emit(params._source.request.startsWith('GET'))"
       }
     }
   }

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -80,6 +80,32 @@
       }
     },
     {
+      "name": "runtime-field-source",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "match_all": {  }
+        },
+        "docvalue_fields" : ["runtime_request_is_get"],
+        "size" : 10000,
+        "_source": false
+      }
+    },
+    {
+      "name": "search-term-runtime-field",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "term": { "runtime_request_is_get" : true }
+        },
+        "size" : 1000,
+        "track_total_hits": false,
+        "_source": false
+      }
+    },
+    {
       "name": "hourly_agg",
       "operation-type": "search",
       "index": "logs-*",

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -106,6 +106,29 @@
       }
     },
     {
+      "name": "agg-term-runtime-field",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query" : {
+          "range": {
+            "@timestamp": {
+              "gte": 893967600,
+              "lte": 893968000
+            }
+          }
+        },
+        "aggs": {
+          "isGetAgg": {
+            "terms": {
+              "field": "runtime_request_is_get"
+            }
+          }
+        },
+        "size" : 0
+      }
+    },
+    {
       "name": "hourly_agg",
       "operation-type": "search",
       "index": "logs-*",


### PR DESCRIPTION
For #https://github.com/elastic/elasticsearch/issues/62621 I am doing some measurements using the new runtime fields that we would like to add to e.g. the http_logs track at some point. This is an early stage WIP mainly used for discussion so I'm opening this as a draft.