### PR TITLE
Deprecating eventdata track

### DIFF
--- a/eventdata/challenges/default.json
+++ b/eventdata/challenges/default.json
@@ -1,5 +1,6 @@
     {
       "name": "append-no-conflicts",
+      "user-info": "This track is deprecated. Please use https://github.com/elastic/rally-eventdata-track.",
       "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "default": true,
       "schedule": [

--- a/eventdata/challenges/default.json
+++ b/eventdata/challenges/default.json
@@ -1,6 +1,6 @@
     {
       "name": "append-no-conflicts",
-      "user-info": "This track is deprecated. Please use https://github.com/elastic/rally-eventdata-track.",
+      "user-info": "This track is deprecated and will be removed soon. Please use https://github.com/elastic/rally-eventdata-track.",
       "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "default": true,
       "schedule": [
@@ -54,6 +54,7 @@
     },
     {
       "name": "transform",
+      "user-info": "This track is deprecated and will be removed soon. Please use https://github.com/elastic/rally-eventdata-track.",
       "description": "Indexes the whole document corpus using Elasticsearch default settings and run transforms to pivot data by terms, date and geo tiles.",
       "default": false,
       "schedule": [


### PR DESCRIPTION
Added user-info message to deprecated the track. The track will be remove in a follow up pr soon to reduce maintenance effort. This is not the [eventdata](https://github.com/elastic/rally-eventdata-track) track that we use in many benchmarks but a version with a static corpus.