### PR TITLE
TSDB: Add an option to disable _source

### DIFF
--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -121,6 +121,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
+* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_mode` (default: time_series): Whether to make a standard index (`standard`) or time series index (`time_series`)
 * `codec` (default: default): The codec to use compressing the index. `default` uses more space and less cpu. `best_compression` uses less space and more cpu.
 

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -27,6 +27,9 @@
       "beat": "metricbeat",
       "version": "7.6.2"
     },
+    "_source": {
+      "enabled": {{ source_enabled | default(true) | tojson }}
+    },
     "dynamic_templates": [
       {
         "labels": {


### PR DESCRIPTION
This is a fairly standard option and we were looking into this in tsdb-land. So the option is useful to have.