### PR TITLE
EQL: No max-num-segments for index sorting challenge

### DIFF
--- a/eql/challenges/index_sorting.json
+++ b/eql/challenges/index_sorting.json
@@ -46,8 +46,7 @@
     {
       "operation": {
         "operation-type": "force-merge",
-        "request-timeout": 7200,
-        "max-num-segments": 1
+        "request-timeout": 7200
       },
       "tags": "setup"
     },


### PR DESCRIPTION
The first results from the index-sorting challenge show quite high latency for the `sequence_2stages_headThenTail` task. The problem is most likely caused by merging the whole index into one huge segment in combination with the reversed sort direction due to the `head` pipe. A local test gave much better latency when not requiring `max-num-segments`.

Also, since the default challenge does not use `max-num-segments`, removing the setting should make query comparisons between the two challenges fairer.