### PR TITLE
reduce target-throughput for tasks that are a little tight in nightlies

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -90,7 +90,7 @@
           "operation": "country_agg_uncached",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 3.6
+          "target-throughput": 3
         },
         {
           "operation": "country_agg_cached",
@@ -109,7 +109,7 @@
           "operation": "expression",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 2
+          "target-throughput": 1.5
         },
         {
           "operation": "painless_static",


### PR DESCRIPTION
service_time increased slightly for geonames tasks "country_agg_uncached" and "expression" as a result of recent benchmark environment changes.  These increases caused a multi-fold increase in measured latency, which is affecting readability in our nightly benchmarks charts.  This change adjusts the throughput target for these two tasks and will accompany an annotation in the charts on elasticsearch-benchmarks.elastic.co