### PR TITLE
Tune EQL queries to get more consistent results.

### DIFF
--- a/eql/track.json
+++ b/eql/track.json
@@ -92,7 +92,7 @@
         }
       },
       "clients": 5,
-      "warmup-iterations": 10,
+      "warmup-iterations": 20,
       "iterations": 50
     },
     {
@@ -124,8 +124,8 @@
         }
       },
       "clients": 5,
-      "warmup-iterations": 10,
-      "iterations": 50
+      "warmup-iterations": 25,
+      "iterations": 100
     },
     {
       "operation": {
@@ -140,7 +140,7 @@
         }
       },
       "clients": 5,
-      "warmup-iterations": 10,
+      "warmup-iterations": 20,
       "iterations": 50
     },
     {
@@ -156,8 +156,8 @@
         }
       },
       "clients": 5,
-      "warmup-iterations": 10,
-      "iterations": 50
+      "warmup-iterations": 25,
+      "iterations": 100
     }
   ]
 }


### PR DESCRIPTION
Increase iterations for 2 "fast" queries from 50 to 100 and their warmup
iterations, and also increase the warmup iterations for the rest except
for the `_slow` which seem pretty consistent from the previous nightly
runs.