### PR TITLE
EQL: Adjust new benchmarks

### DIFF
--- a/eql/track.json
+++ b/eql/track.json
@@ -17,6 +17,14 @@
 "iterations": 100
 {% endset %}
 
+{% set task_options_3qps %}
+"tags": ["fast"],
+"target-throughput": 3,
+"clients": 2,
+"warmup-iterations": 50,
+"iterations": 100
+{% endset %}
+
 {% set task_options_03qps %}
 "tags": ["slow"],
 "target-throughput": 0.3,
@@ -238,7 +246,7 @@
           "query": "process where startsWith(concat(process.name, \" \", process.pid), \"ssh\")"
         }
       },
-      {{ task_options_10qps }}
+      {{ task_options_3qps }}
     },
     {# Basic Sequence Queries #}
     {
@@ -304,7 +312,7 @@
           "query": "sequence by ?source.ip [process where true] [process where true]"
         }
       },
-      {{ task_options_5qps }}
+      {{ task_options_3qps }}
     },
     {# 
       Sequences of varios lengths, sequence_2stages_fewThenFew_noJoinKey is the first query in the progression.


### PR DESCRIPTION
Some of the new EQL benchmark tasks require adjustment because the target throughput is on the verge of causing congestion. As a result, the latency piles up and causes stark outliers in the aggregated latency stats. Visible in the following two graphs:

![image](https://user-images.githubusercontent.com/1016746/144817210-412cd313-c978-40cf-a567-008f25d8763c.png)
![image](https://user-images.githubusercontent.com/1016746/144831533-81744ac2-4ea6-4c04-b54f-d02aaa2e458e.png)
