### PR TITLE
Increase iterations for date histogram aggregation

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -79,8 +79,8 @@
         },
         {
           "operation": "date_histogram_agg",
-          "warmup-iterations": 50,
-          "iterations": 100,
+          "warmup-iterations": 500,
+          "iterations": 500,
           "target-throughput": 1.5
         }
       ]


### PR DESCRIPTION
We have seen warmup issues in our nightly benchmarks for the date
histogram aggregation recently. With this commit we increase the number
of warmup and also measurement iterations to provide more time to warmup
and get more stable measurement results.