### PR TITLE
Change gcs bucket path for EQL data

### DIFF
--- a/eql/README.md
+++ b/eql/README.md
@@ -1,7 +1,7 @@
 ## EQL track
 
-This track contains endgame data from SIEM demo cluster and can be downloaded from: https://rally-tracks.storage.googleapis.com/eql/endgame-4.28.2-000001-documents.json.bz2
-(The 1k test file can be downloaded from https://rally-tracks.storage.googleapis.com/eql/endgame-4.28.2-000001-documents-1k.json.bz2)
+This track contains endgame data from SIEM demo cluster and can be downloaded from: https://rally-tracks.elastic.co/eql/endgame-4.28.2-000001-documents.json.bz2
+(The 1k test file can be downloaded from https://rally-tracks.elastic.co/eql/endgame-4.28.2-000001-documents-1k.json.bz2)
 
 ### Parameters
 

--- a/eql/track.json
+++ b/eql/track.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "endgame-4.28.2-000001",
-      "base-url": "https://rally-tracks.storage.googleapis.com/eql",
+      "base-url": "https://rally-tracks.elastic.co/eql",
       "documents": [
         {
           "target-index": "endgame-4.28.2-000001",


### PR DESCRIPTION
Since the timeout issue seems to have been resolved changed the url to
the default one, replacing the temporary workaround url.