### PR TITLE
[7.14] remove dependency on mapper-size plugin (#211)

### DIFF
--- a/eql/endgame-4.28.2-000001.json
+++ b/eql/endgame-4.28.2-000001.json
@@ -3,9 +3,6 @@
         "_meta": {
             "version": "1.5.0"
         },
-        "_size": {
-            "enabled": true
-        },
         "date_detection": false,
         "dynamic_templates": [
             {


### PR DESCRIPTION
Backports the following commits to 7.14:
 - remove dependency on mapper-size plugin (#211)