### PR TITLE
Ensure force merge down to 1 segment for all geopointshape challenges

### DIFF
--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -37,6 +37,7 @@
         {
           "operation": {
             "operation-type": "force-merge",
+            "max-num-segments": 1,
             "request-timeout": 7200
           }
         },
@@ -109,6 +110,7 @@
         {
           "operation": {
             "operation-type": "force-merge",
+            "max-num-segments": 1,
             "request-timeout": 7200
           }
         },


### PR DESCRIPTION
PR #184 missed the force merge for the challenge
(`append-no-conflicts`) responsible for the nigntly query charts
of the `geopointshape` track.

This commit changes force merge behavior for **all** the challenges
in the track to fully merge (i.e. `max_num_segments`:`1`).