### PR TITLE
Fix incorrect iterations in NYC Taxis

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -81,7 +81,7 @@
           "name": "distance_amount_agg_no_target",
           "operation": "distance_amount_agg",
           "warmup-iterations": 50,
-          "iterations": 100
+          "iterations": 50
         },
         {
           "operation": "distance_amount_agg",
@@ -93,7 +93,7 @@
           "name": "autohisto_agg_no_target",
           "operation": "autohisto_agg",
           "warmup-iterations": 50,
-          "iterations": 50
+          "iterations": 100
         },
         {
           "operation": "autohisto_agg",


### PR DESCRIPTION
This change undoes an improperly resolved conflict from a prior PR. This should reduce typical runtimes of the default NYC Taxis challenge by about 15 minutes.