### PR TITLE
Revert force-merge to one segment in noaa by default

### DIFF
--- a/noaa/README.md
+++ b/noaa/README.md
@@ -53,7 +53,7 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
-* `max_num_segments` (default: 1): An integer specifying the max amount of segments the force-merge operation should use. To unset, set the parameter to `null` with [track parameters via JSON file](https://esrally.readthedocs.io/en/stable/command_line_reference.html#track-params).
+* `max_num_segments` (default: not set): An integer specifying the max amount of segments the force-merge operation should use.
 
 ### License
 

--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -1,4 +1,3 @@
-    {% set force_merge_max_num_segments = (max_num_segments | default(1)) %}
     {
       "name": "append-no-conflicts",
       "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green and we want to ensure that we don't use the query cache. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
@@ -39,8 +38,8 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200{%- if force_merge_max_num_segments is not none %},
-            "max-num-segments": {{force_merge_max_num_segments}}
+            "request-timeout": 7200{%- if max_num_segments is defined %},
+            "max-num-segments": {{max_num_segments}}
              {%- endif %}
           }
         },
@@ -150,8 +149,8 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200{%- if force_merge_max_num_segments is not none %},
-            "max-num-segments": {{force_merge_max_num_segments}}
+            "request-timeout": 7200{%- if max_num_segments is defined %},
+            "max-num-segments": {{max_num_segments}}
              {%- endif %}
           }
         },
@@ -214,8 +213,8 @@
         },
         {
           "operation": "force-merge",
-          "clients": 1{%- if force_merge_max_num_segments is not none %},
-          "max-num-segments": {{force_merge_max_num_segments}}
+          "clients": 1{%- if max_num_segments is defined %},
+          "max-num-segments": {{max_num_segments}}
            {%- endif %}
         },
         {
@@ -398,8 +397,8 @@
         },
         {
           "operation": "force-merge",
-          "clients": 1{%- if force_merge_max_num_segments is not none %},
-          "max-num-segments": {{force_merge_max_num_segments}}
+          "clients": 1{%- if max_num_segments is defined %},
+          "max-num-segments": {{max_num_segments}}
            {%- endif %}
         },
         {


### PR DESCRIPTION
Reverted the default back to unset, as we did not see any improvement in query performance stability with this change but saw some instability with written index.

Relates to: https://github.com/elastic/rally-tracks/pull/194