### PR TITLE
Upgrade custom runners to be compatible with elasticsearch-py 8.2.0.

### DIFF
--- a/eql/track.py
+++ b/eql/track.py
@@ -5,7 +5,7 @@ async def eql(es, params):
         cluster += ":"
 
     await es.eql.search(
-            cluster + params.get("index"),
+            index=cluster + params.get("index"),
             body=params.get("body"),
             request_timeout=params.get("request-timeout")
         )

--- a/nyc_taxis/track.py
+++ b/nyc_taxis/track.py
@@ -4,7 +4,7 @@ import time
 
 def wait_for_ml_lookback(es, params):
     while True:
-        response = es.xpack.ml.get_datafeed_stats(datafeed_id=params["datafeed-id"])
+        response = es.ml.get_datafeed_stats(datafeed_id=params["datafeed-id"])
         if response["datafeeds"][0]["state"] == "stopped":
             break
         time.sleep(5)
@@ -12,7 +12,7 @@ def wait_for_ml_lookback(es, params):
 
 async def wait_for_ml_lookback_async(es, params):
     while True:
-        response = await es.xpack.ml.get_datafeed_stats(datafeed_id=params["datafeed-id"])
+        response = await es.ml.get_datafeed_stats(datafeed_id=params["datafeed-id"])
         if response["datafeeds"][0]["state"] == "stopped":
             break
         await asyncio.sleep(5)


### PR DESCRIPTION
This prepares the custom runners for the `nyc_taxis` and `eql` tracks for Rally's forthcoming upgrade of the ES Python client to 8.2.0.