### PR TITLE
Fix filter on date_histogram in nyc_taxis

### DIFF
--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -121,16 +121,16 @@
     {
       "name": "date_histogram_calendar_interval",
       "operation-type": "search",
-      "query": {
-        "range": {
-          "dropoff_datetime": {
-            "gte": "2015-01-01 00:00:00",
-            "lt": "2016-01-01 00:00:00"
-          }
-        }
-      },
       "body": {
         "size": 0,
+        "query": {
+          "range": {
+            "dropoff_datetime": {
+              "gte": "2015-01-01 00:00:00",
+              "lt": "2016-01-01 00:00:00"
+            }
+          }
+        },
         "aggs": {
           "dropoffs_over_time": {
             "date_histogram": {


### PR DESCRIPTION
It looks like there is a bug in one of the `date_histogram`s of
nyc_taxis. The `query` filtering the histogram outside the request body
so it doesn't do anything.