### PR TITLE
Lower throughput target for runtime 200s in range

### DIFF
--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -84,7 +84,7 @@
           "operation": "200s-in-range",
           "warmup-iterations": 500,
           "iterations": 100,
-          "target-throughput": {%- if runtime_script_grok is defined %}15{% else %}33{% endif %}
+          "target-throughput": {%- if runtime_script_grok is defined %}5{% else %}33{% endif %}
         },
         {
           "operation": "400s-in-range",


### PR DESCRIPTION
Now that using `_source` as the origin of runtime fields has settled I'm
looking into the throughput targets. It looks like 400s in range is
fine. The service time for 200s in range varies between 60ms and 140ms.
That variation ain't great. It turns out that we're targeting a
throughput of 15 operations per second which is a little tight for the
60ms service time. This switches the new target to 5 operations per
second which has a ton of extra space, even for the 140ms service time.
Hopefully we'll see some more stability in the service time after this.