### PR TITLE
Dense vectors add search before force merge

### DIFF
--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -45,6 +45,59 @@
       }
     },
     {
+      "name": "knn-search-10-50-before-force-merge",
+      "operation": "knn-search-10-50",
+      "warmup-iterations": 50,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "knn-search-10-100-before-force-merge",
+      "operation": "knn-search-10-100",
+      "warmup-iterations": 50,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "knn-search-100-1000-before-force-merge",
+      "operation": "knn-search-100-1000",
+      "warmup-iterations": 50,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "script-score-query-before-force-merge",
+      "operation": "script-score-query",
+      "warmup-iterations": 100,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "operation": {
+        "operation-type": "force-merge",
+        "max-num-segments": 1,
+        "request-timeout": 7200,
+        "include-in-reporting": true
+      }
+    },
+    {
+      "name": "refresh-after-force-merge",
+      "operation": "refresh"
+    },
+    {
+      "name": "wait-until-merges-finish",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "_all",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": false
+      }
+    },
+    {
       "name": "knn-search-10-50",
       "operation": "knn-search-10-50",
       "warmup-iterations": 50,
@@ -67,59 +120,6 @@
     },
     {
       "name": "script-score-query",
-      "operation": "script-score-query",
-      "warmup-iterations": 100,
-      "iterations": 100,
-      "clients": 1
-    },
-    {
-      "operation": {
-        "operation-type": "force-merge",
-        "max-num-segments": 1,
-        "request-timeout": 7200,
-        "include-in-reporting": true
-      }
-    },
-    {
-      "name": "refresh-after-force-merge",
-      "operation": "refresh"
-    },
-    {
-      "name": "wait-until-merges-finish-after-force-merge",
-      "operation": {
-        "operation-type": "index-stats",
-        "index": "_all",
-        "condition": {
-          "path": "_all.total.merges.current",
-          "expected-value": 0
-        },
-        "retry-until-success": true,
-        "include-in-reporting": false
-      }
-    },
-    {
-      "name": "knn-search-10-50-after-force-merge",
-      "operation": "knn-search-10-50",
-      "warmup-iterations": 50,
-      "iterations": 100,
-      "clients": 1
-    },
-    {
-      "name": "knn-search-10-100-after-force-merge",
-      "operation": "knn-search-10-100",
-      "warmup-iterations": 50,
-      "iterations": 100,
-      "clients": 1
-    },
-    {
-      "name": "knn-search-100-1000-after-force-merge",
-      "operation": "knn-search-100-1000",
-      "warmup-iterations": 50,
-      "iterations": 100,
-      "clients": 1
-    },
-    {
-      "name": "script-score-query-after-force-merge",
       "operation": "script-score-query",
       "warmup-iterations": 100,
       "iterations": 100,

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -28,19 +28,11 @@
       "clients": {{bulk_indexing_clients | default(1)}}
     },
     {
-      "operation": {
-        "operation-type": "force-merge",
-        "max-num-segments": 1,
-        "request-timeout": 7200,
-        "include-in-reporting": true
-      }
-    },
-    {
-      "name": "refresh-after-force-merge",
+      "name": "refresh-after-index",
       "operation": "refresh"
     },
     {
-      "name": "wait-until-merges-finish",
+      "name": "wait-until-merges-finish-after-index",
       "operation": {
         "operation-type": "index-stats",
         "index": "_all",
@@ -49,7 +41,7 @@
           "expected-value": 0
         },
         "retry-until-success": true,
-        "include-in-reporting": false
+        "include-in-reporting": true
       }
     },
     {
@@ -75,6 +67,59 @@
     },
     {
       "name": "script-score-query",
+      "operation": "script-score-query",
+      "warmup-iterations": 100,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "operation": {
+        "operation-type": "force-merge",
+        "max-num-segments": 1,
+        "request-timeout": 7200,
+        "include-in-reporting": true
+      }
+    },
+    {
+      "name": "refresh-after-force-merge",
+      "operation": "refresh"
+    },
+    {
+      "name": "wait-until-merges-finish-after-force-merge",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "_all",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": true
+      }
+    },
+    {
+      "name": "knn-search-10-50-after-force-merge",
+      "operation": "knn-search-10-50",
+      "warmup-iterations": 50,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "knn-search-10-100-after-force-merge",
+      "operation": "knn-search-10-100",
+      "warmup-iterations": 50,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "knn-search-100-1000-after-force-merge",
+      "operation": "knn-search-100-1000",
+      "warmup-iterations": 50,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "script-score-query-after-force-merge",
       "operation": "script-score-query",
       "warmup-iterations": 100,
       "iterations": 100,

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -41,7 +41,7 @@
           "expected-value": 0
         },
         "retry-until-success": true,
-        "include-in-reporting": true
+        "include-in-reporting": false
       }
     },
     {
@@ -94,7 +94,7 @@
           "expected-value": 0
         },
         "retry-until-success": true,
-        "include-in-reporting": true
+        "include-in-reporting": false
       }
     },
     {

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -29,7 +29,10 @@
     },
     {
       "name": "refresh-after-index",
-      "operation": "refresh"
+      "operation": {
+        "operation-type": "refresh",
+        "request-timeout": 1000
+      }
     },
     {
       "name": "wait-until-merges-finish-after-index",


### PR DESCRIPTION
This is a follow up on PR #260 that was already approved, merged, 
and reverted, as we did not have `request_timeout` for refresh
operation and it was timing out.

This PR is dependant on https://github.com/elastic/rally/pull/1463