### PR TITLE
Add new track param `cluster` for CCS requests

### DIFF
--- a/eql/README.md
+++ b/eql/README.md
@@ -15,3 +15,4 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `cluster` (default: '') Cluster name configured on the target ES host as a remote cluster to allow execution of CCS queries.

--- a/eql/track.json
+++ b/eql/track.json
@@ -1,4 +1,5 @@
 {% import "rally.helpers" as rally with context %}
+{% set cluster = cluster | default('') %}
 {
   "version": 2,
   "description": "EQL benchmarks based on endgame index of SIEM demo cluster",
@@ -86,7 +87,7 @@
         "name": "sequence_2stage_nofilter_fetch1000_size_1000",
         "operation-type": "eql",
         "request-timeout": 3600,
-        "cluster" : "{{cluster | default('')}}",
+        "cluster" : "{{cluster}}",
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip [process where true] [process where true]",
@@ -103,7 +104,7 @@
         "name": "sequence_2stage_equalityFilter_maxspan1m_fetch1000_size500_slow",
         "operation-type": "eql",
         "request-timeout": 3600,
-        "cluster" : "{{cluster | default('')}}",
+        "cluster" : "{{cluster}}",
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip with maxspan=1m [process where user.name != \"SYSTEM\"] [process where user.name == \"SYSTEM\"]",
@@ -120,7 +121,7 @@
         "name": "sequence_2stage_nofilter_fetch1000_size1000_tail1000_head200",
         "operation-type": "eql",
         "request-timeout": 3600,
-        "cluster" : "{{cluster | default('')}}",
+        "cluster" : "{{cluster}}",
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip [process where true] [process where true] | tail 1000 | head 200",
@@ -137,7 +138,7 @@
         "name": "sequence_4stage_nofilter_maxspan5m_fetch1000_size100_head100_tail50",
         "operation-type": "eql",
         "request-timeout": 3600,
-        "cluster" : "{{cluster | default('')}}",
+        "cluster" : "{{cluster}}",
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip with maxspan=5m [process where true] [process where true] [process where true] [network where true] |head 100 | tail 50",
@@ -154,7 +155,7 @@
         "name": "sequence_3stage_startsWithfilter_maxspan30m_fetch1000_size100_tail100_head50",
         "operation-type": "eql",
         "request-timeout": 3600,
-        "cluster" : "{{cluster | default('')}}",
+        "cluster" : "{{cluster}}",
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by host.name with maxspan=30m [process where startsWith(process.name, \"ssh\") == true] by process.ppid [process where startsWith(process.name, \"ssh\") == false] by process.ppid [process where startsWith(process.name, \"ssh\") == true] by process.pid | tail 100 | head 50",

--- a/eql/track.json
+++ b/eql/track.json
@@ -86,6 +86,7 @@
         "name": "sequence_2stage_nofilter_fetch1000_size_1000",
         "operation-type": "eql",
         "request-timeout": 3600,
+        "cluster" : "{{cluster | default('')}}",
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip [process where true] [process where true]",
@@ -102,6 +103,7 @@
         "name": "sequence_2stage_equalityFilter_maxspan1m_fetch1000_size500_slow",
         "operation-type": "eql",
         "request-timeout": 3600,
+        "cluster" : "{{cluster | default('')}}",
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip with maxspan=1m [process where user.name != \"SYSTEM\"] [process where user.name == \"SYSTEM\"]",
@@ -118,6 +120,7 @@
         "name": "sequence_2stage_nofilter_fetch1000_size1000_tail1000_head200",
         "operation-type": "eql",
         "request-timeout": 3600,
+        "cluster" : "{{cluster | default('')}}",
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip [process where true] [process where true] | tail 1000 | head 200",
@@ -134,6 +137,7 @@
         "name": "sequence_4stage_nofilter_maxspan5m_fetch1000_size100_head100_tail50",
         "operation-type": "eql",
         "request-timeout": 3600,
+        "cluster" : "{{cluster | default('')}}",
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by source.ip, destination.ip with maxspan=5m [process where true] [process where true] [process where true] [network where true] |head 100 | tail 50",
@@ -150,6 +154,7 @@
         "name": "sequence_3stage_startsWithfilter_maxspan30m_fetch1000_size100_tail100_head50",
         "operation-type": "eql",
         "request-timeout": 3600,
+        "cluster" : "{{cluster | default('')}}",
         "index": "endgame-4.28*",
         "body": {
           "query": "sequence by host.name with maxspan=30m [process where startsWith(process.name, \"ssh\") == true] by process.ppid [process where startsWith(process.name, \"ssh\") == false] by process.ppid [process where startsWith(process.name, \"ssh\") == true] by process.pid | tail 100 | head 50",


### PR DESCRIPTION
Add a new parameter `cluster` which can be set with --track-params
to allow execution of CCS queries. The default value is '' (empty
string) so that no CCS but direct queries are performed.