### PR TITLE
Add new geoshape default track that runs with less data

### DIFF
--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -138,6 +138,173 @@
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 0.25
+        },
+        {
+          "operation": "mvt",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 0.25
+        },
+        {
+          "operation": "mvt-grid",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 0.25
+        }
+      ]
+    },
+    {
+      "name": "append-no-conflicts-full",
+      "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",
+      "default": false,
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+      }
+      },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "osm*",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            },
+            "retry-until-success": true
+          }
+        },
+        {
+          "operation": "index-append-linestrings-full",
+          "warmup-time-period": 120,
+          "clients": {{bulk_indexing_clients | default(8)}},
+        "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+        },
+        {
+          "name": "refresh-after-linestrings-index",
+          "operation": "refresh",
+          "index": "osmlinestrings"
+        },
+        {
+          "name": "force-merge-linestrings",
+          "operation": {
+            "operation-type": "force-merge",
+            "max-num-segments": 1,
+            "index": "osmlinestrings",
+            "request-timeout": 7200
+          }
+        },
+        {
+          "name": "wait-until-linestrings-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
+          "operation": "index-append-multilinestrings-full",
+          "warmup-time-period": 120,
+          "clients": {{bulk_indexing_clients | default(8)}},
+        "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+        },
+        {
+          "name": "refresh-after-multilinestrings-index",
+          "operation": "refresh",
+          "index": "osmmultilinestrings"
+        },
+        {
+          "name": "force-merge-multilinestrings",
+          "operation": {
+            "operation-type": "force-merge",
+            "max-num-segments": 1,
+            "index": "osmmultilinestrings",
+            "request-timeout": 7200
+          }
+        },
+        {
+          "name": "wait-until-multilinestrings-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
+          "operation": "index-append-polygons-full",
+          "warmup-time-period": 120,
+          "clients": {{bulk_indexing_clients | default(8)}},
+        "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+        },
+        {
+          "name": "refresh-after-polygons-index",
+          "operation": "refresh",
+          "index": "osmpolygons"
+        },
+        {
+          "name": "force-merge-polygons",
+          "operation": {
+            "operation-type": "force-merge",
+            "max-num-segments": 1,
+            "index": "osmpolygons",
+            "request-timeout": 7200
+          }
+        },
+        {
+          "name": "refresh-after-all-indices",
+          "operation": "refresh"
+        },
+        {
+          "name": "wait-until-polygon-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
+          "operation": "polygon",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 0.3
+        },
+        {
+          "operation": "bbox",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 0.25
+        },
+        {
+          "operation": "mvt",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 0.25
+        },
+        {
+          "operation": "mvt-grid",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 0.25
         }
       ]
     }

--- a/geoshape/files.txt
+++ b/geoshape/files.txt
@@ -1,6 +1,12 @@
+default-linestrings.json.bz2
+default-linestrings-1k.json.bz2
 linestrings.json.bz2
 linestrings-1k.json.bz2
+default-multilinestrings.json.bz2
+default-multilinestrings-1k.json.bz2
 multilinestrings.json.bz2
 multilinestrings-1k.json.bz2
 polygons.json.bz2
 polygons-1k.json.bz2
+default-polygons.json.bz2
+default-polygons-1k.json.bz2

--- a/geoshape/index.json
+++ b/geoshape/index.json
@@ -12,6 +12,17 @@
     "properties": {
       "shape": {
         "type": "geo_shape"
+      },
+      "size": {
+        "type": "double",
+        "script": {
+        "source": """
+          ScriptDocValues.Geometry geometry = doc["location"];
+          double w = geometry.getMercatorWidth();
+          double h = geometry.getMercatorHeight();
+          emit(h * h + w * w);
+        """
+        }
       }
     }
   }

--- a/geoshape/operations/default.json
+++ b/geoshape/operations/default.json
@@ -1,24 +1,45 @@
     {
-      "name": "index-append-linestrings",
+      "name": "index-append-linestrings-full",
       "operation-type": "bulk",
       "bulk-size": {{linestring_bulk_size | default(100)}},
       "ingest-percentage": {{ingest_percentage | default(100)}},
       "corpora": "linestrings"
     },
     {
-      "name": "index-append-multilinestrings",
+      "name": "index-append-multilinestrings-full",
       "operation-type": "bulk",
       "bulk-size": {{multilinestring_bulk_size | default(100)}},
       "ingest-percentage": {{ingest_percentage | default(100)}},
       "corpora": "multilinestrings"
     },
     {
-      "name": "index-append-polygons",
+      "name": "index-append-polygons-full",
       "operation-type": "bulk",
       "bulk-size": {{polygon_bulk_size | default(100)}},
       "ingest-percentage": {{ingest_percentage | default(100)}},
       "corpora": "polygons"
     },
+    {
+    "name": "index-append-linestrings",
+    "operation-type": "bulk",
+    "bulk-size": {{linestring_bulk_size | default(100)}},
+    "ingest-percentage": {{ingest_percentage | default(100)}},
+    "corpora": "default-linestrings"
+    },
+    {
+    "name": "index-append-multilinestrings",
+    "operation-type": "bulk",
+    "bulk-size": {{multilinestring_bulk_size | default(100)}},
+    "ingest-percentage": {{ingest_percentage | default(100)}},
+    "corpora": "default-multilinestrings"
+    },
+    {
+    "name": "index-append-polygons",
+    "operation-type": "bulk",
+    "bulk-size": {{polygon_bulk_size | default(100)}},
+    "ingest-percentage": {{ingest_percentage | default(100)}},
+    "corpora": "default-polygons"
+    },            
     {
       "name": "polygon",
       "operation-type": "search",
@@ -59,4 +80,58 @@
           }
         }
       }
-    }
+    },
+    {
+      "name": "mvt",
+      "operation-type": "search",
+      "index": "osm*",
+      "body": {
+        "_source": false,
+         "size" : 10000,
+         "fields": [{"field": "location", "format" : "mvt(9/255/341)"}],
+         "query": {
+           "geo_bounding_box": {
+             "location": {
+               "top_left": [-0.703129, 51.618014],
+               "bottom_right": [0, 51.179343]
+             }
+          }
+     },
+    "sort": [
+      {
+        "size": {
+        "order": "desc"
+        }
+      }
+    ]
+   },
+   {
+   "name": "mvt-grid",
+   "operation-type": "search",
+    "index": "osm*",
+    "body": {
+    "size" : 0,
+    "query": {
+    "geo_bounding_box": {
+      "location": {
+        "top_left": [-0.703129, 51.618014],
+        "bottom_right": [0, 51.179343]
+       }
+      }
+    },
+    "aggs": {
+       "grid" : {
+          "geotile_grid" : {
+              "field": "shape"    
+              "precision" : 17,
+              "size" : 65536,
+              "bounds": {
+                 "top_left": [-0.703129, 51.618014],
+                 "bottom_right": [0, 51.179343]
+               }        
+           }
+         }
+       }
+      }
+    } 
+  }

--- a/geoshape/track.json
+++ b/geoshape/track.json
@@ -56,7 +56,46 @@
           "uncompressed-bytes": 30178820325
         }
       ]
-    }
+    },
+    {
+      "name": "default-linestrings",
+      "base-url": "https://rally-tracks.elastic.co/geoshape",
+      "target-index": "osmlinestrings",
+       "documents": [
+        {
+          "source-file": "default-linestrings.json.bz2",
+          "document-count": 10266018,
+          "compressed-bytes": 1890945556,
+          "uncompressed-bytes": 6786928379
+        }
+      ]
+    },
+    {
+      "name": "default-multilinestrings",
+      "base-url": "https://rally-tracks.elastic.co/geoshape",
+      "target-index": "osmmultilinestrings",
+      "documents": [
+        {
+          "source-file": "default-multilinestrings.json.bz2",
+          "document-count": 266018,
+          "compressed-bytes": 940086544,
+          "uncompressed-bytes": 3110257383
+        }
+      ]
+    },
+    {
+      "name": "default-polygons",
+      "base-url": "https://rally-tracks.elastic.co/geoshape",
+      "target-index": "osmpolygons",
+      "documents": [
+        {
+          "source-file": "default-polygons.json.bz2",
+          "document-count": 13165248,
+          "compressed-bytes": 1063380825,
+          "uncompressed-bytes": 4369059087
+        }
+      ]
+    }    
   ],
   "operations": [
     {{ rally.collect(parts="operations/*.json") }}


### PR DESCRIPTION
The current track for geoshape uses too much data and it is not fully curated, it is pretty hard to use. Therefore here I added a new default track that runs with less data and it is fully curated. It takes to run around 90 minutes and the output looks like:

```
|                                                         Metric |                          Task |       Value |   Unit |
|---------------------------------------------------------------:|------------------------------:|------------:|-------:|
|                     Cumulative indexing time of primary shards |                               |     61.7476 |    min |
|             Min cumulative indexing time across primary shards |                               |     16.8933 |    min |
|          Median cumulative indexing time across primary shards |                               |     19.2621 |    min |
|             Max cumulative indexing time across primary shards |                               |     25.5922 |    min |
|            Cumulative indexing throttle time of primary shards |                               |           0 |    min |
|    Min cumulative indexing throttle time across primary shards |                               |           0 |    min |
| Median cumulative indexing throttle time across primary shards |                               |           0 |    min |
|    Max cumulative indexing throttle time across primary shards |                               |           0 |    min |
|                        Cumulative merge time of primary shards |                               |     56.8158 |    min |
|                       Cumulative merge count of primary shards |                               |          85 |        |
|                Min cumulative merge time across primary shards |                               |     9.52783 |    min |
|             Median cumulative merge time across primary shards |                               |     18.7066 |    min |
|                Max cumulative merge time across primary shards |                               |     28.5814 |    min |
|               Cumulative merge throttle time of primary shards |                               |       22.86 |    min |
|       Min cumulative merge throttle time across primary shards |                               |      1.3177 |    min |
|    Median cumulative merge throttle time across primary shards |                               |     9.16597 |    min |
|       Max cumulative merge throttle time across primary shards |                               |     12.3763 |    min |
|                      Cumulative refresh time of primary shards |                               |    0.475633 |    min |
|                     Cumulative refresh count of primary shards |                               |          79 |        |
|              Min cumulative refresh time across primary shards |                               |     0.08635 |    min |
|           Median cumulative refresh time across primary shards |                               |    0.100633 |    min |
|              Max cumulative refresh time across primary shards |                               |     0.28865 |    min |
|                        Cumulative flush time of primary shards |                               |     2.21708 |    min |
|                       Cumulative flush count of primary shards |                               |          44 |        |
|                Min cumulative flush time across primary shards |                               |    0.393983 |    min |
|             Median cumulative flush time across primary shards |                               |    0.788533 |    min |
|                Max cumulative flush time across primary shards |                               |     1.03457 |    min |
|                                        Total Young Gen GC time |                               |      42.923 |      s |
|                                       Total Young Gen GC count |                               |        8234 |        |
|                                          Total Old Gen GC time |                               |           0 |      s |
|                                         Total Old Gen GC count |                               |           0 |        |
|                                                     Store size |                               |     23.0339 |     GB |
|                                                  Translog size |                               | 1.53668e-07 |     GB |
|                                         Heap used for segments |                               |           0 |     MB |
|                                       Heap used for doc values |                               |           0 |     MB |
|                                            Heap used for terms |                               |           0 |     MB |
|                                            Heap used for norms |                               |           0 |     MB |
|                                           Heap used for points |                               |           0 |     MB |
|                                    Heap used for stored fields |                               |           0 |     MB |
|                                                  Segment count |                               |           3 |        |
|                                                 Min Throughput |      index-append-linestrings |     9575.37 | docs/s |
|                                                Mean Throughput |      index-append-linestrings |     19258.6 | docs/s |
|                                              Median Throughput |      index-append-linestrings |     17126.2 | docs/s |
|                                                 Max Throughput |      index-append-linestrings |     33383.4 | docs/s |
|                                        50th percentile latency |      index-append-linestrings |     22.8926 |     ms |
|                                        90th percentile latency |      index-append-linestrings |     48.9998 |     ms |
|                                        99th percentile latency |      index-append-linestrings |     326.657 |     ms |
|                                      99.9th percentile latency |      index-append-linestrings |     1525.28 |     ms |
|                                     99.99th percentile latency |      index-append-linestrings |     2489.32 |     ms |
|                                       100th percentile latency |      index-append-linestrings |     3489.38 |     ms |
|                                   50th percentile service time |      index-append-linestrings |     22.8926 |     ms |
|                                   90th percentile service time |      index-append-linestrings |     48.9998 |     ms |
|                                   99th percentile service time |      index-append-linestrings |     326.657 |     ms |
|                                 99.9th percentile service time |      index-append-linestrings |     1525.28 |     ms |
|                                99.99th percentile service time |      index-append-linestrings |     2489.32 |     ms |
|                                  100th percentile service time |      index-append-linestrings |     3489.38 |     ms |
|                                                     error rate |      index-append-linestrings |           0 |      % |
|                                                 Min Throughput | index-append-multilinestrings |     1383.77 | docs/s |
|                                                Mean Throughput | index-append-multilinestrings |     1647.76 | docs/s |
|                                              Median Throughput | index-append-multilinestrings |     1642.79 | docs/s |
|                                                 Max Throughput | index-append-multilinestrings |     1910.33 | docs/s |
|                                        50th percentile latency | index-append-multilinestrings |     277.989 |     ms |
|                                        90th percentile latency | index-append-multilinestrings |     630.371 |     ms |
|                                        99th percentile latency | index-append-multilinestrings |     1726.06 |     ms |
|                                       100th percentile latency | index-append-multilinestrings |     2366.92 |     ms |
|                                   50th percentile service time | index-append-multilinestrings |     277.989 |     ms |
|                                   90th percentile service time | index-append-multilinestrings |     630.371 |     ms |
|                                   99th percentile service time | index-append-multilinestrings |     1726.06 |     ms |
|                                  100th percentile service time | index-append-multilinestrings |     2366.92 |     ms |
|                                                     error rate | index-append-multilinestrings |           0 |      % |
|                                                 Min Throughput |         index-append-polygons |     22814.2 | docs/s |
|                                                Mean Throughput |         index-append-polygons |     28999.1 | docs/s |
|                                              Median Throughput |         index-append-polygons |     28876.5 | docs/s |
|                                                 Max Throughput |         index-append-polygons |     35559.8 | docs/s |
|                                        50th percentile latency |         index-append-polygons |     22.4867 |     ms |
|                                        90th percentile latency |         index-append-polygons |      41.931 |     ms |
|                                        99th percentile latency |         index-append-polygons |     131.829 |     ms |
|                                      99.9th percentile latency |         index-append-polygons |     889.152 |     ms |
|                                     99.99th percentile latency |         index-append-polygons |     3262.88 |     ms |
|                                       100th percentile latency |         index-append-polygons |     10792.1 |     ms |
|                                   50th percentile service time |         index-append-polygons |     22.4867 |     ms |
|                                   90th percentile service time |         index-append-polygons |      41.931 |     ms |
|                                   99th percentile service time |         index-append-polygons |     131.829 |     ms |
|                                 99.9th percentile service time |         index-append-polygons |     889.152 |     ms |
|                                99.99th percentile service time |         index-append-polygons |     3262.88 |     ms |
|                                  100th percentile service time |         index-append-polygons |     10792.1 |     ms |
|                                                     error rate |         index-append-polygons |           0 |      % |
|                                                 Min Throughput |            polygon-intersects |        2.99 |  ops/s |
|                                                Mean Throughput |            polygon-intersects |         3.1 |  ops/s |
|                                              Median Throughput |            polygon-intersects |        3.13 |  ops/s |
|                                                 Max Throughput |            polygon-intersects |        3.15 |  ops/s |
|                                        50th percentile latency |            polygon-intersects |     17466.6 |     ms |
|                                        90th percentile latency |            polygon-intersects |     19564.7 |     ms |
|                                        99th percentile latency |            polygon-intersects |     20224.5 |     ms |
|                                       100th percentile latency |            polygon-intersects |     20411.2 |     ms |
|                                   50th percentile service time |            polygon-intersects |     263.683 |     ms |
|                                   90th percentile service time |            polygon-intersects |     396.764 |     ms |
|                                   99th percentile service time |            polygon-intersects |     409.035 |     ms |
|                                  100th percentile service time |            polygon-intersects |      437.65 |     ms |
|                                                     error rate |            polygon-intersects |           0 |      % |
|                                                 Min Throughput |              polygon-contains |        2.97 |  ops/s |
|                                                Mean Throughput |              polygon-contains |        2.99 |  ops/s |
|                                              Median Throughput |              polygon-contains |        2.98 |  ops/s |
|                                                 Max Throughput |              polygon-contains |        3.01 |  ops/s |
|                                        50th percentile latency |              polygon-contains |     21387.5 |     ms |
|                                        90th percentile latency |              polygon-contains |     24176.6 |     ms |
|                                        99th percentile latency |              polygon-contains |     25084.1 |     ms |
|                                       100th percentile latency |              polygon-contains |     25209.1 |     ms |
|                                   50th percentile service time |              polygon-contains |     375.053 |     ms |
|                                   90th percentile service time |              polygon-contains |     389.712 |     ms |
|                                   99th percentile service time |              polygon-contains |     403.382 |     ms |
|                                  100th percentile service time |              polygon-contains |     405.091 |     ms |
|                                                     error rate |              polygon-contains |           0 |      % |
|                                                 Min Throughput |              polygon-disjoint |        3.09 |  ops/s |
|                                                Mean Throughput |              polygon-disjoint |        3.11 |  ops/s |
|                                              Median Throughput |              polygon-disjoint |        3.11 |  ops/s |
|                                                 Max Throughput |              polygon-disjoint |        3.12 |  ops/s |
|                                        50th percentile latency |              polygon-disjoint |     17928.6 |     ms |
|                                        90th percentile latency |              polygon-disjoint |     20780.6 |     ms |
|                                        99th percentile latency |              polygon-disjoint |     21744.1 |     ms |
|                                       100th percentile latency |              polygon-disjoint |     21762.5 |     ms |
|                                   50th percentile service time |              polygon-disjoint |     361.145 |     ms |
|                                   90th percentile service time |              polygon-disjoint |     371.948 |     ms |
|                                   99th percentile service time |              polygon-disjoint |     388.631 |     ms |
|                                  100th percentile service time |              polygon-disjoint |     413.999 |     ms |
|                                                     error rate |              polygon-disjoint |           0 |      % |
|                                                 Min Throughput |                polygon-within |        0.86 |  ops/s |
|                                                Mean Throughput |                polygon-within |        0.87 |  ops/s |
|                                              Median Throughput |                polygon-within |        0.87 |  ops/s |
|                                                 Max Throughput |                polygon-within |        0.88 |  ops/s |
|                                        50th percentile latency |                polygon-within |     38055.3 |     ms |
|                                        90th percentile latency |                polygon-within |     41720.6 |     ms |
|                                        99th percentile latency |                polygon-within |     42511.6 |     ms |
|                                       100th percentile latency |                polygon-within |     42744.5 |     ms |
|                                   50th percentile service time |                polygon-within |     1441.93 |     ms |
|                                   90th percentile service time |                polygon-within |      1479.7 |     ms |
|                                   99th percentile service time |                polygon-within |     1508.29 |     ms |
|                                  100th percentile service time |                polygon-within |     1679.45 |     ms |
|                                                     error rate |                polygon-within |           0 |      % |
|                                                 Min Throughput |               bbox-intersects |        3.27 |  ops/s |
|                                                Mean Throughput |               bbox-intersects |        3.28 |  ops/s |
|                                              Median Throughput |               bbox-intersects |        3.28 |  ops/s |
|                                                 Max Throughput |               bbox-intersects |        3.29 |  ops/s |
|                                        50th percentile latency |               bbox-intersects |     26099.2 |     ms |
|                                        90th percentile latency |               bbox-intersects |     30459.4 |     ms |
|                                        99th percentile latency |               bbox-intersects |     31340.5 |     ms |
|                                       100th percentile latency |               bbox-intersects |     31390.8 |     ms |
|                                   50th percentile service time |               bbox-intersects |     345.724 |     ms |
|                                   90th percentile service time |               bbox-intersects |     355.523 |     ms |
|                                   99th percentile service time |               bbox-intersects |      365.91 |     ms |
|                                  100th percentile service time |               bbox-intersects |     420.155 |     ms |
|                                                     error rate |               bbox-intersects |           0 |      % |
|                                                 Min Throughput |                 bbox-contains |        2.61 |  ops/s |
|                                                Mean Throughput |                 bbox-contains |        2.63 |  ops/s |
|                                              Median Throughput |                 bbox-contains |        2.63 |  ops/s |
|                                                 Max Throughput |                 bbox-contains |        2.65 |  ops/s |
|                                        50th percentile latency |                 bbox-contains |     45272.4 |     ms |
|                                        90th percentile latency |                 bbox-contains |       52645 |     ms |
|                                        99th percentile latency |                 bbox-contains |     54192.2 |     ms |
|                                       100th percentile latency |                 bbox-contains |     54414.5 |     ms |
|                                   50th percentile service time |                 bbox-contains |     426.044 |     ms |
|                                   90th percentile service time |                 bbox-contains |     437.935 |     ms |
|                                   99th percentile service time |                 bbox-contains |     449.378 |     ms |
|                                  100th percentile service time |                 bbox-contains |     464.149 |     ms |
|                                                     error rate |                 bbox-contains |           0 |      % |
|                                                 Min Throughput |                 bbox-disjoint |        3.02 |  ops/s |
|                                                Mean Throughput |                 bbox-disjoint |        3.15 |  ops/s |
|                                              Median Throughput |                 bbox-disjoint |        3.15 |  ops/s |
|                                                 Max Throughput |                 bbox-disjoint |        3.24 |  ops/s |
|                                        50th percentile latency |                 bbox-disjoint |     29453.3 |     ms |
|                                        90th percentile latency |                 bbox-disjoint |     32172.5 |     ms |
|                                        99th percentile latency |                 bbox-disjoint |     32553.1 |     ms |
|                                       100th percentile latency |                 bbox-disjoint |     32632.3 |     ms |
|                                   50th percentile service time |                 bbox-disjoint |     285.843 |     ms |
|                                   90th percentile service time |                 bbox-disjoint |      412.48 |     ms |
|                                   99th percentile service time |                 bbox-disjoint |      438.75 |     ms |
|                                  100th percentile service time |                 bbox-disjoint |     444.406 |     ms |
|                                                     error rate |                 bbox-disjoint |           0 |      % |
|                                                 Min Throughput |                   bbox-within |        0.99 |  ops/s |
|                                                Mean Throughput |                   bbox-within |           1 |  ops/s |
|                                              Median Throughput |                   bbox-within |           1 |  ops/s |
|                                                 Max Throughput |                   bbox-within |           1 |  ops/s |
|                                        50th percentile latency |                   bbox-within |     1094.98 |     ms |
|                                        90th percentile latency |                   bbox-within |     2113.01 |     ms |
|                                        99th percentile latency |                   bbox-within |     2922.64 |     ms |
|                                       100th percentile latency |                   bbox-within |     3087.06 |     ms |
|                                   50th percentile service time |                   bbox-within |     830.521 |     ms |
|                                   90th percentile service time |                   bbox-within |     1627.58 |     ms |
|                                   99th percentile service time |                   bbox-within |     1676.17 |     ms |
|                                  100th percentile service time |                   bbox-within |     1678.78 |     ms |
|                                                     error rate |                   bbox-within |           0 |      % |
|                                                 Min Throughput |                      mvt-hits |         0.5 |  ops/s |
|                                                Mean Throughput |                      mvt-hits |         0.5 |  ops/s |
|                                              Median Throughput |                      mvt-hits |         0.5 |  ops/s |
|                                                 Max Throughput |                      mvt-hits |         0.5 |  ops/s |
|                                        50th percentile latency |                      mvt-hits |     1523.67 |     ms |
|                                        90th percentile latency |                      mvt-hits |     1559.31 |     ms |
|                                        99th percentile latency |                      mvt-hits |     1585.32 |     ms |
|                                       100th percentile latency |                      mvt-hits |     1587.98 |     ms |
|                                   50th percentile service time |                      mvt-hits |     1521.62 |     ms |
|                                   90th percentile service time |                      mvt-hits |     1557.36 |     ms |
|                                   99th percentile service time |                      mvt-hits |     1583.86 |     ms |
|                                  100th percentile service time |                      mvt-hits |     1585.79 |     ms |
|                                                     error rate |                      mvt-hits |           0 |      % |
|                                                 Min Throughput |                      mvt-grid |           1 |  ops/s |
|                                                Mean Throughput |                      mvt-grid |           1 |  ops/s |
|                                              Median Throughput |                      mvt-grid |           1 |  ops/s |
|                                                 Max Throughput |                      mvt-grid |           1 |  ops/s |
|                                        50th percentile latency |                      mvt-grid |       903.4 |     ms |
|                                        90th percentile latency |                      mvt-grid |     926.379 |     ms |
|                                        99th percentile latency |                      mvt-grid |     935.879 |     ms |
|                                       100th percentile latency |                      mvt-grid |     953.411 |     ms |
|                                   50th percentile service time |                      mvt-grid |     901.979 |     ms |
|                                   90th percentile service time |                      mvt-grid |       925.4 |     ms |
|                                   99th percentile service time |                      mvt-grid |     934.971 |     ms |
|                                  100th percentile service time |                      mvt-grid |     951.744 |     ms |
|                                                     error rate |                      mvt-grid |           0 |      % |

```