### PR TITLE
Remove random score functions in geonames

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -147,18 +147,6 @@
           "target-throughput": 1.5
         },
         {
-          "operation": "random_function_score",
-          "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.5
-        },
-        {
-          "operation": "random_script_score",
-          "warmup-iterations": 200,
-          "iterations": 100,
-          "target-throughput": 1.5
-        },
-        {
           "operation": "large_terms",
           "warmup-iterations": 200,
           "iterations": 100,

--- a/geonames/operations/default.json
+++ b/geonames/operations/default.json
@@ -246,39 +246,6 @@
       }
     },
     {
-      "name": "random_function_score",
-      "operation-type": "search",
-      "body": {
-        "query": {
-          "function_score": {
-            "query": {
-              "match_all": {}
-            },
-            "random_score": {
-              "seed": 100,
-              "field": "_seq_no"
-            }  
-          }
-        }
-      }
-    },  
-    {
-      "name": "random_script_score",
-      "operation-type": "search",
-      "body": {
-        "query": {
-          "script_score": {
-            "query": {
-              "match_all": {}
-            },
-            "script": {
-              "source": "randomScore(100, '_seq_no')"
-            }
-          }
-        }
-      }
-    },     
-    {
       "name": "large_terms",
       "operation-type": "search",
       "param-source": "pure-terms-query-source"


### PR DESCRIPTION
Random score queries, having random components, don't guarantee
stable query service time (and latency) and create problems
for investigations.

There were originally added in PR #53 to compare the performance
between function_score and script_score. As we have enough
data for this comparison (random_score query in script_score showed
to perform better than in funciton_score), we can remove these
operations now.