### PR TITLE
Add ignore-response-error-level for bulk

### DIFF
--- a/eql/README.md
+++ b/eql/README.md
@@ -14,3 +14,4 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `number_of_shards` (default: 5)
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.

--- a/eql/README.md
+++ b/eql/README.md
@@ -14,4 +14,4 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `number_of_shards` (default: 5)
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.

--- a/eql/track.json
+++ b/eql/track.json
@@ -51,7 +51,8 @@
         "bulk-size": {{bulk_size | default(5000)}},
         "ingest-percentage": {{ingest_percentage | default(100)}}
       },
-      "clients": {{bulk_indexing_clients | default(8)}}
+      "clients": {{bulk_indexing_clients | default(8)}},
+      "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
     },
     {
       "name": "refresh-after-index",

--- a/eventdata/README.md
+++ b/eventdata/README.md
@@ -45,7 +45,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index. 
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/eventdata/README.md
+++ b/eventdata/README.md
@@ -45,6 +45,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index. 
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/eventdata/challenges/default.json
+++ b/eventdata/challenges/default.json
@@ -27,7 +27,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "operation": {
@@ -79,7 +80,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "operation": {

--- a/geonames/README.md
+++ b/geonames/README.md
@@ -47,6 +47,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index. 
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/geonames/README.md
+++ b/geonames/README.md
@@ -47,7 +47,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index. 
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -27,7 +27,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -237,7 +238,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "operation": {
@@ -291,7 +293,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "operation": {
@@ -346,7 +349,8 @@
         {
           "operation": "index-update",
           "warmup-time-period": 45,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "operation": {

--- a/geopoint/README.md
+++ b/geopoint/README.md
@@ -30,7 +30,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/geopoint/README.md
+++ b/geopoint/README.md
@@ -30,6 +30,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -27,7 +27,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -112,7 +113,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
         "name": "refresh-after-index",
@@ -177,7 +179,8 @@
         {
           "operation": "index-update",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
         "name": "refresh-after-index",

--- a/geopointshape/README.md
+++ b/geopointshape/README.md
@@ -25,7 +25,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/geopointshape/README.md
+++ b/geopointshape/README.md
@@ -25,6 +25,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -27,7 +27,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -98,7 +99,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
         "name": "refresh-after-index",
@@ -161,7 +163,8 @@
         {
           "operation": "index-update",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
         "name": "refresh-after-index",

--- a/geoshape/README.md
+++ b/geoshape/README.md
@@ -24,6 +24,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/geoshape/README.md
+++ b/geoshape/README.md
@@ -24,7 +24,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -27,7 +27,8 @@
         {
           "operation": "index-append-linestrings",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-linestrings-index",
@@ -58,7 +59,8 @@
         {
           "operation": "index-append-multilinestrings",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-multilinestrings-index",
@@ -89,7 +91,8 @@
         {
           "operation": "index-append-polygons",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-polygons-index",

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -46,7 +46,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `ingest_pipeline`: Only applicable for `--challenge=append-index-only-with-ingest-pipeline`, selects which ingest
 node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'geoip'`. For example: `--challenge=append-index-only-with-ingest-pipeline --track-params="ingest_pipeline:'baseline'" `
 * `runtime_fields`: If defined the challenge loads the `unparsed` set of documents, indexing the `@timestamp` and the raw `message` field and the runtime fields required for the `runtime-fields` challenge.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -46,6 +46,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `ingest_pipeline`: Only applicable for `--challenge=append-index-only-with-ingest-pipeline`, selects which ingest
 node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'geoip'`. For example: `--challenge=append-index-only-with-ingest-pipeline --track-params="ingest_pipeline:'baseline'" `
 * `runtime_fields`: If defined the challenge loads the `unparsed` set of documents, indexing the `@timestamp` and the raw `message` field and the runtime fields required for the `runtime-fields` challenge.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -41,7 +41,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -103,7 +104,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -165,7 +167,8 @@
         {
           "operation": "index-append-with-ingest-{{ingest_pipeline | default('baseline')}}-pipeline",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -227,7 +230,8 @@
         {
           "operation": "update",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -286,7 +290,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",

--- a/metricbeat/challenges/default.json
+++ b/metricbeat/challenges/default.json
@@ -27,7 +27,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 0,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",

--- a/nested/README.md
+++ b/nested/README.md
@@ -58,7 +58,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/nested/README.md
+++ b/nested/README.md
@@ -58,6 +58,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -28,7 +28,8 @@
           "operation": "index-append",
           "warmup-time-period": 120,
           "time-period": 3600,
-          "clients": {{bulk_indexing_clients | default(4)}}
+          "clients": {{bulk_indexing_clients | default(4)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -137,7 +138,8 @@
           "operation": "index-append",
           "warmup-time-period": 120,
           "time-period": 3600,
-          "clients": {{bulk_indexing_clients | default(4)}}
+          "clients": {{bulk_indexing_clients | default(4)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
         "name": "refresh-after-index",

--- a/noaa/README.md
+++ b/noaa/README.md
@@ -52,7 +52,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/noaa/README.md
+++ b/noaa/README.md
@@ -52,6 +52,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -28,7 +28,8 @@
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
           "warmup-time-period": 70,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -136,7 +137,8 @@
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
           "warmup-time-period": 70,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -197,7 +199,8 @@
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
           "warmup-time-period": 70,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -378,7 +381,8 @@
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
           "warmup-time-period": 10,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",

--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -70,6 +70,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -70,7 +70,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -31,7 +31,8 @@
         {
           "operation": "index",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -116,7 +117,8 @@
         {
           "operation": "index",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -173,7 +175,8 @@
         {
           "operation": "index",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -227,7 +230,8 @@
         {
           "operation": "update",
           "warmup-time-period": 1200,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -451,7 +455,8 @@
         {
           "operation": "index",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -526,7 +531,8 @@
         {
           "operation": "index",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",

--- a/percolator/README.md
+++ b/percolator/README.md
@@ -28,7 +28,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/percolator/README.md
+++ b/percolator/README.md
@@ -28,6 +28,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -28,7 +28,8 @@
           "operation": "index",
           "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
           "warmup-time-period": 10,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",

--- a/pmc/README.md
+++ b/pmc/README.md
@@ -39,7 +39,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * [`default_search_timeout`](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/search.html#global-search-timeout) (default: -1)
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/pmc/README.md
+++ b/pmc/README.md
@@ -39,6 +39,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * [`default_search_timeout`](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/search.html#global-search-timeout) (default: -1)
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -37,7 +37,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -132,7 +133,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -194,7 +196,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",
@@ -257,7 +260,8 @@
         {
           "operation": "index-update",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "name": "refresh-after-index",

--- a/so/README.md
+++ b/so/README.md
@@ -51,6 +51,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
+* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/so/README.md
+++ b/so/README.md
@@ -51,7 +51,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `error-level` default('non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `error-level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 
 ### License
 

--- a/so/challenges/default.json
+++ b/so/challenges/default.json
@@ -27,7 +27,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error-level | default('non-fatal')}}"
         },
         {
           "operation": {


### PR DESCRIPTION
Added configurable `error-level` track parameter, default non-fatal
Relates to: https://github.com/elastic/rally/pull/1235