### PR TITLE
Make slow runtime field query target realistic

### DIFF
--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -72,7 +72,7 @@
           "operation": "term",
           "warmup-iterations": {%- if runtime_script_grok is defined %}50{% else %}500{% endif %},
           "iterations": {%- if runtime_script_grok is defined %}10{% else %}100{% endif %},
-          "target-throughput": {%- if runtime_script_grok is defined %}0.125{% else %}50{% endif %}
+          "target-throughput": {%- if runtime_script_grok is defined %}0.05{% else %}50{% endif %}
         },
         {
           "operation": "range",


### PR DESCRIPTION
In #152 we fixed a query against runtime fields so it would not longer
erroniously report that the request took 10ms. The error took 10ms to
generate..... OK! Now that we run the actual request against _source (
see #148 for that) our old througput target of about 8 seconds per
request ain't gonna work - `_source` is slower. About 18 seconds per
request. This updates the throughput target.