### PR TITLE
Fix two operations around runtime fields

### DIFF
--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -1,4 +1,4 @@
-{
+        {
           "operation": "delete-index"
         },
         {
@@ -70,9 +70,9 @@
         },
         {
           "operation": "term",
-          "warmup-iterations": 500,
-          "iterations": 100,
-          "target-throughput": 50
+          "warmup-iterations": {%- if runtime_script_grok is defined %}50{% else %}500{% endif %},
+          "iterations": {%- if runtime_script_grok is defined %}10{% else %}100{% endif %},
+          "target-throughput": {%- if runtime_script_grok is defined %}0.125{% else %}50{% endif %}
         },
         {
           "operation": "range",
@@ -84,7 +84,7 @@
           "operation": "200s-in-range",
           "warmup-iterations": 500,
           "iterations": 100,
-          "target-throughput": {%- if runtime_script_grok is defined %}15{% else %}50{% endif %}
+          "target-throughput": {%- if runtime_script_grok is defined %}15{% else %}33{% endif %}
         },
         {
           "operation": "400s-in-range",

--- a/http_logs/index-runtime-grok.json
+++ b/http_logs/index-runtime-grok.json
@@ -23,7 +23,7 @@
         "type": "ip",
         "script": "String m = doc[\"message\"].value; int end = m.indexOf(\" \"); emit(m.substring(0, end));"
       },
-      "request": {
+      "request.raw": {
         "type": "keyword",
         "script": "String m = doc[\"message\"].value; int start = m.indexOf(\"\\\"\") + 1; int end = m.indexOf(\"\\\"\", start); emit(m.substring(start, end));"
       },


### PR DESCRIPTION
This fixes the throughput for the new `200s-in-range` when run against
standard indexed fields to be something more reasonable. It also fixes
the `term` query test for runtime field. Previously it was running
against an unmapped field so it would return nothing very very quickly.
Now it runs against the runtime field and shows how slow queries against
a runtime field can be when you don't add another query to limit the
docs we have to look at.

Closes #149