### PR TITLE
SQL benchmarks

### DIFF
--- a/eql/track.py
+++ b/eql/track.py
@@ -1,9 +1,6 @@
-import logging
 
 
 async def eql(es, params):
-    logger = logging.getLogger(__name__)
-    logger.info("Provided params [%s].", params)
     if cluster := params.get("cluster", ""):
         cluster += ":"
 

--- a/noaa/challenges/sql.json
+++ b/noaa/challenges/sql.json
@@ -62,7 +62,6 @@
         {
           "name": "refresh-after-index",
           "operation": "refresh",
-          "clients": 1,
           "tags": ["setup"]
         },
         {
@@ -75,7 +74,6 @@
         {
           "name": "refresh-after-force-merge",
           "operation": "refresh",
-          "clients": 1,
           "tags": ["setup"]
         },
         {

--- a/noaa/challenges/sql.json
+++ b/noaa/challenges/sql.json
@@ -1,0 +1,275 @@
+    {% set task_options_10qps %}
+      "target-throughput": 10,
+      "clients": 2,
+      "warmup-iterations": 50,
+      "iterations": 100,
+      "tags": ["queries"]
+    {% endset %}
+
+    {% set task_options_5qps %}
+    "target-throughput": 5,
+    "clients": 2,
+    "warmup-iterations": 50,
+    "iterations": 100,
+    "tags": ["queries"]
+    {% endset %}
+
+    {% set task_options_1qps %}
+    "target-throughput": 1,
+    "clients": 2,
+    "warmup-iterations": 25,
+    "iterations": 50,
+    "tags": ["queries"]
+    {% endset %}
+
+    {
+      "name": "sql",
+      "description": "Checks the performance of SQL",
+      "default": false,
+      "schedule": [
+        {
+          "operation": "delete-index",
+          "tags": ["setup"]
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          },
+          "tags": ["setup"]
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "weather-data-2016",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            },
+            "retry-until-success": true
+          },
+          "tags": ["setup"]
+        },
+        {
+          "operation": "index",
+          "#COMMENT": "This is an incredibly short warmup time period but it is necessary to get also measurement samples. As this benchmark is rather about search than indexing this is ok.",
+          "warmup-time-period": 10,
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+          "tags": ["setup"]
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "clients": 1,
+          "tags": ["setup"]
+        },
+        {
+          "operation": "force-merge",
+          "tags": ["setup"],
+          "clients": 1{%- if max_num_segments is defined %},
+          "max-num-segments": {{max_num_segments}}
+          {%- endif %}
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "clients": 1,
+          "tags": ["setup"]
+        },
+        {
+          "operation": {
+            "name": "increase-max-open-scoll-context",
+            "operation-type": "put-settings",
+            "body": {
+              "transient" : {
+                  "search.max_open_scroll_context" : "2000"
+              }
+            }
+          },
+          "tags": ["setup"]
+        },
+        {
+          "operation": {
+            "name": "select_const",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT 1"
+            }
+          },
+          {{ task_options_10qps }}
+        },
+        {
+          "operation": {
+            "name": "select_star",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT * FROM \"weather-data-2016\""
+            }
+          },
+          {{ task_options_10qps }}
+        },
+        {
+          "operation": {
+            "name": "select_field",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name FROM \"weather-data-2016\""
+            }
+          },
+          {{ task_options_10qps }}
+        },
+        {
+          "operation": {
+            "name": "select_scriptField",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT LCASE(SUBSTRING(station.name, 0, 2)) FROM \"weather-data-2016\""
+            }
+          },
+          {{ task_options_10qps }}
+        },
+        {
+          "operation": {
+            "name": "select_stringScriptFilter",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name FROM \"weather-data-2016\" WHERE LCASE(SUBSTRING(station.name, 0, 2)) = 'sa' AND station.elevation > 2800"
+            }
+          },
+          {{ task_options_1qps }}
+        },
+        {
+          "operation": {
+            "name": "select_stringScriptFilterWithLimit",
+            {# https://github.com/elastic/elasticsearch/issues/80523 #}
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name FROM \"weather-data-2016\" WHERE LCASE(SUBSTRING(station.name, 0, 2)) = 'sa' AND station.elevation > 2800 LIMIT 10"
+            }
+          },
+          {{ task_options_1qps }}
+        },
+        {
+          "operation": {
+            "name": "select_numericScriptFilter",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name FROM \"weather-data-2016\" WHERE CEIL(TMIN) % 7 = 5 AND station.elevation > 2800"
+            }
+          },
+          {{ task_options_5qps }}
+        },
+        {
+          "operation": {
+            "name": "select_stringScriptSort",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name FROM \"weather-data-2016\" WHERE station.elevation > 2800 ORDER BY LCASE(SUBSTRING(station.name, 0, 2))"
+            }
+          },
+          {{ task_options_1qps }}
+        },
+        {
+          "operation": {
+            "name": "select_numericScriptSort",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name FROM \"weather-data-2016\" WHERE station.elevation > 2800 ORDER BY CEIL(TMIN) % 7 = 5"
+            }
+          },
+          {{ task_options_5qps }}
+        },
+        {
+          "operation": {
+            "name": "aggregate_byStringScript",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT LCASE(SUBSTRING(station.name, 0, 2)) FROM \"weather-data-2016\" WHERE station.elevation > 2800 GROUP BY 1"
+            }
+          },
+          {{ task_options_1qps }}
+        },
+        {
+          "operation": {
+            "name": "aggregate_byNumericScript",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT CEIL(TMIN) % 7 FROM \"weather-data-2016\" WHERE station.elevation > 2800 GROUP BY 1"
+            }
+          },
+          {{ task_options_5qps }}
+        },
+        {
+          "operation": {
+            "name": "aggregate_overStringScript",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name, SUM(LENGTH(SUBSTRING(station.name, 0, 5))) S FROM \"weather-data-2016\" WHERE station.elevation > 2800 GROUP BY 1"
+            }
+          },
+          {{ task_options_1qps }}
+        },
+        {
+          "operation": {
+            "name": "aggregate_overStringScript_sortByAggregate",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name, SUM(LENGTH(SUBSTRING(station.name, 0, 5))) S FROM \"weather-data-2016\" WHERE station.elevation > 2800 GROUP BY 1 ORDER BY S"
+            }
+          },
+          {{ task_options_1qps }}
+        },
+        {
+          "operation": {
+            "name": "aggregate_overStringScript_filterByAggregate",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name, SUM(LENGTH(SUBSTRING(station.name, 0, 5))) S FROM \"weather-data-2016\" WHERE station.elevation > 2800 GROUP BY 1 HAVING S > 1000"
+            }
+          },
+          {{ task_options_1qps }}
+        },
+        {
+          "operation": {
+            "name": "aggregate_overNumericScript",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name, SUM(CEIL(TMIN) % 7) FROM \"weather-data-2016\" WHERE station.elevation > 2800 GROUP BY 1"
+            }
+          },
+          {{ task_options_5qps }}
+        },
+        {
+          "operation": {
+            "name": "aggregate_overNumericScript_sortByAggregate",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name, SUM(CEIL(TMIN) % 7) FROM \"weather-data-2016\" WHERE station.elevation > 2800 GROUP BY 1 ORDER BY 2"
+            }
+          },
+          {{ task_options_5qps }}
+        },
+        {
+          "operation": {
+            "name": "aggregate_overNumericScript_filterByAggregate",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT station.name, SUM(CEIL(TMIN) % 7) S FROM \"weather-data-2016\" WHERE station.elevation > 2800 GROUP BY 1 HAVING S > 0"
+            }
+          },
+          {{ task_options_5qps }}
+        },
+        {
+          "operation": {
+            "name": "pivot",
+            "operation-type": "sql",
+            "body": {
+              "query": "SELECT * FROM (SELECT station.country_code, TMIN FROM \"weather-data-2016\") PIVOT (AVG(TMIN) FOR station.country_code IN ('AS', 'CA'))"
+            }
+          },
+          {{ task_options_1qps }}
+        }
+      ]
+    }

--- a/noaa/track.py
+++ b/noaa/track.py
@@ -1,11 +1,7 @@
-import logging
 
 
-async def sql(es, params):
-    logger = logging.getLogger(__name__)
-    logger.info("Provided params [%s].", params)
-    
-    body = params.get("body")
+async def sql(es, params):    
+    body = params["body"]
     # default page_timeout is not suited for benchmarks as it keeps the scroll contexts open for 45s
     if 'page_timeout' not in body:
         body['page_timeout'] = '100ms'

--- a/noaa/track.py
+++ b/noaa/track.py
@@ -1,0 +1,20 @@
+import logging
+
+
+async def sql(es, params):
+    logger = logging.getLogger(__name__)
+    logger.info("Provided params [%s].", params)
+    
+    body = params.get("body")
+    # default page_timeout is not suited for benchmarks as it keeps the scroll contexts open for 45s
+    if 'page_timeout' not in body:
+        body['page_timeout'] = '100ms'
+
+    await es.sql.query(
+            body=body,
+            request_timeout=params.get("request-timeout")
+        )
+
+
+def register(registry):
+    registry.register_runner("sql", sql, async_runner=True)


### PR DESCRIPTION
Introduces SQL benchmarks using the existing NOAA dataset: 33M measurements from weather stations, 6GB in index. The dataset is ideal for running analytical queries like average temp over 12 months in all stations in Canada and seems to match SQL like use cases best (of the already existing datasets).