### PR TITLE
Force-merge to one segment in nested by default

### DIFF
--- a/nested/README.md
+++ b/nested/README.md
@@ -59,6 +59,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `max_num_segments` (default: 1): An integer specifying the max amount of segments the force-merge operation should use. To unset, set the parameter to `null` with [track parameters via JSON file](https://esrally.readthedocs.io/en/stable/command_line_reference.html#track-params).
 
 ### License
 

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -153,6 +153,7 @@
             "operation-type": "force-merge",
             "request-timeout": 7200{%- if force_merge_max_num_segments is not none %},
             "max-num-segments": {{force_merge_max_num_segments}}
+             {%- endif %}
           }
         },
         {

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -1,3 +1,4 @@
+    {% set force_merge_max_num_segments = (max_num_segments | default(1)) %}
     {
       "name": "nested-search-challenge",
       "description": "Indexes the document corpus for an hour using Elasticsearch default settings. After that randomized nested queries are run.",
@@ -38,7 +39,9 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200
+            "request-timeout": 7200{%- if force_merge_max_num_segments is not none %},
+            "max-num-segments": {{force_merge_max_num_segments}}
+             {%- endif %}
           }
         },
         {
@@ -148,7 +151,8 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200
+            "request-timeout": 7200{%- if force_merge_max_num_segments is not none %},
+            "max-num-segments": {{force_merge_max_num_segments}}
           }
         },
         {


### PR DESCRIPTION
Updated the default for force-merge parameter max_num_segments to 1, to
improve the stability of the benchmark and to be consistent with the
other tracks.

Relates to #193