### PR TITLE
Provide a timeout for EQL tasks

### DIFF
--- a/eql/track.json
+++ b/eql/track.json
@@ -83,11 +83,12 @@
       "operation": {
         "name": "sequence_2stage_nofilter_fetch1000_size_1000",
         "operation-type": "eql",
+        "request-timeout": 3600,
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip [process where true] [process where true]",
           "fetch_size": 1000,
-	  "size" : 1000
+	      "size" : 1000
         }
       },
       "clients": 5,
@@ -98,11 +99,12 @@
       "operation": {
         "name": "sequence_2stage_equalityFilter_maxspan1m_fetch1000_size500_slow",
         "operation-type": "eql",
+        "request-timeout": 3600,
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip with maxspan=1m [process where user.name != \"SYSTEM\"] [process where user.name == \"SYSTEM\"]",
           "fetch_size": 1000,
-	  "size" : 500
+	      "size" : 500
         }
       },
       "clients": 2,
@@ -113,11 +115,12 @@
       "operation": {
         "name": "sequence_2stage_nofilter_fetch1000_size1000_tail1000_head200",
         "operation-type": "eql",
+        "request-timeout": 3600,
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip [process where true] [process where true] | tail 1000 | head 200",
           "fetch_size": 1000,
-	  "size" : 1000
+	      "size" : 1000
         }
       },
       "clients": 5,
@@ -128,11 +131,12 @@
       "operation": {
         "name": "sequence_4stage_nofilter_maxspan5m_fetch1000_size100_head100_tail50",
         "operation-type": "eql",
+        "request-timeout": 3600,
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip with maxspan=5m [process where true] [process where true] [process where true] [network where true] |head 100 | tail 50",
           "fetch_size": 1000,
-	  "size" : 100
+	      "size" : 100
         }
       },
       "clients": 5,
@@ -143,11 +147,12 @@
       "operation": {
         "name": "sequence_3stage_startsWithfilter_maxspan30m_fetch1000_size100_tail100_head50",
         "operation-type": "eql",
+        "request-timeout": 3600,
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by host.name with maxspan=30m [process where startsWith(process.name, \"ssh\") == true] by process.ppid [process where startsWith(process.name, \"ssh\") == false] by process.ppid [process where startsWith(process.name, \"ssh\") == true] by process.pid | tail 100 | head 50",
           "fetch_size": 1000,
-	  "size" : 100
+	      "size" : 100
         }
       },
       "clients": 5,

--- a/eql/track.py
+++ b/eql/track.py
@@ -1,12 +1,15 @@
 import logging
 
+
 async def eql(es, params):
     logger = logging.getLogger(__name__)
     logger.info("Provided params [%s].", params)
     await es.eql.search(
             params.get("index"),
             body=params.get("body"),
+            request_timeout=params.get("request-timeout")
         )
+
 
 def register(registry):
     registry.register_runner("eql", eql, async_runner=True)


### PR DESCRIPTION
With this commit we specify a default timeout of 1 hour for each EQL
task as they take longer to finish than other API calls.