### PR TITLE
Use a new CDN backed bucket for standard tracks

### DIFF
--- a/eventdata/track.json
+++ b/eventdata/track.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "eventdata",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/eventdata",
+      "base-url": "https://rally-tracks.elastic.co/eventdata",
       "documents": [
         {
           "source-file": "eventdata.json.bz2",

--- a/geonames/track.json
+++ b/geonames/track.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "geonames",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/geonames",
+      "base-url": "https://rally-tracks.elastic.co/geonames",
       "documents": [
         {
           "source-file": "documents-2.json.bz2",

--- a/geopoint/track.json
+++ b/geopoint/track.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "geopoint",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/geopoint",
+      "base-url": "https://rally-tracks.elastic.co/geopoint",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/geopointshape/track.json
+++ b/geopointshape/track.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "geopointshape",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/geopointshape",
+      "base-url": "https://rally-tracks.elastic.co/geopointshape",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/geoshape/track.json
+++ b/geoshape/track.json
@@ -20,7 +20,7 @@
   "corpora": [
     {
       "name": "linestrings",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/geoshape",
+      "base-url": "https://rally-tracks.elastic.co/geoshape",
       "target-index": "osmlinestrings",
       "documents": [
         {
@@ -33,7 +33,7 @@
     },
     {
       "name": "multilinestrings",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/geoshape",
+      "base-url": "https://rally-tracks.elastic.co/geoshape",
       "target-index": "osmmultilinestrings",
       "documents": [
         {
@@ -46,7 +46,7 @@
     },
     {
       "name": "polygons",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/geoshape",
+      "base-url": "https://rally-tracks.elastic.co/geoshape",
       "target-index": "osmpolygons",
       "documents": [
         {

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -48,7 +48,7 @@
       {%- if ingest_pipeline is defined and ingest_pipeline == "grok" or runtime_fields is defined %}
         {
           "name": "http_logs_unparsed",
-          "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs",
+          "base-url": "https://rally-tracks.elastic.co/http_logs",
           "documents": [
           {
             "target-index": "logs-181998",
@@ -104,7 +104,7 @@
     {%- else %}
       {
         "name": "http_logs",
-        "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/http_logs",
+        "base-url": "https://rally-tracks.elastic.co/http_logs",
         "documents": [
           {
             "target-index": "logs-181998",

--- a/metricbeat/track.json
+++ b/metricbeat/track.json
@@ -11,7 +11,7 @@
   "corpora": [
     {
       "name": "metricbeat",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/metricbeat",
+      "base-url": "https://rally-tracks.elastic.co/metricbeat",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/nested/track.json
+++ b/nested/track.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "nested",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/nested",
+      "base-url": "https://rally-tracks.elastic.co/nested",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/noaa/track.json
+++ b/noaa/track.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "noaa",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/noaa",
+      "base-url": "https://rally-tracks.elastic.co/noaa",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/nyc_taxis/track.json
+++ b/nyc_taxis/track.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "nyc_taxis",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/nyc_taxis",
+      "base-url": "https://rally-tracks.elastic.co/nyc_taxis",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/percolator/track.json
+++ b/percolator/track.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "percolator",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/percolator",
+      "base-url": "https://rally-tracks.elastic.co/percolator",
       "documents": [
         {
           "source-file": "queries-2.json.bz2",

--- a/pmc/track.json
+++ b/pmc/track.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "pmc",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/pmc",
+      "base-url": "https://rally-tracks.elastic.co/pmc",
       "documents": [
         {
           "source-file": "documents.json.bz2",

--- a/so/track.json
+++ b/so/track.json
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "so",
-      "base-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/so",
+      "base-url": "https://rally-tracks.elastic.co/so",
       "documents": [
         {
           "source-file": "posts.json.bz2",


### PR DESCRIPTION
Following the pattern we used with the EQL track (#147) we switch
storage of the corpora of standard tracks to a CDN backed Google Cloud
Storage bucket.

The previous bucket wasn't CDN backed so this should result in a
concrete improvement of the user experience.