### PR TITLE
Add indexing with concurrent searches

### DIFF
--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -27,48 +27,11 @@
       "operation": {
         "operation-type": "bulk",
         "bulk-size": {{bulk_size | default(5000)}},
-        "ingest-percentage": 10
+        "ingest-percentage": 20
       },
       "warmup-time-period": {{ bulk_warmup | default(40) | int }},
       "clients": {{bulk_indexing_clients | default(1)}}
     },
-    {
-      "parallel": {
-        "tasks": [
-          {
-            "name": "index-append-concurrent-with-searches",
-            "operation": {
-              "operation-type": "bulk",
-              "bulk-size": {{bulk_size | default(5000)}},
-              "ingest-percentage": 10
-            },
-            "warmup-time-period": {{ bulk_warmup | default(40) | int }},
-            "clients": {{bulk_indexing_clients | default(1)}}
-          },
-          {
-            "name": "knn-search-10-50-concurrent-with-indexing",
-            "operation": "knn-search-10-50",
-            "warmup-iterations": 50,
-            "iterations": 100,
-            "clients": 1
-          },
-          {
-            "name": "knn-search-10-100-concurrent-with-indexing",
-            "operation": "knn-search-10-100",
-            "warmup-iterations": 50,
-            "iterations": 100,
-            "clients": 1
-          },
-          {
-            "name": "knn-search-100-1000-concurrent-with-indexing",
-            "operation": "knn-search-100-1000",
-            "warmup-iterations": 50,
-            "iterations": 100,
-            "clients": 1
-          }
-        ]
-      }  
-    },      
     {
       "name": "refresh-after-index",
       "operation": {
@@ -87,6 +50,36 @@
         },
         "retry-until-success": true,
         "include-in-reporting": false
+      }
+    },
+    {
+      "parallel": {
+        "warmup-time-period": 10,
+        "completed-by": "index-update-concurrent-with-searches",
+        "tasks": [
+          {
+            "name": "index-update-concurrent-with-searches",
+            "operation": {
+              "operation-type": "bulk",
+              "bulk-size": 5000,
+              "ingest-percentage": 5,
+              "refresh" : "wait_for"
+            },
+            "clients": 1
+          },
+          {
+            "name": "knn-search-100-1000-concurrent-with-indexing",
+            "operation": "knn-search-100-1000",
+            "clients": 1
+          }
+        ]
+      }
+    },
+    {
+      "name": "refresh-after-update",
+      "operation": {
+        "operation-type": "refresh",
+        "request-timeout": 1000
       }
     },
     {

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -1,6 +1,6 @@
 {
   "name": "index-and-search",
-  "description": "indexes vectors, force merges to a single segment, then searches them",
+  "description": "Indexes half of the dataset, then indexes another half with concurrent searches",
   "default": true,
   "schedule": [
     {
@@ -23,10 +23,52 @@
       }
     },
     {
-      "operation": "index-append",
+      "name": "index-append",
+      "operation": {
+        "operation-type": "bulk",
+        "bulk-size": {{bulk_size | default(5000)}},
+        "ingest-percentage": 10
+      },
       "warmup-time-period": {{ bulk_warmup | default(40) | int }},
       "clients": {{bulk_indexing_clients | default(1)}}
     },
+    {
+      "parallel": {
+        "tasks": [
+          {
+            "name": "index-append-concurrent-with-searches",
+            "operation": {
+              "operation-type": "bulk",
+              "bulk-size": {{bulk_size | default(5000)}},
+              "ingest-percentage": 10
+            },
+            "warmup-time-period": {{ bulk_warmup | default(40) | int }},
+            "clients": {{bulk_indexing_clients | default(1)}}
+          },
+          {
+            "name": "knn-search-10-50-concurrent-with-indexing",
+            "operation": "knn-search-10-50",
+            "warmup-iterations": 50,
+            "iterations": 100,
+            "clients": 1
+          },
+          {
+            "name": "knn-search-10-100-concurrent-with-indexing",
+            "operation": "knn-search-10-100",
+            "warmup-iterations": 50,
+            "iterations": 100,
+            "clients": 1
+          },
+          {
+            "name": "knn-search-100-1000-concurrent-with-indexing",
+            "operation": "knn-search-100-1000",
+            "warmup-iterations": 50,
+            "iterations": 100,
+            "clients": 1
+          }
+        ]
+      }  
+    },      
     {
       "name": "refresh-after-index",
       "operation": {

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -62,8 +62,7 @@
             "operation": {
               "operation-type": "bulk",
               "bulk-size": 5000,
-              "ingest-percentage": 5,
-              "refresh" : "wait_for"
+              "ingest-percentage": 5
             }
           },
           {

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -1,6 +1,6 @@
 {
   "name": "index-and-search",
-  "description": "Indexes half of the dataset, then indexes another half with concurrent searches",
+  "description": "Indexes vectors, then executes searches under various conditions",
   "default": true,
   "schedule": [
     {
@@ -64,13 +64,11 @@
               "bulk-size": 5000,
               "ingest-percentage": 5,
               "refresh" : "wait_for"
-            },
-            "clients": 1
+            }
           },
           {
             "name": "knn-search-100-1000-concurrent-with-indexing",
-            "operation": "knn-search-100-1000",
-            "clients": 1
+            "operation": "knn-search-100-1000"
           }
         ]
       }

--- a/dense_vector/operations/default.json
+++ b/dense_vector/operations/default.json
@@ -1,10 +1,4 @@
 {
-  "name": "index-append",
-  "operation-type": "bulk",
-  "bulk-size": {{bulk_size | default(5000)}},
-  "ingest-percentage": {{ingest_percentage | default(100)}}
-},
-{
   "name": "knn-search-10-50",
   "operation-type": "raw-request",
   "path": "/vectors/_knn_search",


### PR DESCRIPTION
A very common use case is to run indexing at the same time as searches.
This patch addresses this use case.
We first index 50% of data. During the indexing of rest of data, we
also run concurrent searches.