### PR TITLE
remove dependency on mapper-size plugin in EQL track

### DIFF
--- a/eql/endgame-4.28.2-000001.json
+++ b/eql/endgame-4.28.2-000001.json
@@ -3,9 +3,6 @@
         "_meta": {
             "version": "1.5.0"
         },
-        "_size": {
-            "enabled": true
-        },
         "date_detection": false,
         "dynamic_templates": [
             {


### PR DESCRIPTION
It looks like the mapper-size plugin is not really needed and I couldn't figure out what it has been used for. Since it makes some steps in the workflow more cumbersome, I think it's best to remove it. First step would be to remove the dependency on the plugin from the track.

Creating this as a separate PR to be able to isolate potential effects on performance (I don't expect any though).