### PR TITLE
Lower query throughput in geonames

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -77,13 +77,13 @@
           "operation": "term",
           "warmup-iterations": 500,
           "iterations": 1000,
-          "target-throughput": 140
+          "target-throughput": 100
         },
         {
           "operation": "phrase",
           "warmup-iterations": 500,
           "iterations": 1000,
-          "target-throughput": 140
+          "target-throughput": 110
         },
         {
           "operation": "country_agg_uncached",


### PR DESCRIPTION
With this commit we lower the target throughput for two queries in the
`geonames` track. For both we want to target roughly 70% utilization:

* `term`: We measured a median service time of roughly 7ms which
corresponds to a target throughput of 100 ops/s with 70% utilization.
* `phrase`: We measured a median service time of roughly 6ms which
corresponds to a target throughput of 110 ops/s with 70% utilization.