### PR TITLE
Reduce percolator-with-content-google target throughput

### DIFF
--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -78,7 +78,7 @@
           "operation": "percolator_with_content_google",
           "warmup-iterations": 100,
           "iterations": 100,
-          "target-throughput": 30
+          "target-throughput": 27
         },
         {
           "operation": "percolator_no_score_with_content_google",


### PR DESCRIPTION
Latency charts have occasional spikes because we can't reach the defined
target throughput.

Lower the target throughput of the operation
"percolator_with_content_google" to 27 ops/s.