### PR TITLE
Lower target-throughput for geonames term and phrase queries

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -77,13 +77,13 @@
           "operation": "term",
           "warmup-iterations": 500,
           "iterations": 1000,
-          "target-throughput": 150
+          "target-throughput": 140
         },
         {
           "operation": "phrase",
           "warmup-iterations": 500,
           "iterations": 1000,
-          "target-throughput": 150
+          "target-throughput": 145
         },
         {
           "operation": "country_agg_uncached",

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -83,7 +83,7 @@
           "operation": "phrase",
           "warmup-iterations": 500,
           "iterations": 1000,
-          "target-throughput": 145
+          "target-throughput": 140
         },
         {
           "operation": "country_agg_uncached",


### PR DESCRIPTION
From observation in the nightly environment we can see that occasionally
the phrase and term query may take >300ms and >1000ms. This leads to
unnecessary spikes in the latency charts.

Relates to https://github.com/elastic/elasticsearch/pull/61957