### PR TITLE
Run NYC taxis searches without target throughput too

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -82,6 +82,36 @@
           "warmup-iterations": 500,
           "iterations": 500,
           "target-throughput": 1.5
+        },
+        {
+          "name": "default_no_target",
+          "operation": "default",
+          "warmup-iterations": 50,
+          "iterations": 100
+        },
+        {
+          "name": "range_no_target",
+          "operation": "range",
+          "warmup-iterations": 50,
+          "iterations": 100
+        },
+        {
+          "name": "distance_amount_agg_no_target",
+          "operation": "distance_amount_agg",
+          "warmup-iterations": 50,
+          "iterations": 100
+        },
+        {
+          "name": "autohisto_agg_no_target",
+          "operation": "autohisto_agg",
+          "warmup-iterations": 50,
+          "iterations": 100
+        },
+        {
+          "name": "date_histogram_agg_no_target",
+          "operation": "date_histogram_agg",
+          "warmup-iterations": 500,
+          "iterations": 500
         }
       ]
     },


### PR DESCRIPTION
This is part of an experiment that might end up with target-throughput removal across all tracks. This would be beneficial to avoid duplication for ARM benchmarks, which is why we're starting with NYC Taxis.

Tested with `esrally race --distribution-version=7.16.3 --track-path=~/src/rally-tracks/nyc_taxis --challenge=append-no-conflicts --test-mode`.