### PR TITLE
dense_vector track: enable force_merge metric reporting

### DIFF
--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -31,7 +31,8 @@
       "operation": {
         "operation-type": "force-merge",
         "max-num-segments": 1,
-        "request-timeout": 7200
+        "request-timeout": 7200,
+        "include-in-reporting": true
       }
     },
     {


### PR DESCRIPTION
Force merge reporting is disabled by default. This commit enables reporting of force merge metrics to be visualized in nightly benchmarks.