### PR TITLE
Add operation for new terms_enum API

### DIFF
--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -88,6 +88,13 @@
         },
 {%- endif %}
         {
+          "name": "terms_enum",
+          "operation": "terms_enum",
+          "warmup-iterations": 500,
+          "iterations": 100,
+          "target-throughput": 50
+        },  
+        {
           "operation": "range",
           "warmup-iterations": 100,
           "iterations": 100,

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -334,4 +334,14 @@
           }
         ]
       }
+    },
+    {
+      "name": "terms_enum",
+      "operation-type": "raw-request",
+      "path": "/logs-*/_terms_enum",
+      "method": "GET",
+      "body": {
+        "field": "request.raw",
+        "string": "GET image"
+      }
     }


### PR DESCRIPTION
Adds an operation for the new terms_enum API (the API used to provide fast autocomplete support for field values in Kibana).

Closes #178 