### PR TITLE
Add EQL track (#140)

### DIFF
--- a/eql/README.md
+++ b/eql/README.md
@@ -1,0 +1,16 @@
+## EQL track
+
+This track contains endgame data from SIEM demo cluster and can be downloaded from: https://rally-tracks.storage.googleapis.com/eql/endgame-4.28.2-000001-documents.json.bz2
+(The 1k test file can be downloaded from https://rally-tracks.storage.googleapis.com/eql/endgame-4.28.2-000001-documents-1k.json.bz2)
+
+### Parameters
+
+This track allows to overwrite the following parameters using `--track-params`:
+
+* `bulk_size` (default: 5000)
+* `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
+* `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
+* `number_of_replicas` (default: 0)
+* `number_of_shards` (default: 5)
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
+* `cluster_health` (default: "green"): The minimum required cluster health.

--- a/eql/README.md
+++ b/eql/README.md
@@ -1,7 +1,8 @@
 ## EQL track
 
 This track contains endgame data from SIEM demo cluster and can be downloaded from: https://rally-tracks.storage.googleapis.com/eql/endgame-4.28.2-000001-documents.json.bz2
-(The 1k test file can be downloaded from https://rally-tracks.storage.googleapis.com/eql/endgame-4.28.2-000001-documents-1k.json.bz2)
+(The 1k test file can be downloaded from https://rally-tracks.storage.googleapis.com/eql/endgame-4.28.2-000001-documents-1k.json.bz2).
+The track should be used for Elasticsearch versions >= 7.10.0.
 
 ### Parameters
 

--- a/eql/endgame-4.28.2-000001.json
+++ b/eql/endgame-4.28.2-000001.json
@@ -1,0 +1,2820 @@
+{
+    "mappings": {
+        "_meta": {
+            "version": "1.5.0"
+        },
+        "_size": {
+            "enabled": true
+        },
+        "date_detection": false,
+        "dynamic_templates": [
+            {
+                "strings_as_keyword": {
+                    "mapping": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "match_mapping_type": "string"
+                }
+            }
+        ],
+        "properties": {
+            "@timestamp": {
+                "type": "date"
+            },
+            "agent": {
+                "properties": {
+                    "ephemeral_id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "client": {
+                "properties": {
+                    "address": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "as": {
+                        "properties": {
+                            "number": {
+                                "type": "long"
+                            },
+                            "organization": {
+                                "properties": {
+                                    "name": {
+                                        "fields": {
+                                            "text": {
+                                                "norms": false,
+                                                "type": "text"
+                                            }
+                                        },
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "bytes": {
+                        "type": "long"
+                    },
+                    "domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "geo": {
+                        "properties": {
+                            "city_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "continent_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "location": {
+                                "type": "geo_point"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "mac": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "nat": {
+                        "properties": {
+                            "ip": {
+                                "type": "ip"
+                            },
+                            "port": {
+                                "type": "long"
+                            }
+                        }
+                    },
+                    "packets": {
+                        "type": "long"
+                    },
+                    "port": {
+                        "type": "long"
+                    },
+                    "registered_domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "top_level_domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "user": {
+                        "properties": {
+                            "domain": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "email": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "full_name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "group": {
+                                "properties": {
+                                    "domain": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "id": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "hash": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    }
+                }
+            },
+            "cloud": {
+                "properties": {
+                    "account": {
+                        "properties": {
+                            "id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "availability_zone": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "instance": {
+                        "properties": {
+                            "id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "machine": {
+                        "properties": {
+                            "type": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "provider": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "region": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "container": {
+                "properties": {
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "image": {
+                        "properties": {
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "tag": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "labels": {
+                        "type": "object"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "runtime": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "destination": {
+                "properties": {
+                    "address": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "as": {
+                        "properties": {
+                            "number": {
+                                "type": "long"
+                            },
+                            "organization": {
+                                "properties": {
+                                    "name": {
+                                        "fields": {
+                                            "text": {
+                                                "norms": false,
+                                                "type": "text"
+                                            }
+                                        },
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "bytes": {
+                        "type": "long"
+                    },
+                    "domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "geo": {
+                        "properties": {
+                            "city_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "continent_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "location": {
+                                "type": "geo_point"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "mac": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "nat": {
+                        "properties": {
+                            "ip": {
+                                "type": "ip"
+                            },
+                            "port": {
+                                "type": "long"
+                            }
+                        }
+                    },
+                    "packets": {
+                        "type": "long"
+                    },
+                    "port": {
+                        "type": "long"
+                    },
+                    "registered_domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "top_level_domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "user": {
+                        "properties": {
+                            "domain": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "email": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "full_name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "group": {
+                                "properties": {
+                                    "domain": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "id": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "hash": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    }
+                }
+            },
+            "dll": {
+                "properties": {
+                    "code_signature": {
+                        "properties": {
+                            "exists": {
+                                "type": "boolean"
+                            },
+                            "status": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "subject_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "trusted": {
+                                "type": "boolean"
+                            },
+                            "valid": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "hash": {
+                        "properties": {
+                            "md5": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "sha1": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "sha256": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "sha512": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "path": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "pe": {
+                        "properties": {
+                            "company": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "file_version": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "original_file_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "product": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    }
+                }
+            },
+            "dns": {
+                "properties": {
+                    "answers": {
+                        "properties": {
+                            "class": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "data": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "ttl": {
+                                "type": "long"
+                            },
+                            "type": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "header_flags": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "op_code": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "question": {
+                        "properties": {
+                            "class": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "registered_domain": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "subdomain": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "top_level_domain": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "type": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "resolved_ip": {
+                        "type": "ip"
+                    },
+                    "response_code": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "ecs": {
+                "properties": {
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "endgame": {
+                "dynamic": "false",
+                "properties": {
+                    "event_subtype_full": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "event_type_full": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "metadata": {
+                        "properties": {
+                            "type": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    }
+                }
+            },
+            "error": {
+                "properties": {
+                    "code": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "message": {
+                        "norms": false,
+                        "type": "text"
+                    },
+                    "stack_trace": {
+                        "doc_values": false,
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "index": false,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "event": {
+                "properties": {
+                    "action": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "category": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "code": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "created": {
+                        "type": "date"
+                    },
+                    "dataset": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "duration": {
+                        "type": "long"
+                    },
+                    "end": {
+                        "type": "date"
+                    },
+                    "hash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "ingested": {
+                        "type": "date"
+                    },
+                    "kind": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "module": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "original": {
+                        "doc_values": false,
+                        "ignore_above": 1024,
+                        "index": false,
+                        "type": "keyword"
+                    },
+                    "outcome": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "provider": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "reference": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "risk_score": {
+                        "type": "float"
+                    },
+                    "risk_score_norm": {
+                        "type": "float"
+                    },
+                    "sequence": {
+                        "type": "long"
+                    },
+                    "severity": {
+                        "type": "long"
+                    },
+                    "start": {
+                        "type": "date"
+                    },
+                    "timezone": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "url": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "file": {
+                "properties": {
+                    "accessed": {
+                        "type": "date"
+                    },
+                    "attributes": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "code_signature": {
+                        "properties": {
+                            "exists": {
+                                "type": "boolean"
+                            },
+                            "status": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "subject_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "trusted": {
+                                "type": "boolean"
+                            },
+                            "valid": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "created": {
+                        "type": "date"
+                    },
+                    "ctime": {
+                        "type": "date"
+                    },
+                    "device": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "directory": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "drive_letter": {
+                        "ignore_above": 1,
+                        "type": "keyword"
+                    },
+                    "extension": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "gid": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "group": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "hash": {
+                        "properties": {
+                            "md5": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "sha1": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "sha256": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "sha512": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "inode": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "mime_type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "mode": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "mtime": {
+                        "type": "date"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "owner": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "path": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "pe": {
+                        "properties": {
+                            "company": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "file_version": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "original_file_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "product": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "size": {
+                        "type": "long"
+                    },
+                    "target_path": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "uid": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "group": {
+                "properties": {
+                    "domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "host": {
+                "properties": {
+                    "architecture": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "geo": {
+                        "properties": {
+                            "city_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "continent_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "location": {
+                                "type": "geo_point"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "hostname": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "mac": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "os": {
+                        "properties": {
+                            "family": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "full": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "kernel": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "platform": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "version": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "uptime": {
+                        "type": "long"
+                    },
+                    "user": {
+                        "properties": {
+                            "domain": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "email": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "full_name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "group": {
+                                "properties": {
+                                    "domain": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "id": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "hash": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    }
+                }
+            },
+            "http": {
+                "properties": {
+                    "request": {
+                        "properties": {
+                            "body": {
+                                "properties": {
+                                    "bytes": {
+                                        "type": "long"
+                                    },
+                                    "content": {
+                                        "fields": {
+                                            "text": {
+                                                "norms": false,
+                                                "type": "text"
+                                            }
+                                        },
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "bytes": {
+                                "type": "long"
+                            },
+                            "method": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "referrer": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "response": {
+                        "properties": {
+                            "body": {
+                                "properties": {
+                                    "bytes": {
+                                        "type": "long"
+                                    },
+                                    "content": {
+                                        "fields": {
+                                            "text": {
+                                                "norms": false,
+                                                "type": "text"
+                                            }
+                                        },
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "bytes": {
+                                "type": "long"
+                            },
+                            "status_code": {
+                                "type": "long"
+                            }
+                        }
+                    },
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "labels": {
+                "properties": {
+                    "account_id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "endpoint_id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "log": {
+                "properties": {
+                    "level": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "logger": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "origin": {
+                        "properties": {
+                            "file": {
+                                "properties": {
+                                    "line": {
+                                        "type": "integer"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "function": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "original": {
+                        "doc_values": false,
+                        "ignore_above": 1024,
+                        "index": false,
+                        "type": "keyword"
+                    },
+                    "syslog": {
+                        "properties": {
+                            "facility": {
+                                "properties": {
+                                    "code": {
+                                        "type": "long"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "priority": {
+                                "type": "long"
+                            },
+                            "severity": {
+                                "properties": {
+                                    "code": {
+                                        "type": "long"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "message": {
+                "norms": false,
+                "type": "text"
+            },
+            "network": {
+                "properties": {
+                    "application": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "bytes": {
+                        "type": "long"
+                    },
+                    "community_id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "direction": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "forwarded_ip": {
+                        "type": "ip"
+                    },
+                    "iana_number": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "inner": {
+                        "properties": {
+                            "vlan": {
+                                "properties": {
+                                    "id": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "packets": {
+                        "type": "long"
+                    },
+                    "protocol": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "transport": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "vlan": {
+                        "properties": {
+                            "id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    }
+                }
+            },
+            "observer": {
+                "properties": {
+                    "egress": {
+                        "properties": {
+                            "interface": {
+                                "properties": {
+                                    "alias": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "id": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "vlan": {
+                                "properties": {
+                                    "id": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "zone": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "geo": {
+                        "properties": {
+                            "city_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "continent_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "location": {
+                                "type": "geo_point"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "hostname": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "ingress": {
+                        "properties": {
+                            "interface": {
+                                "properties": {
+                                    "alias": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "id": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "vlan": {
+                                "properties": {
+                                    "id": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "zone": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "mac": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "os": {
+                        "properties": {
+                            "family": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "full": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "kernel": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "platform": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "version": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "product": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "serial_number": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "vendor": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "organization": {
+                "properties": {
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "name": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "package": {
+                "properties": {
+                    "architecture": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "build_version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "checksum": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "description": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "install_scope": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "installed": {
+                        "type": "date"
+                    },
+                    "license": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "path": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "reference": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "size": {
+                        "type": "long"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "process": {
+                "properties": {
+                    "args": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "args_count": {
+                        "type": "long"
+                    },
+                    "code_signature": {
+                        "properties": {
+                            "exists": {
+                                "type": "boolean"
+                            },
+                            "status": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "subject_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "trusted": {
+                                "type": "boolean"
+                            },
+                            "valid": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "command_line": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "entity_id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "executable": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "exit_code": {
+                        "type": "long"
+                    },
+                    "hash": {
+                        "properties": {
+                            "md5": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "sha1": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "sha256": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "sha512": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "name": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "parent": {
+                        "properties": {
+                            "args": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "args_count": {
+                                "type": "long"
+                            },
+                            "code_signature": {
+                                "properties": {
+                                    "exists": {
+                                        "type": "boolean"
+                                    },
+                                    "status": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "subject_name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "trusted": {
+                                        "type": "boolean"
+                                    },
+                                    "valid": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            "command_line": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "entity_id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "executable": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "exit_code": {
+                                "type": "long"
+                            },
+                            "hash": {
+                                "properties": {
+                                    "md5": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "sha1": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "sha256": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "sha512": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "pgid": {
+                                "type": "long"
+                            },
+                            "pid": {
+                                "type": "long"
+                            },
+                            "ppid": {
+                                "type": "long"
+                            },
+                            "start": {
+                                "type": "date"
+                            },
+                            "thread": {
+                                "properties": {
+                                    "id": {
+                                        "type": "long"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "title": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "uptime": {
+                                "type": "long"
+                            },
+                            "working_directory": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "pe": {
+                        "properties": {
+                            "company": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "description": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "file_version": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "original_file_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "product": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "pgid": {
+                        "type": "long"
+                    },
+                    "pid": {
+                        "type": "long"
+                    },
+                    "ppid": {
+                        "type": "long"
+                    },
+                    "start": {
+                        "type": "date"
+                    },
+                    "thread": {
+                        "properties": {
+                            "id": {
+                                "type": "long"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "title": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "uptime": {
+                        "type": "long"
+                    },
+                    "working_directory": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "registry": {
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "bytes": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "strings": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "type": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "hive": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "key": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "path": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "value": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "related": {
+                "properties": {
+                    "hash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "user": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "rule": {
+                "dynamic": "false",
+                "properties": {
+                    "author": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "category": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "description": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "license": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "reference": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "ruleset": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "uuid": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "server": {
+                "properties": {
+                    "address": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "as": {
+                        "properties": {
+                            "number": {
+                                "type": "long"
+                            },
+                            "organization": {
+                                "properties": {
+                                    "name": {
+                                        "fields": {
+                                            "text": {
+                                                "norms": false,
+                                                "type": "text"
+                                            }
+                                        },
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "bytes": {
+                        "type": "long"
+                    },
+                    "domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "geo": {
+                        "properties": {
+                            "city_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "continent_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "location": {
+                                "type": "geo_point"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "mac": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "nat": {
+                        "properties": {
+                            "ip": {
+                                "type": "ip"
+                            },
+                            "port": {
+                                "type": "long"
+                            }
+                        }
+                    },
+                    "packets": {
+                        "type": "long"
+                    },
+                    "port": {
+                        "type": "long"
+                    },
+                    "registered_domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "top_level_domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "user": {
+                        "properties": {
+                            "domain": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "email": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "full_name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "group": {
+                                "properties": {
+                                    "domain": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "id": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "hash": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    }
+                }
+            },
+            "service": {
+                "properties": {
+                    "ephemeral_id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "node": {
+                        "properties": {
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "state": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "source": {
+                "properties": {
+                    "address": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "as": {
+                        "properties": {
+                            "number": {
+                                "type": "long"
+                            },
+                            "organization": {
+                                "properties": {
+                                    "name": {
+                                        "fields": {
+                                            "text": {
+                                                "norms": false,
+                                                "type": "text"
+                                            }
+                                        },
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "bytes": {
+                        "type": "long"
+                    },
+                    "domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "geo": {
+                        "properties": {
+                            "city_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "continent_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "country_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "location": {
+                                "type": "geo_point"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_iso_code": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "region_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "ip": {
+                        "type": "ip"
+                    },
+                    "mac": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "nat": {
+                        "properties": {
+                            "ip": {
+                                "type": "ip"
+                            },
+                            "port": {
+                                "type": "long"
+                            }
+                        }
+                    },
+                    "packets": {
+                        "type": "long"
+                    },
+                    "port": {
+                        "type": "long"
+                    },
+                    "registered_domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "top_level_domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "user": {
+                        "properties": {
+                            "domain": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "email": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "full_name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "group": {
+                                "properties": {
+                                    "domain": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "id": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "name": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "hash": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    }
+                }
+            },
+            "tags": {
+                "ignore_above": 1024,
+                "type": "keyword"
+            },
+            "threat": {
+                "properties": {
+                    "framework": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "tactic": {
+                        "properties": {
+                            "id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "reference": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "technique": {
+                        "properties": {
+                            "id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "reference": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    }
+                }
+            },
+            "tls": {
+                "properties": {
+                    "cipher": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "client": {
+                        "properties": {
+                            "certificate": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "certificate_chain": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "hash": {
+                                "properties": {
+                                    "md5": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "sha1": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "sha256": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "issuer": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "ja3": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "not_after": {
+                                "type": "date"
+                            },
+                            "not_before": {
+                                "type": "date"
+                            },
+                            "server_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "subject": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "supported_ciphers": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "curve": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "established": {
+                        "type": "boolean"
+                    },
+                    "next_protocol": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "resumed": {
+                        "type": "boolean"
+                    },
+                    "server": {
+                        "properties": {
+                            "certificate": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "certificate_chain": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "hash": {
+                                "properties": {
+                                    "md5": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "sha1": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    },
+                                    "sha256": {
+                                        "ignore_above": 1024,
+                                        "type": "keyword"
+                                    }
+                                }
+                            },
+                            "issuer": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "ja3s": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "not_after": {
+                                "type": "date"
+                            },
+                            "not_before": {
+                                "type": "date"
+                            },
+                            "subject": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "version_protocol": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "trace": {
+                "properties": {
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "transaction": {
+                "properties": {
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "url": {
+                "properties": {
+                    "domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "extension": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "fragment": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "full": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "original": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "password": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "path": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "port": {
+                        "type": "long"
+                    },
+                    "query": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "registered_domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "scheme": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "top_level_domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "username": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "user": {
+                "properties": {
+                    "domain": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "email": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "full_name": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "group": {
+                        "properties": {
+                            "domain": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "id": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "hash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "name": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "user_agent": {
+                "properties": {
+                    "device": {
+                        "properties": {
+                            "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "original": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "os": {
+                        "properties": {
+                            "family": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "full": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "kernel": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "name": {
+                                "fields": {
+                                    "text": {
+                                        "norms": false,
+                                        "type": "text"
+                                    }
+                                },
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "platform": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            },
+                            "version": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "vulnerability": {
+                "properties": {
+                    "category": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "classification": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "description": {
+                        "fields": {
+                            "text": {
+                                "norms": false,
+                                "type": "text"
+                            }
+                        },
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "enumeration": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "reference": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "report_id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "scanner": {
+                        "properties": {
+                            "vendor": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "score": {
+                        "properties": {
+                            "base": {
+                                "type": "float"
+                            },
+                            "environmental": {
+                                "type": "float"
+                            },
+                            "temporal": {
+                                "type": "float"
+                            },
+                            "version": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "severity": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            },
+            "winlog": {
+                "properties": {
+                    "channel": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "computer_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "event_id": {
+                        "type": "long"
+                    },
+                    "message": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "opcode": {
+                        "type": "long"
+                    },
+                    "provider_guid": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "provider_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    },
+                    "task": {
+                        "type": "long"
+                    }
+                }
+            }
+        }
+    },
+    "settings": {
+        "index": {
+            "mapping": {
+                "ignore_malformed": "true",
+                "total_fields": {
+                    "limit": "10000"
+                }
+            },
+            "number_of_replicas": "{{number_of_replicas | default(0)}}",
+            "number_of_shards": "{{number_of_shards | default(5)}}",
+            "refresh_interval": "30s"
+        }
+    }
+}

--- a/eql/track.json
+++ b/eql/track.json
@@ -1,0 +1,158 @@
+{% import "rally.helpers" as rally with context %}
+{
+  "version": 2,
+  "description": "EQL benchmarks based on endgame index of SIEM demo cluster",
+  "default": true,
+  "indices": [
+    {
+      "name": "endgame-4.28.2-000001",
+      "body": "endgame-4.28.2-000001.json"
+    }
+  ],
+  "corpora": [
+    {
+      "name": "endgame-4.28.2-000001",
+      "base-url": "https://rally-tracks.storage.googleapis.com/eql",
+      "documents": [
+        {
+          "target-index": "endgame-4.28.2-000001",
+          "source-file": "endgame-4.28.2-000001-documents.json.bz2",
+          "document-count": 60782211,
+          "compressed-bytes": 4875067116,
+          "uncompressed-bytes": 117268958204
+        }
+      ]
+    }
+  ],
+  "schedule": [
+    {
+      "operation": "delete-index"
+    },
+    {
+      "operation": {
+        "operation-type": "create-index",
+        "settings": {{index_settings | default({}) | tojson}}
+      }
+    },
+    {
+      "operation": {
+        "operation-type": "cluster-health",
+        "index": "endgame-4.28.2-000001",
+        "request-params": {
+          "wait_for_status": "{{cluster_health | default('green')}}",
+          "wait_for_no_relocating_shards": "true"
+        }
+      }
+    },
+    {
+      "operation": {
+        "operation-type": "bulk",
+        "bulk-size": {{bulk_size | default(5000)}},
+        "ingest-percentage": {{ingest_percentage | default(100)}}
+      },
+      "clients": {{bulk_indexing_clients | default(8)}}
+    },
+    {
+      "name": "refresh-after-index",
+      "operation": "refresh"
+    },
+    {
+      "operation": {
+        "operation-type": "force-merge",
+        "request-timeout": 7200
+      }
+    },
+    {
+      "name": "refresh-after-force-merge",
+      "operation": "refresh"
+    },
+    {
+      "name": "wait-until-merges-finish",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "_all",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": false
+      }
+    },
+    {
+      "operation": {
+        "name": "sequence_2stage_nofilter_fetch1000_size_1000",
+        "operation-type": "eql",
+        "index": "endgame-4.28*",
+        "body": {
+          "query": "sequence by source.ip, destination.ip [process where true] [process where true]",
+          "fetch_size": 1000,
+	  "size" : 1000
+        }
+      },
+      "clients": 5,
+      "warmup-iterations": 10,
+      "iterations": 50
+    },
+    {
+      "operation": {
+        "name": "sequence_2stage_equalityFilter_maxspan1m_fetch1000_size500_slow",
+        "operation-type": "eql",
+        "index": "endgame-4.28*",
+        "body": {
+          "query": "sequence by source.ip, destination.ip with maxspan=1m [process where user.name != \"SYSTEM\"] [process where user.name == \"SYSTEM\"]",
+          "fetch_size": 1000,
+	  "size" : 500
+        }
+      },
+      "clients": 2,
+      "warmup-iterations": 5,
+      "iterations": 20
+    },
+    {
+      "operation": {
+        "name": "sequence_2stage_nofilter_fetch1000_size1000_tail1000_head200",
+        "operation-type": "eql",
+        "index": "endgame-4.28*",
+        "body": {
+          "query": "sequence by source.ip, destination.ip [process where true] [process where true] | tail 1000 | head 200",
+          "fetch_size": 1000,
+	  "size" : 1000
+        }
+      },
+      "clients": 5,
+      "warmup-iterations": 10,
+      "iterations": 50
+    },
+    {
+      "operation": {
+        "name": "sequence_4stage_nofilter_maxspan5m_fetch1000_size100_head100_tail50",
+        "operation-type": "eql",
+        "index": "endgame-4.28*",
+        "body": {
+          "query": "sequence by source.ip, destination.ip with maxspan=5m [process where true] [process where true] [process where true] [network where true] |head 100 | tail 50",
+          "fetch_size": 1000,
+	  "size" : 100
+        }
+      },
+      "clients": 5,
+      "warmup-iterations": 10,
+      "iterations": 50
+    },
+    {
+      "operation": {
+        "name": "sequence_3stage_startsWithfilter_maxspan30m_fetch1000_size100_tail100_head50",
+        "operation-type": "eql",
+        "index": "endgame-4.28*",
+        "body": {
+          "query": "sequence by host.name with maxspan=30m [process where startsWith(process.name, \"ssh\") == true] by process.ppid [process where startsWith(process.name, \"ssh\") == false] by process.ppid [process where startsWith(process.name, \"ssh\") == true] by process.pid | tail 100 | head 50",
+          "fetch_size": 1000,
+	  "size" : 100
+        }
+      },
+      "clients": 5,
+      "warmup-iterations": 10,
+      "iterations": 50
+    }
+  ]
+}

--- a/eql/track.py
+++ b/eql/track.py
@@ -1,0 +1,12 @@
+import logging
+
+async def eql(es, params):
+    logger = logging.getLogger(__name__)
+    logger.info("Provided params [%s].", params)
+    await es.eql.search(
+            params.get("index"),
+            body=params.get("body"),
+        )
+
+def register(registry):
+    registry.register_runner("eql", eql, async_runner=True)


### PR DESCRIPTION
Add a new track to benchmark EQL performance.

Because of some sporadic errors with downloading the data the bucket url is
used is not the standard one, issue tracked in https://github.com/elastic/infra/issues/24746

(cherry picked from commit 44cfc28c02089976ad6cdac9c046830adf58611d)