### PR TITLE
index-append-with-timestamp-pipeline: set ignore non-fatal errors by default

### DIFF
--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -26,7 +26,8 @@
         {
           "operation": "index-append-with-timestamp-pipeline",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}}
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
         },
 {%- else %}
         {


### PR DESCRIPTION
Set `ignore-response-error-level: non-fatal` by default for task `index-append-with-timestamp-pipeline` to prevent aborting track execution on a non-fatal error. The same was implemented previously for `index-append` in https://github.com/elastic/rally-tracks/pull/206. Both fixes address errors we've encountered with http_logs encryption-at-rest benchmarks.