### PR TITLE
Improve consistency of geo tracks

### DIFF
--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -173,6 +173,7 @@
         {
           "operation": {
             "operation-type": "force-merge",
+            "max-num-segments": 1,
             "request-timeout": 7200
           }
         },

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -39,6 +39,7 @@
           "name": "force-merge-linestrings",
           "operation": {
             "operation-type": "force-merge",
+            "max-num-segments": 1,
             "index": "osmlinestrings",
             "request-timeout": 7200
           }
@@ -71,6 +72,7 @@
           "name": "force-merge-multilinestrings",
           "operation": {
             "operation-type": "force-merge",
+            "max-num-segments": 1,
             "index": "osmmultilinestrings",
             "request-timeout": 7200
           }
@@ -103,6 +105,7 @@
           "name": "force-merge-polygons",
           "operation": {
             "operation-type": "force-merge",
+            "max-num-segments": 1,
             "index": "osmpolygons",
             "request-timeout": 7200
           }


### PR DESCRIPTION
The execution speed of geo tracks may change drastically depending on 
the BKD tree structures in different segments. This change ensures that 
we have only one segment before running the search queries.