### PR TITLE
Switch runtime_script_grok to _source

### DIFF
--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -45,7 +45,8 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `ingest_pipeline`: Only applicable for `--challenge=append-index-only-with-ingest-pipeline`, selects which ingest
 node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'geoip'`. For example: `--challenge=append-index-only-with-ingest-pipeline --track-params="ingest_pipeline:'baseline'" `
-* `runtime_script_grok`: If defined the challenges load the `unparsed` set of documents, indexing the `@timestamp` and the raw `message` field. All of the other fields are declared as `runtime` fields extracting the value usig a script.
+* `runtime_script_grok`: If defined the challenge loads the `unparsed` set of documents, indexing the `@timestamp` and the raw `message` field. All of the other fields are declared as `runtime` fields extracting the value usig a script.
+* `runtime_source`: Specifies the way that `runtime_script_grok` loads values to grok. The default is `_source` which loads from `_source`. Other options are `wildcard` which loads from a `wildcard` field and `keyword` which loads from a keyword field.
 
 ### License
 

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -45,7 +45,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `ingest_pipeline`: Only applicable for `--challenge=append-index-only-with-ingest-pipeline`, selects which ingest
 node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'geoip'`. For example: `--challenge=append-index-only-with-ingest-pipeline --track-params="ingest_pipeline:'baseline'" `
-* `runtime_script_grok`: If defined the challenge loads the `unparsed` set of documents, indexing the `@timestamp` and the raw `message` field. All of the other fields are declared as `runtime` fields extracting the value usig a script.
+* `runtime_script_grok`: If defined the challenge loads the `unparsed` set of documents, indexing the `@timestamp` and the raw `message` field. All of the other fields are declared as `runtime` fields extracting the value using a script.
 * `runtime_source`: Specifies the way that `runtime_script_grok` loads values to grok. The default is `_source` which loads from `_source`. Other options are `wildcard` which loads from a `wildcard` field and `keyword` which loads from a keyword field.
 
 ### License

--- a/http_logs/index-runtime-grok-doc-values.json
+++ b/http_logs/index-runtime-grok-doc-values.json
@@ -1,0 +1,44 @@
+{
+  "settings": {
+    "index.number_of_shards": {{number_of_shards | default(5)}},
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.requests.cache.enable": false
+  },
+  "mappings": {
+    "dynamic": "strict",
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
+    "properties": {
+      "@timestamp": {
+        "format": "strict_date_optional_time||epoch_second",
+        "type": "date"
+      },
+      "message": {
+        "type": "{{runtime_source}}"
+      }
+    },
+    "runtime": {
+      "clientip": {
+        "type": "ip",
+        "script": "String m = doc[\"message\"].value; int end = m.indexOf(\" \"); emit(m.substring(0, end));"
+      },
+      "request": {
+        "type": "keyword",
+        "script": "String m = doc[\"message\"].value; int start = m.indexOf(\"\\\"\") + 1; int end = m.indexOf(\"\\\"\", start); emit(m.substring(start, end));"
+      },
+      "status": {
+        "type": "long",
+        "script": "String m = doc[\"message\"].value; int end = m.lastIndexOf(\" \"); int start = m.lastIndexOf(\" \", end - 1) + 1; emit(Long.parseLong(m.substring(start, end)));"
+      },
+      "size": {
+        "type": "long",
+        "script": "String m = doc[\"message\"].value; int start = m.lastIndexOf(\" \") + 1; emit(Long.parseLong(m.substring(start)));"
+      },
+      "runtime_timestamp": {
+        "type": "date",
+        "script": "String m = doc[\"message\"].value; int start = m.indexOf(\" \"); start = m.indexOf(\" \", start + 1); start = m.indexOf(\" \", start + 1); int end = m.indexOf(\" \", start + 1); emit(parse(m.substring(start + 2, end - 1)));"
+      }
+    }
+  }
+}

--- a/http_logs/index-runtime-grok-source.json
+++ b/http_logs/index-runtime-grok-source.json
@@ -23,7 +23,7 @@
         "type": "ip",
         "script": "String m = doc[\"message\"].value; int end = m.indexOf(\" \"); emit(m.substring(0, end));"
       },
-      "request": {
+      "request.keyword": {
         "type": "keyword",
         "script": "String m = doc[\"message\"].value; int start = m.indexOf(\"\\\"\") + 1; int end = m.indexOf(\"\\\"\", start); emit(m.substring(start, end));"
       },

--- a/http_logs/index-runtime-grok-source.json
+++ b/http_logs/index-runtime-grok-source.json
@@ -13,12 +13,12 @@
       "@timestamp": {
         "format": "strict_date_optional_time||epoch_second",
         "type": "date"
-      },
-      "message": {
-        "type": "keyword"
       }
     },
     "runtime": {
+      "message": {
+        "type": "keyword" {# Loads the field from _source #}
+      },
       "clientip": {
         "type": "ip",
         "script": "String m = doc[\"message\"].value; int end = m.indexOf(\" \"); emit(m.substring(0, end));"

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -2,7 +2,11 @@
 
 
 {%- if runtime_script_grok is defined %}
-  {% set index_body = 'index-runtime-grok.json' %}
+  {%- if runtime_source is not defined or runtime_source == "_source" %}
+    {% set index_body = 'index-runtime-grok-source.json' %}
+  {%- else %}
+    {% set index_body = 'index-runtime-grok-doc-values.json' %}
+  {%- endif %}
 {%- else %}
   {% set index_body = 'index.json' %}
 {%- endif %}


### PR DESCRIPTION
This switches the `runtime_script_grok` track to load from `_source` by
default and makes it possible to configure it to load from either
`_source`, a `wildcard` field, or a `keyword` field.

Loading values from `_source` is more realistic for the "saving space"
use case and we should see that in the index size. Loading from
`wildcard` would be more realistic in the "flexibility" use case so that
is useful to run locally, but for now it makes sense to run the "saving
space" use case in rally. Loading values from a `keyword` field is
useful mostly as a baseline to compare to the `wildcard` field. We
*think* `wildcard` is always better at flexibility and `_source` is
always better at saving space, but being able to test `keyword` will
validate our theories.