### PR TITLE
Add `cluster` param to eql track for CCS (#187)

### DIFF
--- a/eql/track.py
+++ b/eql/track.py
@@ -4,8 +4,11 @@ import logging
 async def eql(es, params):
     logger = logging.getLogger(__name__)
     logger.info("Provided params [%s].", params)
+    if cluster := params.get("cluster", ""):
+        cluster += ":"
+
     await es.eql.search(
-            params.get("index"),
+            cluster + params.get("index"),
             body=params.get("body"),
             request_timeout=params.get("request-timeout")
         )


### PR DESCRIPTION
Add a new param: `cluster` which can be set to indicate
which configured remote cluster to hit when running the EQL
benchmarks in CCS setup.

(cherry picked from commit a4f3ee6e680b0feb6f7cc321aa9554bab7346929)