### PR TITLE
Decrease target-throughput of painless in geonames

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -116,13 +116,13 @@
           "operation": "painless_static",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 1.5
+          "target-throughput": 1.4
         },
         {
           "operation": "painless_dynamic",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 1.5
+          "target-throughput": 1.4
         },
         {
           "operation": "decay_geo_gauss_function_score",


### PR DESCRIPTION
Painless static and dynamic are spiking unnecessarily in
https://elasticsearch-benchmarks.elastic.co, with the service_time
occasionally just below 700ms.

Lower target-thoughput so that latency will not increase
as long as queries get serviced within ~714ms.