### PR TITLE
Adjust throughputs for some EQL queries after Lucene upgrade

### DIFF
--- a/eql/queries.json
+++ b/eql/queries.json
@@ -90,7 +90,7 @@
         "query": "sequence [any where true] [any where true]"
       }
     },
-    {{ task_options_10qps }}
+    {{ task_options_1qps }}
   },
   {
     "operation": {
@@ -116,7 +116,7 @@
         "query": "sequence [any where true] [any where true] | tail 200 | head 100"
       }
     },
-    {{ task_options_10qps }}
+    {{ task_options_1qps }}
   },
   {
     "operation": {
@@ -129,7 +129,7 @@
         "query": "sequence with maxspan=1m [any where true] [any where true]"
       }
     },
-    {{ task_options_10qps }}
+    {{ task_options_1qps }}
   },
   {
     "operation": {


### PR DESCRIPTION
After merging https://github.com/elastic/elasticsearch/pull/84540 there was a spectacular spike in latency for the 3 EQL queries `sequence_2stages_baseline`, `sequence_2stages_tailThenHead` and `sequence_2stages_maxspan1m`. A big part of the regression can be explained by congestion effects caused by a smaller, but still large, increase in service_time.

E.g. typical service times for a single run of `sequence_2stages_baseline` looked like this before:
<img width="976" alt="image" src="https://user-images.githubusercontent.com/1016746/158346566-6d086a39-120c-48f3-aa9c-65f024ca5285.png">
Now, we see a 3-4 fold increase:
<img width="980" alt="image" src="https://user-images.githubusercontent.com/1016746/158346696-05bac4ef-aa4e-4453-8710-94a612b9803c.png">

This PR adjusts the target throughput such that the congestion effect no longer occurs.