### PR TITLE
Remove deprecated sorted indexing challenge in geonames

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -267,64 +267,6 @@
       ]
     },
     {
-      "name": "append-sorted-no-conflicts",
-      "description": "Indexes the whole document corpus in an index sorted by country_code field in ascending order. Document ids are unique so all index operations are append only.",
-      "user-info": "This challenge is deprecated and will be removed soon. Use the corresponding challenge in http_logs to benchmark sorted indices.",
-      "schedule": [
-        {
-          "operation": "delete-index"
-        },
-        {
-          "operation": {
-            "operation-type": "create-index",
-            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
-              "index.sort.field": ["country_code.raw", "admin1_code.raw"],
-              "index.sort.order": ["asc", "asc"]
-            }{%- endif %}
-          }
-        },
-        {
-          "name": "check-cluster-health",
-          "operation": {
-            "operation-type": "cluster-health",
-            "index": "geonames",
-            "request-params": {
-              "wait_for_status": "{{cluster_health | default('green')}}",
-              "wait_for_no_relocating_shards": "true"
-            },
-            "retry-until-success": true
-          }
-        },
-        {
-          "operation": "index-append",
-          "warmup-time-period": 120,
-          "clients": {{bulk_indexing_clients | default(8)}},
-          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
-        },
-        {
-          "operation": {
-            "operation-type": "force-merge",
-            "request-timeout": 7200{%- if max_num_segments is defined %},
-            "max-num-segments": {{max_num_segments}}
-             {%- endif %}
-          }
-        },
-        {
-          "name": "wait-until-merges-finish",
-          "operation": {
-            "operation-type": "index-stats",
-            "index": "_all",
-            "condition": {
-              "path": "_all.total.merges.current",
-              "expected-value": 0
-            },
-            "retry-until-success": true,
-            "include-in-reporting": false
-          }
-        }
-      ]
-    },
-    {
       "name": "append-fast-with-conflicts",
       "description": "Indexes the whole document corpus using a setup that will lead to a larger indexing throughput than the default settings. Rally will produce duplicate ids in 25% of all documents (not configurable) so we can simulate a scenario with appends most of the time and some updates in between.",
       "schedule": [


### PR DESCRIPTION
Closes #202 

In #200 we agreed to deprecate sorted indexing challenge in geonames, and in #202 we scheduled its removal after grace period.