### PR TITLE
Benchmark for date_histo with one bucket

### DIFF
--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -430,6 +430,13 @@
           "target-interval": 3
         },
         {
+          "operation": "date-histo-entire-range",
+          "clients": 1,
+          "warmup-iterations": 100,
+          "iterations": 500,
+          "target-interval": 0.2
+        },
+        {
           "operation": "date-histo-numeric-terms",
           "clients": 1,
           "warmup-iterations": 10,

--- a/noaa/operations/default.json
+++ b/noaa/operations/default.json
@@ -839,6 +839,21 @@
       }
     },
     {
+      "name": "date-histo-entire-range",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "date",
+              "fixed_interval": "2000d"
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "date-histo-numeric-terms",
       "operation-type": "search",
       "body": {


### PR DESCRIPTION
This adds a benchmark for `date_histogram` when a single bucket covers
the entire index. We expect this to be quite common for buckets with a
size near a day. Its fairly common for folks to use "daily" indices that
contain *about* a day's worth of data. That day isn't likely to line up
*exactly* with daily buckets. But for buckets marginally larger than a
day and for indices even a little smaller than a day I think it'll be
quite common.

Benchmark for https://github.com/elastic/elasticsearch/pull/71180