### PR TITLE
Combine http_logs data to single file

### DIFF
--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -10,6 +10,7 @@
   "version": 2,
   "description": "HTTP server log data",
   "#TODO": "Replace index definitions with a template after setting the track version to 2. Explicit index definitions are not necessary anymore.",
+      {%- if ingest_pipeline is defined and ingest_pipeline == "grok" or runtime_fields is defined %}
   "indices": [
     {
       "name": "logs-181998",
@@ -45,7 +46,6 @@
     }
   ],
   "corpora": [
-      {%- if ingest_pipeline is defined and ingest_pipeline == "grok" or runtime_fields is defined %}
         {
           "name": "http_logs_unparsed",
           "base-url": "https://rally-tracks.elastic.co/http_logs",
@@ -101,64 +101,30 @@
           }
         ]
       }
+  ],
     {%- else %}
+  "indices": [
+      {
+        "name": "logs-http_logs",
+        "body": "index.json"
+      }
+  ],
+  "corpora": [
       {
         "name": "http_logs",
         "base-url": "https://rally-tracks.elastic.co/http_logs",
         "documents": [
           {
-            "target-index": "logs-181998",
-            "source-file": "documents-181998.json.bz2",
-            "document-count": 2708746,
-            "compressed-bytes": 13843641,
-            "uncompressed-bytes": 363512754
-          },
-          {
-            "target-index": "logs-191998",
-            "source-file": "documents-191998.json.bz2",
-            "document-count": 9697882,
-            "compressed-bytes": 49546887,
-            "uncompressed-bytes": 1301732149
-          },
-          {
-            "target-index": "logs-201998",
-            "source-file": "documents-201998.json.bz2",
-            "document-count": 13053463,
-            "compressed-bytes": 65759419,
-            "uncompressed-bytes": 1744012279
-          },
-          {
-            "target-index": "logs-211998",
-            "source-file": "documents-211998.json.bz2",
-            "document-count": 17647279,
-            "compressed-bytes": 88445049,
-            "uncompressed-bytes": 2364230815
-          },
-          {
-            "target-index": "logs-221998",
-            "source-file": "documents-221998.json.bz2",
-            "document-count": 10716760,
-            "compressed-bytes": 54274027,
-            "uncompressed-bytes": 1438320123
-          },
-          {
-            "target-index": "logs-231998",
-            "source-file": "documents-231998.json.bz2",
-            "document-count": 11961342,
-            "compressed-bytes": 61043842,
-            "uncompressed-bytes": 1597530673
-          },
-          {
-            "target-index": "logs-241998",
-            "source-file": "documents-241998.json.bz2",
-            "document-count": 181463624,
-            "compressed-bytes": 907295259,
-            "uncompressed-bytes": 24555905444
+            "target-index": "logs-http_logs",
+            "source-file": "documents-unified.json.bz2",
+            "document-count": 247249096,
+            "compressed-bytes": 1240202396,
+            "uncompressed-bytes": 33365244237
           }
         ]
       }
-    {%- endif %}
   ],
+{%- endif %}
   "operations": [
     {{ rally.collect(parts="operations/*.json") }}
   ],


### PR DESCRIPTION
In order to support a desired behavior change in Rally bulk indexing (see elastic/rally#1412), we need to unify the data set in http_logs to a single file.

Marked as WIP while developing incrementally and testing.

Planned Work:
- [x] Build/deploy parsed data set to rally-tracks.elastic.co
- [ ] Test for regressions using append-no-conflicts challenge
- [ ] Build/deploy unparsed data set to rally-tracks.elastic.co
- [ ] Test for regressions using runtime-fields challenge

Potential goblins:
* Change of performance due to collapsing to single index (will need to add action and metadata to data set files)
