### PR TITLE
update to use new on_prepare_track API

### DIFF
--- a/http_logs/track.py
+++ b/http_logs/track.py
@@ -1,8 +1,8 @@
 from copy import copy
 import re
 
-from esrally import exceptions
 from esrally.track import loader
+
 
 def reindex(es, params):
     result = es.reindex(body=params.get("body"), request_timeout=params.get("request_timeout"))
@@ -27,7 +27,7 @@ class RuntimeFieldResolver(loader.TrackProcessor):
                     task.operation.params = self._replace_field(f"{impl}.from_{source}.", task.operation.params)
 
     def on_prepare_track(self, track, data_root_dir):
-        return True
+        return []
 
     def _replace_field(self, field, t):
         if t == 'path' or t == 'status':
@@ -48,3 +48,4 @@ def register(registry):
     else:
         registry.register_runner("reindex", reindex)
     registry.register_track_processor(RuntimeFieldResolver())
+    registry.register_track_processor(loader.DefaultTrackPreparator())


### PR DESCRIPTION
elastic/rally#1228 broke the RuntimeFieldResolver with an API change, this updates the API to the new paradigm

also relates elastic/rally#1253