### PR TITLE
Reduce target throughput for noaa disjunction big range

### DIFF
--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -107,7 +107,7 @@
           "operation": "range_field_disjunction_big_range_small_term_query",
           "warmup-iterations": 100,
           "iterations": 500,
-          "target-throughput": 6
+          "target-throughput": 5
         }
       ]
     },


### PR DESCRIPTION
In our nightly benchmarks, we see some spikiness in `nightly-basic-noaa-add-defaults-range_field_disjunction_big_range_small_term_query-latency`, particularly after Aug 16th, which is an annotated regression.
<img width="2543" alt="image" src="https://user-images.githubusercontent.com/7477841/136800296-023e619e-41ef-41bf-bf09-2b0cfafa71f1.png">

Given we are charting latency, rather than service_time, it seems that perhaps the task is over-scheduled, and that the smaller spikes are probably very similar to the larger spikes (e.g. that we have "runaway" latency).  To check this theory, we chart service_time:
<img width="2520" alt="image" src="https://user-images.githubusercontent.com/7477841/136800629-7e7ba4d0-1f86-445b-aa28-11e266d8a868.png">

Our theory holds true.  This change increases the target allowable latency from an effective 166.7 ms to 200 ms by reducing target throughput from 6 to 5.