### PR TITLE
Add fetch tests for synthetic source

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -66,6 +66,12 @@
           "target-throughput": 3
         },
         {
+          "operation": "default_1k",
+          "warmup-iterations": 50,
+          "iterations": 100,
+          "target-throughput": 3
+        },
+        {
           "operation": "range",
           "warmup-iterations": 50,
           "iterations": 100

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -35,6 +35,16 @@
       }
     },
     {
+      "name": "default_1k",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "size": 1000
+      }
+    },
+    {
       "name": "range",
       "operation-type": "search",
       "body": {

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -58,6 +58,16 @@
         {
           "name": "refresh-after-force-merge",
           "operation": "refresh"
+        },
+        {
+          "operation": "default",
+          "warmup-iterations": 50,
+          "iterations": 100
+        },
+        {
+          "operation": "default_1k",
+          "warmup-iterations": 50,
+          "iterations": 100
         }
       ]
     }

--- a/tsdb/operations/default.json
+++ b/tsdb/operations/default.json
@@ -3,4 +3,23 @@
       "operation-type": "bulk",
       "bulk-size": {{bulk_size | default(5000)}},
       "ingest-percentage": {{ingest_percentage | default(100)}}
+    },
+    {
+      "name": "default",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "match_all": {}
+        }
+      }
+    },
+    {
+      "name": "default_1k",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "size": 1000
+      }
     }


### PR DESCRIPTION
This adds a `default_1k` operation to nyc_taxis to fetch 1,000
documents. It adds that same operation to tsdb, and another one to fetch
10 documents, similar to nyc_taxis `default` operation. These are all
useful to test the fetch speed of synthetic source. Specifically it
tests fetching the same documents over and over again. That's useful!
It shows that, at least in this case, synthetic source is fast for
nyc_taxis:
```
|                              |            |  normal | synthetic |    |         |
| 50th percentile service time | default_1k | 10.9269 |   10.5904 | ms |  -3.08% |
| 90th percentile service time | default_1k | 22.4911 |   15.4604 | ms | -31.26% |
| 99th percentile service time | default_1k | 24.4341 |   20.982  | ms | -14.13% |
|100th percentile service time | default_1k | 24.9321 |   20.9966 | ms | -15.79% |
```

That's lovely and surprising. It also shows that synthetic source is
slow for tsdb, which has many many many fields:
```
|                               |            | normal | synthetic |    |           |
|  50th percentile service time | default_1k | 4.4208 |   163.061 | ms | +3588.48% |
|  90th percentile service time | default_1k | 4.6127 |   166.374 | ms | +3506.88% |
|  99th percentile service time | default_1k | 5.0065 |   168.403 | ms | +3263.67% |
| 100th percentile service time | default_1k | 5.1351 |   173.503 | ms | +3278.76% |
```

It'd be useful to also test fetching *random* docs too - probably more
useful and realistic. But this is also useful!