### PR TITLE
update distance_amount_agg with filter, re-fix field name

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -69,7 +69,7 @@
           "operation": "distance_amount_agg",
           "warmup-iterations": 50,
           "iterations": 100,
-          "target-throughput": 2
+          "target-interval": 20
         },
         {
           "operation": "autohisto_agg",

--- a/nyc_taxis/challenges/indexing-querying.json
+++ b/nyc_taxis/challenges/indexing-querying.json
@@ -92,10 +92,22 @@
               "operation-type": "search",
               "body": {
                 "size": 10000,
+                "query": {
+                  "bool": {
+                    "filter": {
+                      "range": {
+                        "trip_distance": {
+                          "lt": 50,
+                          "gte": 0
+                        }
+                      }
+                    }
+                  }
+                },
                 "aggs": {
                   "distance_histo": {
                     "histogram": {
-                      "field": "distance",
+                      "field": "trip_distance",
                       "interval": 1
                     },
                     "aggs": {

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -53,10 +53,22 @@
       "operation-type": "search",
       "body": {
         "size": 0,
+        "query": {
+          "bool": {
+            "filter": {
+              "range": {
+                "trip_distance": {
+                  "lt": 50,
+                  "gte": 0
+                }
+              }
+            }
+          }
+        },
         "aggs": {
           "distance_histo": {
             "histogram": {
-              "field": "distance",
+              "field": "trip_distance",
               "interval": 1
             },
             "aggs": {


### PR DESCRIPTION
Tested this in the target nightly environment, albeit prior to #244. `"target-interval": 20` was just a guess, but it looks to be crucially between the throttled and unthrottled latency:

|                                                         Metric |                          Task |       Value |   Unit |
|---------------------------------------------------------------:|------------------------------:|------------:|-------:|
|                                                 Min Throughput |           distance_amount_agg |        0.05 |  ops/s |
|                                                Mean Throughput |           distance_amount_agg |        0.05 |  ops/s |
|                                              Median Throughput |           distance_amount_agg |        0.05 |  ops/s |
|                                                 Max Throughput |           distance_amount_agg |        0.05 |  ops/s |
|                                        50th percentile latency |           distance_amount_agg |     16377.8 |     ms |
|                                        90th percentile latency |           distance_amount_agg |     16919.9 |     ms |
|                                        99th percentile latency |           distance_amount_agg |     17585.7 |     ms |
|                                       100th percentile latency |           distance_amount_agg |     17879.7 |     ms |
|                                   50th percentile service time |           distance_amount_agg |     16373.7 |     ms |
|                                   90th percentile service time |           distance_amount_agg |     16915.6 |     ms |
|                                   99th percentile service time |           distance_amount_agg |     17581.8 |     ms |
|                                  100th percentile service time |           distance_amount_agg |     17875.9 |     ms |
|                                                     error rate |           distance_amount_agg |           0 |      % |
|                                                 Min Throughput | distance_amount_agg_no_target |        0.04 |  ops/s |
|                                                Mean Throughput | distance_amount_agg_no_target |        0.04 |  ops/s |
|                                              Median Throughput | distance_amount_agg_no_target |        0.04 |  ops/s |
|                                                 Max Throughput | distance_amount_agg_no_target |        0.04 |  ops/s |
|                                        50th percentile latency | distance_amount_agg_no_target |     22534.9 |     ms |
|                                        90th percentile latency | distance_amount_agg_no_target |     22950.4 |     ms |
|                                        99th percentile latency | distance_amount_agg_no_target |     23370.8 |     ms |
|                                       100th percentile latency | distance_amount_agg_no_target |     23667.6 |     ms |
|                                   50th percentile service time | distance_amount_agg_no_target |     22534.9 |     ms |
|                                   90th percentile service time | distance_amount_agg_no_target |     22950.4 |     ms |
|                                   99th percentile service time | distance_amount_agg_no_target |     23370.8 |     ms |
|                                  100th percentile service time | distance_amount_agg_no_target |     23667.6 |     ms |


This will be interesting to watch for the week after it's merged. For what it's worth, this adds quite a bit of time to the runtime of Elasticsearch's "group 1" nightly benchmarks (4613 seconds to 11199 seconds, effectively adding 1 hour and 50 min to the anticipated run time).
