### PR TITLE
Adding optional max_num_segments param for geonames

### DIFF
--- a/geonames/README.md
+++ b/geonames/README.md
@@ -44,6 +44,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Rally docs](http://esrally.readthedocs.io/en/latest/track.html#bulk) for the full definition of this parameter. This requires to run the respective challenge.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 5)
+* `max_num_segments`: The maximum number of segments to force-merge to.
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index. 
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -37,7 +37,9 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200
+            "request-timeout": 7200{%- if max_num_segments is defined %},
+            "max-num-segments": {{max_num_segments}}
+             {%- endif %}
           }
         },
         {
@@ -244,7 +246,9 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200
+            "request-timeout": 7200{%- if max_num_segments is defined %},
+            "max-num-segments": {{max_num_segments}}
+             {%- endif %}
           }
         },
         {
@@ -299,7 +303,9 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200
+            "request-timeout": 7200{%- if max_num_segments is defined %},
+            "max-num-segments": {{max_num_segments}}
+             {%- endif %}
           }
         },
         {
@@ -355,7 +361,9 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200
+            "request-timeout": 7200{%- if max_num_segments is defined %},
+            "max-num-segments": {{max_num_segments}}
+             {%- endif %}
           }
         },
         {
@@ -406,7 +414,9 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200
+            "request-timeout": 7200{%- if max_num_segments is defined %},
+            "max-num-segments": {{max_num_segments}}
+             {%- endif %}
           }
         },
         {


### PR DESCRIPTION
Allow to configure number of segments for force merge for geonames.