### PR TITLE
Revert "Use native SQL operation type and add paging queries"

### DIFF
--- a/sql/README.md
+++ b/sql/README.md
@@ -13,10 +13,6 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `max_num_segments` (default: 1)
 * `query_percentage` (default: 100): Factor applied to the number of warmup-iterations and iterations for queries. Useful to run quick experiments but watch out for effects due to the shorter warmup period!
 
-## Testing
-
-Because some of the pagination queries expect more than 1k records to work, `--test-mode` is not supported for this track. Instead, the `ingest_percentage` and `query_percentage` track parameters can be used to test the track: `--track-params="ingest_percentage:1,query_percentage:2"`
-
 ## Query Selection
 
 The queries have been selected using the following criterias:

--- a/sql/track.json
+++ b/sql/track.json
@@ -4,7 +4,7 @@
 {{ (iterations * (query_percentage | default(100)) / 100) | int }}
 {%- endmacro %}
 
-{% macro query_10qps(name, query, pages=1, fetch_size=1000) -%}
+{% macro query_10qps(name, query) -%}
 {
   "operation": {
     "name": "{{ name }}",
@@ -15,10 +15,8 @@
         Because ES < 7.16 uses `request_timeout` as `page_timeout` the values need to be identical but high enough such that
         the requests do not time out. #}
       "page_timeout": "1000ms",
-      "request_timeout": "1000ms",
-      "fetch_size": {{ fetch_size }}
-    },
-    "pages": {{ pages }}
+      "request_timeout": "1000ms"
+    }
   },
   "target-throughput": 10,
   "clients": 2,
@@ -28,7 +26,7 @@
 }
 {%- endmacro %}
 
-{% macro query_5qps(name, query, pages=1, fetch_size=1000) -%}
+{% macro query_5qps(name, query) -%}
 {
   "operation": {
     "name": "{{ name }}",
@@ -39,10 +37,8 @@
         Because ES < 7.16 uses `request_timeout` as `page_timeout` the values need to be identical but high enough such that
         the requests do not time out. #}
       "page_timeout": "2000ms",
-      "request_timeout": "2000ms",
-      "fetch_size": {{ fetch_size }}
-    },
-    "pages": {{ pages }}
+      "request_timeout": "2000ms"
+    }
   },
   "target-throughput": 5,
   "clients": 2,
@@ -52,7 +48,7 @@
 }
 {%- endmacro %}
 
-{% macro query_1qps(name, query, pages=1, fetch_size=1000) -%}
+{% macro query_1qps(name, query) -%}
 {
   "operation": {
     "name": "{{ name }}",
@@ -63,10 +59,8 @@
         Because ES < 7.16 uses `request_timeout` as `page_timeout` the values need to be identical but high enough such that
         the requests do not time out. #}
       "page_timeout": "5000ms",
-      "request_timeout": "5000ms",
-      "fetch_size": {{ fetch_size }}
-    },
-    "pages": {{ pages }}
+      "request_timeout": "5000ms"
+    }
   },
   "target-throughput": 1,
   "clients": 2,
@@ -87,7 +81,7 @@
   ],
   "corpora": [
     {
-      "name": "noaa-sql",
+      "name": "noaa",
       "base-url": "https://rally-tracks.elastic.co/noaa-sql",
       "documents": [
         {
@@ -186,16 +180,6 @@
           "tags": ["setup"]
         },
         {{ query_10qps(
-            "describe",
-            "DESCRIBE \\\"weather-data-2016\\\""
-        ) }},
-        {{ query_10qps(
-            "describe_5pages",
-            "DESCRIBE \\\"weather-data-2016\\\"",
-            5,
-            10
-        ) }},
-        {{ query_10qps(
             "select_const",
             "SELECT 1"
         ) }},
@@ -232,11 +216,6 @@
             "select_numericScriptSort",
             "SELECT station.name FROM \\\"weather-data-2016\\\" WHERE station.elevation > 2800 ORDER BY CEIL(TMIN) % 7 = 5"
         ) }},
-        {{ query_10qps(
-            "select_5pages",
-            "SELECT station.name FROM \\\"weather-data-2016\\\"",
-            5
-        ) }},
         {{ query_1qps(
             "aggregate_byStringScript",
             "SELECT LCASE(SUBSTRING(station.name, 0, 2)) FROM \\\"weather-data-2016\\\" WHERE station.elevation > 2800 GROUP BY 1"
@@ -269,24 +248,9 @@
             "aggregate_overNumericScript_filterByAggregate",
             "SELECT station.name, SUM(CEIL(TMIN) % 7) S FROM \\\"weather-data-2016\\\" WHERE station.elevation > 2800 GROUP BY 1 HAVING S > 0"
         ) }},
-        {{ query_5qps(
-            "aggregate_5pages",
-            "SELECT station.name, COUNT(*) FROM \\\"weather-data-2016\\\" GROUP BY station.name",
-            5
-        ) }},
-        {{ query_5qps(
-            "aggregate_sortByAggregate_5pages",
-            "SELECT station.name, COUNT(*) FROM \\\"weather-data-2016\\\" WHERE station.elevation > 1400 GROUP BY 1 ORDER BY 2",
-            5
-        ) }},
         {{ query_1qps(
             "pivot",
             "SELECT * FROM (SELECT station.country_code, TMIN FROM \\\"weather-data-2016\\\") PIVOT (AVG(TMIN) FOR station.country_code IN ('AS', 'CA'))"
-        ) }},
-        {{ query_5qps(
-            "pivot_5pages",
-            "SELECT * FROM (SELECT station.name, station.country_code FROM \\\"weather-data-2016\\\") PIVOT (COUNT(*) FOR station.country_code IN ('US', 'AS'))",
-            5
         ) }}
       ]
     }

--- a/sql/track.py
+++ b/sql/track.py
@@ -1,0 +1,8 @@
+async def sql(es, params):    
+    await es.sql.query(
+        body=params["body"]
+    )
+
+
+def register(registry):
+    registry.register_runner("sql", sql, async_runner=True)


### PR DESCRIPTION
Reverts elastic/rally-tracks#242

At least one of the new queries (`aggregate_5pages `) fails with the complete dataset on the nightly with a `[{'type': 'query_phase_execution_exception', 'reason': 'Time exceeded'}]` error.