### PR TITLE
http_logs: default to ignore non-fatal errors during index-append

### DIFF
--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -32,7 +32,8 @@
         {
           "operation": "index-append",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
         },
 {%- endif %}
         {


### PR DESCRIPTION
With this PR we set `ignore-response-error-level: non-fatal` for index-append in the http_logs default track schedule. This resolves an issue where index-append could abort if a non-fatal network timeout occurs during bulk indexing. If the client does encounter a timeout, we want the client to ignore the error and continue retrying.