### PR TITLE
TSDB: Fix "duplicates"

### DIFF
--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -9,6 +9,8 @@
       {% if index_mode | default('time_series') is equalto 'time_series' %}
       "routing_path": [
         "metricset.name",
+        "host.name",
+        "kubernetes.container.name",
         "kubernetes.event.involved_object.uid",
         "kubernetes.node.name",
         "kubernetes.system.container.id",
@@ -6563,7 +6565,7 @@
           },
           "name": {
             "type": "keyword",
-            "ignore_above": 1024
+            "time_series_dimension": true
           },
           "os": {
             "properties": {
@@ -7816,7 +7818,7 @@
               },
               "name": {
                 "type": "keyword",
-                "ignore_above": 1024
+                "time_series_dimension": true
               },
               "rootfs": {
                 "properties": {

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -6565,7 +6565,7 @@
           },
           "name": {
             "type": "keyword",
-            "time_series_dimension": true
+            "ignore_above": 1024
           },
           "os": {
             "properties": {


### PR DESCRIPTION
Now there we're calculating the `_id` from dimensions I found that we
have duplicated `_id`s in our test data. But it's not because we
actually measure things three time. No! We just handn't annotated all of
the dimensions as `time_series_dimension`s.