### PR TITLE
Wait until cluster health is green

### DIFF
--- a/eql/track.json
+++ b/eql/track.json
@@ -41,7 +41,8 @@
         "request-params": {
           "wait_for_status": "{{cluster_health | default('green')}}",
           "wait_for_no_relocating_shards": "true"
-        }
+        },
+        "retry-until-success": true
       }
     },
     {

--- a/eventdata/challenges/default.json
+++ b/eventdata/challenges/default.json
@@ -20,7 +20,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -71,7 +72,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -20,7 +20,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -229,7 +230,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -282,7 +284,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -336,7 +339,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -20,7 +20,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -104,7 +105,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -168,7 +170,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -20,7 +20,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -90,7 +91,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -152,7 +154,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -20,7 +20,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -15,7 +15,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
 {%- if runtime_script_grok is defined %}

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -34,7 +34,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -95,7 +96,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -153,7 +155,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -217,7 +220,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -275,7 +279,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/metricbeat/challenges/default.json
+++ b/metricbeat/challenges/default.json
@@ -20,7 +20,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -20,7 +20,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
        {
@@ -128,7 +129,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -20,7 +20,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -127,7 +128,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -187,7 +189,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -360,7 +363,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -24,7 +24,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -108,7 +109,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -164,7 +166,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -217,7 +220,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -440,7 +444,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -514,7 +519,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -20,7 +20,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -30,7 +30,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -124,7 +125,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -185,7 +187,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {
@@ -247,7 +250,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {

--- a/so/challenges/default.json
+++ b/so/challenges/default.json
@@ -20,7 +20,8 @@
             "request-params": {
               "wait_for_status": "{{cluster_health | default('green')}}",
               "wait_for_no_relocating_shards": "true"
-            }
+            },
+            "retry-until-success": true
           }
         },
         {


### PR DESCRIPTION
With this commit we retry the cluster health check until the cluster is
green. Without this change the cluster health check might time out
before the desired status has been reached and the benchmark continues
earlier than intended.