### PR TITLE
Define start/end in ML datafeed to avoid empty buckets

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -511,7 +511,8 @@
           "operation": {
             "operation-type": "start-ml-datafeed",
             "datafeed-id": "{{ml_feed_id}}",
-            "end": "now"
+            "start": "2015-01-01T00:00:00",
+            "end": "2016-01-01T00:00:00"
           }
         },
         {


### PR DESCRIPTION
This does not affect performance but was highlighted as a good practice:

I've compared this on the nightly hardware:

```
Comparing baseline
  Race ID: e4dcd269-fd8f-448d-b6f7-a9370cbdd354
  Race timestamp: 2022-03-30 18:00:57
  Challenge: append-ml
  Car: 4gheap+trial-license+x-pack-ml+x-pack-security
  User tags: license=trial, name=nyc_taxis-ml-4g-1node, race-configs-id=race-configs-group-1.json, reason=pquentin-ml-start-stop, setup=bare, x-pack=true

with contender
  Race ID: 34a924a5-2eaf-47e9-9760-34ab63925814
  Race timestamp: 2022-03-30 18:00:57
  Challenge: append-ml
  Car: 4gheap+trial-license+x-pack-ml+x-pack-security
  User tags: license=trial, name=nyc_taxis-ml-4g-1node, race-configs-id=race-configs-group-1.json, reason=pquentin-ml-start-stop, setup=bare, x-pack=true

------------------------------------------------------
    _______             __   _____
   / ____(_)___  ____ _/ /  / ___/_________  ________
  / /_  / / __ \/ __ `/ /   \__ \/ ___/ __ \/ ___/ _ \
 / __/ / / / / / /_/ / /   ___/ / /__/ /_/ / /  /  __/
/_/   /_/_/ /_/\__,_/_/   /____/\___/\____/_/   \___/
------------------------------------------------------

|                                                        Metric |             Task |         Baseline |       Contender |        Diff |   Unit |   Diff % |
|--------------------------------------------------------------:|-----------------:|-----------------:|----------------:|------------:|-------:|---------:|
|                    Cumulative indexing time of primary shards |                  |     53.2549      |    52.894       |    -0.36093 |    min |   -0.68% |
|             Min cumulative indexing time across primary shard |                  |     53.2549      |    52.894       |    -0.36093 |    min |   -0.68% |
|          Median cumulative indexing time across primary shard |                  |     53.2549      |    52.894       |    -0.36093 |    min |   -0.68% |
|             Max cumulative indexing time across primary shard |                  |     53.2549      |    52.894       |    -0.36093 |    min |   -0.68% |
|           Cumulative indexing throttle time of primary shards |                  |      0           |     0           |     0       |    min |    0.00% |
|    Min cumulative indexing throttle time across primary shard |                  |      0           |     0           |     0       |    min |    0.00% |
| Median cumulative indexing throttle time across primary shard |                  |      0           |     0           |     0       |    min |    0.00% |
|    Max cumulative indexing throttle time across primary shard |                  |      0           |     0           |     0       |    min |    0.00% |
|                       Cumulative merge time of primary shards |                  |     18.0037      |    16.373       |    -1.63067 |    min |   -9.06% |
|                      Cumulative merge count of primary shards |                  |     31           |    29           |    -2       |        |   -6.45% |
|                Min cumulative merge time across primary shard |                  |     18.0037      |    16.373       |    -1.63067 |    min |   -9.06% |
|             Median cumulative merge time across primary shard |                  |     18.0037      |    16.373       |    -1.63067 |    min |   -9.06% |
|                Max cumulative merge time across primary shard |                  |     18.0037      |    16.373       |    -1.63067 |    min |   -9.06% |
|              Cumulative merge throttle time of primary shards |                  |      4.89218     |     4.64748     |    -0.2447  |    min |   -5.00% |
|       Min cumulative merge throttle time across primary shard |                  |      4.89218     |     4.64748     |    -0.2447  |    min |   -5.00% |
|    Median cumulative merge throttle time across primary shard |                  |      4.89218     |     4.64748     |    -0.2447  |    min |   -5.00% |
|       Max cumulative merge throttle time across primary shard |                  |      4.89218     |     4.64748     |    -0.2447  |    min |   -5.00% |
|                     Cumulative refresh time of primary shards |                  |      1.37018     |     1.17865     |    -0.19153 |    min |  -13.98% |
|                    Cumulative refresh count of primary shards |                  |     33           |    34           |     1       |        |   +3.03% |
|              Min cumulative refresh time across primary shard |                  |      1.37018     |     1.17865     |    -0.19153 |    min |  -13.98% |
|           Median cumulative refresh time across primary shard |                  |      1.37018     |     1.17865     |    -0.19153 |    min |  -13.98% |
|              Max cumulative refresh time across primary shard |                  |      1.37018     |     1.17865     |    -0.19153 |    min |  -13.98% |
|                       Cumulative flush time of primary shards |                  |      0.923267    |     0.956167    |     0.0329  |    min |   +3.56% |
|                      Cumulative flush count of primary shards |                  |     10           |     9           |    -1       |        |  -10.00% |
|                Min cumulative flush time across primary shard |                  |      0.923267    |     0.956167    |     0.0329  |    min |   +3.56% |
|             Median cumulative flush time across primary shard |                  |      0.923267    |     0.956167    |     0.0329  |    min |   +3.56% |
|                Max cumulative flush time across primary shard |                  |      0.923267    |     0.956167    |     0.0329  |    min |   +3.56% |
|                                        Min ML processing time | benchmark_ml_job |      0           |     0           |     0       |     ms |    0.00% |
|                                       Mean ML processing time | benchmark_ml_job |     23.5351      |    23.6691      |     0.13395 |     ms |   +0.57% |
|                                     Median ML processing time | benchmark_ml_job |     20           |    20           |     0       |     ms |    0.00% |
|                                        Max ML processing time | benchmark_ml_job |   1056           |  1068           |    12       |     ms |   +1.14% |
|                                       Total Young Gen GC time |                  |     15.638       |    15.695       |     0.057   |      s |   +0.36% |
|                                      Total Young Gen GC count |                  |    780           |   772           |    -8       |        |   -1.03% |
|                                         Total Old Gen GC time |                  |      0           |     0           |     0       |      s |    0.00% |
|                                        Total Old Gen GC count |                  |      0           |     0           |     0       |        |    0.00% |
|                                                    Store size |                  |      7.08602     |     7.04978     |    -0.03624 |     GB |   -0.51% |
|                                                 Translog size |                  |      5.12227e-08 |     5.12227e-08 |     0       |     GB |    0.00% |
|                                        Heap used for segments |                  |      0           |     0           |     0       |     MB |    0.00% |
|                                      Heap used for doc values |                  |      0           |     0           |     0       |     MB |    0.00% |
|                                           Heap used for terms |                  |      0           |     0           |     0       |     MB |    0.00% |
|                                           Heap used for norms |                  |      0           |     0           |     0       |     MB |    0.00% |
|                                          Heap used for points |                  |      0           |     0           |     0       |     MB |    0.00% |
|                                   Heap used for stored fields |                  |      0           |     0           |     0       |     MB |    0.00% |
|                                                 Segment count |                  |     29           |    26           |    -3       |        |  -10.34% |
|                                   Total Ingest Pipeline count |                  |      0           |     0           |     0       |        |    0.00% |
|                                    Total Ingest Pipeline time |                  |      0           |     0           |     0       |     ms |    0.00% |
|                                  Total Ingest Pipeline failed |                  |      0           |     0           |     0       |        |    0.00% |
|                                                Min Throughput |            index |  98335.7         | 96921.7         | -1414       | docs/s |   -1.44% |
|                                               Mean Throughput |            index |  99610.2         | 98605.4         | -1004.79    | docs/s |   -1.01% |
|                                             Median Throughput |            index |  99607.8         | 98642.8         |  -964.979   | docs/s |   -0.97% |
|                                                Max Throughput |            index | 100897           | 99438.9         | -1457.57    | docs/s |   -1.44% |
|                                       50th percentile latency |            index |    673.96        |   656.558       |   -17.4021  |     ms |   -2.58% |
|                                       90th percentile latency |            index |    872.354       |   859.83        |   -12.5236  |     ms |   -1.44% |
|                                       99th percentile latency |            index |   4088.46        |  4577.08        |   488.618   |     ms |  +11.95% |
|                                     99.9th percentile latency |            index |   8056.07        |  6544.23        | -1511.84    |     ms |  -18.77% |
|                                      100th percentile latency |            index |  10228.7         |  9766.83        |  -461.849   |     ms |   -4.52% |
|                                  50th percentile service time |            index |    673.96        |   656.558       |   -17.4021  |     ms |   -2.58% |
|                                  90th percentile service time |            index |    872.354       |   859.83        |   -12.5236  |     ms |   -1.44% |
|                                  99th percentile service time |            index |   4088.46        |  4577.08        |   488.618   |     ms |  +11.95% |
|                                99.9th percentile service time |            index |   8056.07        |  6544.23        | -1511.84    |     ms |  -18.77% |
|                                 100th percentile service time |            index |  10228.7         |  9766.83        |  -461.849   |     ms |   -4.52% |
|                               50th percentile processing time |            index |    681.442       |   665.573       |   -15.8697  |     ms |   -2.33% |
|                               90th percentile processing time |            index |    879.811       |   868.913       |   -10.8983  |     ms |   -1.24% |
|                               99th percentile processing time |            index |   4095.49        |  4583.33        |   487.841   |     ms |  +11.91% |
|                             99.9th percentile processing time |            index |   8063.33        |  6549.65        | -1513.68    |     ms |  -18.77% |
|                              100th percentile processing time |            index |  10235.9         |  9771.14        |  -464.773   |     ms |   -4.54% |
|                                                    error rate |            index |      0           |     0           |     0       |      % |    0.00% |


-------------------------------
[INFO] SUCCESS (took 0 seconds)
-------------------------------
```

This change can only increase performance as we won't have buckets from 2016 to now. And indeed, the change appears to be within the level of noise (look for `benchmark_ml_job`).