### PR TITLE
Fix term for source runtime fields

### DIFF
--- a/http_logs/index-runtime-grok-source.json
+++ b/http_logs/index-runtime-grok-source.json
@@ -23,7 +23,7 @@
         "type": "ip",
         "script": "String m = doc[\"message\"].value; int end = m.indexOf(\" \"); emit(m.substring(0, end));"
       },
-      "request.keyword": {
+      "request.raw": {
         "type": "keyword",
         "script": "String m = doc[\"message\"].value; int start = m.indexOf(\"\\\"\") + 1; int end = m.indexOf(\"\\\"\", start); emit(m.substring(start, end));"
       },


### PR DESCRIPTION
When runtime fields are based on `_source` (added in #148) we were mapping
`request.keyword` instead of `request.raw` what was causing term queries
to quickly fail, giving incorrect timings.