### PR TITLE
fix synthetic source configuration

### DIFF
--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -66,12 +66,11 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `recency` (default: 0): A number between 0 and 1 that defines whether to bias towards more recent ids when simulating conflicts. See the [Rally docs](http://esrally.readthedocs.io/en/latest/track.html#bulk) for the full definition of this parameter. Only used by the `update` challenge.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
-* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
+* `source_mode` (default: stored): Should the `_source` be `stored` to disk exactly as sent (the default), thrown away (`disabled`), or reconstructed on the fly (`synthetic`)
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
-* `synthetic_source` (default: false): Should we enable `synthetic` _source to save space?
 
 ### License
 

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -6,9 +6,8 @@
   },
   "mappings": {
     "_source": {
-      "enabled": {{ source_enabled | default(true) | tojson }}{% if synthetic_source | default(False) | string | lower == "true" %},
-      "synthetic": true
-      {% endif %}
+      "mode": {{ source_mode | default("stored") | tojson }}
+
     },
     "properties": {
       "surcharge": {
@@ -76,7 +75,7 @@
         "type": "geo_point"
       },
       "vendor_name": {
-        "type": "text"{% if synthetic_source | default(False) | string | lower == "true" %},
+        "type": "text"{% if source_mode == "synthetic" %},
         "fields": {
           "raw": {
             "type": "keyword"

--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -151,10 +151,9 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
-* `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
+* `source_mode` (default: stored): Should the `_source` be `stored` to disk exactly as sent (the default), thrown away (`disabled`), or reconstructed on the fly (`synthetic`)
 * `index_mode` (default: time_series): Whether to make a standard index (`standard`) or time series index (`time_series`)
 * `codec` (default: default): The codec to use compressing the index. `default` uses more space and less cpu. `best_compression` uses less space and more cpu.
-* `synthetic_source` (default: false): Should we enable `synthetic` _source to save space?
 * `ingest_mode` (default: index) Should be `data_stream` to benchmark ingesting into a tsdb data stream.
 
 ### License

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -29,9 +29,7 @@
       "version": "7.6.2"
     },
     "_source": {
-      "enabled": {{ source_enabled | default(true) | tojson }}{% if synthetic_source | default(False) | string | lower == "true" %},
-      "synthetic": true
-      {% endif %}
+      "mode": {{ source_mode | default("stored") | tojson }}
     },
     "dynamic_templates": [
       {
@@ -545,7 +543,7 @@
         "strings_as_keyword": {
           "match_mapping_type": "string",
           "mapping": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},"ignore_above": 1024{% endif %}
+            "type": "keyword"{% if source_mode != "synthetic" %},"ignore_above": 1024{% endif %}
           }
         }
       }
@@ -574,7 +572,7 @@
                 }
               },
               "mbean": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -628,7 +626,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -651,7 +649,7 @@
                 }
               },
               "mbean": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -727,7 +725,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -753,7 +751,7 @@
                 }
               },
               "mbean": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -829,7 +827,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -979,19 +977,19 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "node": {
                 "properties": {
                   "host": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -1017,32 +1015,32 @@
       "agent": {
         "properties": {
           "ephemeral_id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "hostname": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "type": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -1105,7 +1103,7 @@
                 }
               },
               "hostname": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -1396,7 +1394,7 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -1427,7 +1425,7 @@
           "cloudwatch": {
             "properties": {
               "namespace": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -1517,7 +1515,7 @@
                   "image": {
                     "properties": {
                       "id": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -1526,7 +1524,7 @@
                   "monitoring": {
                     "properties": {
                       "state": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -1535,7 +1533,7 @@
                   "private": {
                     "properties": {
                       "dns_name": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -1547,7 +1545,7 @@
                   "public": {
                     "properties": {
                       "dns_name": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -1562,7 +1560,7 @@
                         "type": "long"
                       },
                       "name": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -1653,37 +1651,37 @@
               "db_instance": {
                 "properties": {
                   "arn": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "class": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "db_cluster_identifier": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "engine_name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "identifier": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "role": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "status": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -1883,7 +1881,7 @@
               "bucket": {
                 "properties": {
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -2037,7 +2035,7 @@
               "queue": {
                 "properties": {
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -2111,19 +2109,19 @@
             }
           },
           "namespace": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "resource": {
             "properties": {
               "group": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2135,7 +2133,7 @@
                 }
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -2153,7 +2151,7 @@
             }
           },
           "subscription_id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -2162,7 +2160,7 @@
       "beat": {
         "properties": {
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -2185,7 +2183,7 @@
               "output": {
                 "properties": {
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -2194,7 +2192,7 @@
               "queue": {
                 "properties": {
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -2247,7 +2245,7 @@
                         }
                       },
                       "type": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -2282,7 +2280,7 @@
             }
           },
           "type": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -2318,7 +2316,7 @@
           "cluster_health": {
             "properties": {
               "overall_status": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2330,7 +2328,7 @@
                   "round": {
                     "properties": {
                       "status": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -2461,7 +2459,7 @@
                 }
               },
               "health": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2469,7 +2467,7 @@
                 "type": "date"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2534,7 +2532,7 @@
                 }
               },
               "device_class": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2542,7 +2540,7 @@
                 "type": "long"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2572,7 +2570,7 @@
           "osd_tree": {
             "properties": {
               "children": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2583,7 +2581,7 @@
                 "type": "long"
               },
               "device_class": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2591,7 +2589,7 @@
                 "type": "boolean"
               },
               "father": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2599,7 +2597,7 @@
                 "type": "long"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2610,12 +2608,12 @@
                 "type": "long"
               },
               "status": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2630,7 +2628,7 @@
                 "type": "long"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2665,7 +2663,7 @@
       "client": {
         "properties": {
           "address": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -2683,7 +2681,7 @@
                         "type": "text",
                         "norms": false
                       }
-                    }{% if synthetic_source | default(False) | string | lower == "false" %},
+                    }{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -2695,29 +2693,29 @@
             "type": "long"
           },
           "domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "geo": {
             "properties": {
               "city_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "continent_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2725,17 +2723,17 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -2745,7 +2743,7 @@
             "type": "ip"
           },
           "mac": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -2766,24 +2764,24 @@
             "type": "long"
           },
           "registered_domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "top_level_domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "user": {
             "properties": {
               "domain": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "email": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2794,36 +2792,36 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "group": {
                 "properties": {
                   "domain": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "hash": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -2834,7 +2832,7 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -2847,26 +2845,26 @@
           "account": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "availability_zone": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "image": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -2875,12 +2873,12 @@
           "instance": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -2889,7 +2887,7 @@
           "machine": {
             "properties": {
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -2898,19 +2896,19 @@
           "project": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "provider": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "region": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -2989,19 +2987,19 @@
       "container": {
         "properties": {
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "image": {
             "properties": {
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "tag": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -3011,12 +3009,12 @@
             "type": "object"
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "runtime": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -3144,7 +3142,7 @@
                 }
               },
               "family": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -3156,27 +3154,27 @@
                 }
               },
               "proto": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "rcode": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "server": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "zone": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -3228,7 +3226,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -3255,7 +3253,7 @@
                 }
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -3490,7 +3488,7 @@
                 "type": "long"
               },
               "hostname": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -3692,7 +3690,7 @@
       "destination": {
         "properties": {
           "address": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -3710,7 +3708,7 @@
                         "type": "text",
                         "norms": false
                       }
-                    }{% if synthetic_source | default(False) | string | lower == "false" %},
+                    }{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -3722,29 +3720,29 @@
             "type": "long"
           },
           "domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "geo": {
             "properties": {
               "city_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "continent_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -3752,17 +3750,17 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -3772,7 +3770,7 @@
             "type": "ip"
           },
           "mac": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -3793,24 +3791,24 @@
             "type": "long"
           },
           "registered_domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "top_level_domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "user": {
             "properties": {
               "domain": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "email": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -3821,36 +3819,36 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "group": {
                 "properties": {
                   "domain": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "hash": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -3861,7 +3859,7 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -3874,17 +3872,17 @@
           "answers": {
             "properties": {
               "class": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "data": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -3892,56 +3890,56 @@
                 "type": "long"
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "header_flags": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "op_code": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "question": {
             "properties": {
               "class": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "registered_domain": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "subdomain": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "top_level_domain": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -3951,12 +3949,12 @@
             "type": "ip"
           },
           "response_code": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "type": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -3967,7 +3965,7 @@
           "container": {
             "properties": {
               "command": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -3991,12 +3989,12 @@
                 }
               },
               "status": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "tags": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -4158,7 +4156,7 @@
           "event": {
             "properties": {
               "action": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -4168,29 +4166,29 @@
                     "type": "object"
                   },
                   "id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "from": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "status": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -4207,7 +4205,7 @@
                     "type": "long"
                   },
                   "output": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -4220,7 +4218,7 @@
                 "type": "long"
               },
               "status": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -4234,12 +4232,12 @@
               "id": {
                 "properties": {
                   "current": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "parent": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -4259,7 +4257,7 @@
                 }
               },
               "tags": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -4284,7 +4282,7 @@
                 }
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -4393,7 +4391,7 @@
                 }
               },
               "interface": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -4440,7 +4438,7 @@
       "ecs": {
         "properties": {
           "version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -4456,7 +4454,7 @@
                     "type": "long"
                   },
                   "index": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -4482,7 +4480,7 @@
               "leader": {
                 "properties": {
                   "index": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -4496,12 +4494,12 @@
           "cluster": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -4514,7 +4512,7 @@
                     "type": "long"
                   },
                   "source": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -4530,7 +4528,7 @@
               "state": {
                 "properties": {
                   "id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -4580,7 +4578,7 @@
                     }
                   },
                   "status": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -4619,7 +4617,7 @@
           "index": {
             "properties": {
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -4634,48 +4632,48 @@
                   "source": {
                     "properties": {
                       "host": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
                       "id": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
                       "name": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
                     }
                   },
                   "stage": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "target": {
                     "properties": {
                       "host": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
                       "id": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
                       "name": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
                     }
                   },
                   "type": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -4819,12 +4817,12 @@
                     }
                   },
                   "id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "state": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -4835,7 +4833,7 @@
           "node": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -4882,14 +4880,14 @@
                     }
                   },
                   "version": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -5117,7 +5115,7 @@
                 }
               },
               "version": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -5134,14 +5132,14 @@
               "relocating_node": {
                 "properties": {
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -5359,18 +5357,18 @@
       "error": {
         "properties": {
           "code": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "message": {
             "type": "text",
-            "norms": false{% if synthetic_source | default(False) | string | lower == "true" %},
+            "norms": false{% if source_mode == "synthetic" %},
             "fields": {
               "raw": {
                 "type": "keyword"
@@ -5385,12 +5383,12 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "type": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -5399,7 +5397,7 @@
       "etcd": {
         "properties": {
           "api_version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -5520,7 +5518,7 @@
                 }
               },
               "leader": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -5558,31 +5556,31 @@
           "self": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "leaderinfo": {
                 "properties": {
                   "leader": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "starttime": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "uptime": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -5625,12 +5623,12 @@
                 }
               },
               "starttime": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -5774,17 +5772,17 @@
       "event": {
         "properties": {
           "action": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "category": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "code": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -5792,7 +5790,7 @@
             "type": "date"
           },
           "dataset": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -5803,12 +5801,12 @@
             "type": "date"
           },
           "hash": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -5816,27 +5814,27 @@
             "type": "date"
           },
           "kind": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "module": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "original": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "outcome": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "provider": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -5856,12 +5854,12 @@
             "type": "date"
           },
           "timezone": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "type": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -5880,7 +5878,7 @@
             "type": "date"
           },
           "attributes": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -5891,66 +5889,66 @@
             "type": "date"
           },
           "device": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "directory": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "drive_letter": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1
             {% endif %}
           },
           "extension": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "gid": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "group": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "hash": {
             "properties": {
               "md5": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "sha1": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "sha256": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "sha512": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "inode": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "mode": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -5958,12 +5956,12 @@
             "type": "date"
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "owner": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -5974,7 +5972,7 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -5988,17 +5986,17 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "type": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "uid": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -6007,22 +6005,22 @@
       "geo": {
         "properties": {
           "city_name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "continent_name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "country_iso_code": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "country_name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -6030,17 +6028,17 @@
             "type": "geo_point"
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "region_iso_code": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "region_name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -6051,7 +6049,7 @@
           "expvar": {
             "properties": {
               "cmdline": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -6085,7 +6083,7 @@
                 }
               },
               "cmdline": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -6169,7 +6167,7 @@
           "server": {
             "properties": {
               "example": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -6180,17 +6178,17 @@
       "group": {
         "properties": {
           "domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -6447,14 +6445,14 @@
                         "type": "long"
                       },
                       "last": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
                     }
                   },
                   "status": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -6545,7 +6543,7 @@
                     "type": "long"
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -6671,7 +6669,7 @@
                 }
               },
               "service_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -6702,7 +6700,7 @@
                 }
               },
               "status": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -6731,22 +6729,22 @@
       "hash": {
         "properties": {
           "md5": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "sha1": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "sha256": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "sha512": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -6755,7 +6753,7 @@
       "host": {
         "properties": {
           "architecture": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -6763,29 +6761,29 @@
             "type": "boolean"
           },
           "domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "geo": {
             "properties": {
               "city_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "continent_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -6793,29 +6791,29 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "hostname": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -6823,29 +6821,29 @@
             "type": "ip"
           },
           "mac": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "os": {
             "properties": {
               "build": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "codename": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "family": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -6856,12 +6854,12 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "kernel": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -6872,24 +6870,24 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "platform": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "version": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "type": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -6899,12 +6897,12 @@
           "user": {
             "properties": {
               "domain": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "email": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -6915,36 +6913,36 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "group": {
                 "properties": {
                   "domain": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "hash": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -6955,7 +6953,7 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -6982,7 +6980,7 @@
                         "type": "text",
                         "norms": false
                       }
-                    }{% if synthetic_source | default(False) | string | lower == "false" %},
+                    }{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -6995,12 +6993,12 @@
                 "type": "object"
               },
               "method": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "referrer": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -7020,7 +7018,7 @@
                         "type": "text",
                         "norms": false
                       }
-                    }{% if synthetic_source | default(False) | string | lower == "false" %},
+                    }{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -7030,7 +7028,7 @@
                 "type": "long"
               },
               "code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -7038,7 +7036,7 @@
                 "type": "object"
               },
               "phrase": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -7051,7 +7049,7 @@
             "type": "object"
           },
           "version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -7062,12 +7060,12 @@
           "agent": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "version": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -7079,24 +7077,24 @@
           "server": {
             "properties": {
               "product": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "vendor": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "version": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "url": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -7107,7 +7105,7 @@
           "broker": {
             "properties": {
               "address": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -7122,7 +7120,7 @@
                 }
               },
               "mbean": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -7275,7 +7273,7 @@
                 "type": "float"
               },
               "mbean": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -7295,7 +7293,7 @@
               "broker": {
                 "properties": {
                   "address": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -7307,17 +7305,17 @@
               "client": {
                 "properties": {
                   "host": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "member_id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -7334,12 +7332,12 @@
                 }
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "meta": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -7350,7 +7348,7 @@
                 "type": "long"
               },
               "topic": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -7361,7 +7359,7 @@
               "broker": {
                 "properties": {
                   "address": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -7402,7 +7400,7 @@
                     "type": "boolean"
                   },
                   "isr": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -7424,19 +7422,19 @@
                     }
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "topic_broker_id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "topic_id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -7457,7 +7455,7 @@
                 "type": "float"
               },
               "mbean": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -7507,7 +7505,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -7525,19 +7523,19 @@
               "host": {
                 "properties": {
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "index": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -7621,7 +7619,7 @@
                 "type": "boolean"
               },
               "status": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -7647,7 +7645,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -7656,7 +7654,7 @@
                   "overall": {
                     "properties": {
                       "state": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -7847,22 +7845,22 @@
               "request": {
                 "properties": {
                   "client": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "code": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "component": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "content_type": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -7877,7 +7875,7 @@
                     }
                   },
                   "dry_run": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -7903,22 +7901,22 @@
                     }
                   },
                   "group": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "handler": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "host": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "kind": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -7947,32 +7945,32 @@
                     }
                   },
                   "method": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "resource": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "scope": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "subresource": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "verb": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "version": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -8041,7 +8039,7 @@
                 "time_series_dimension": true
               },
               "image": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -8193,7 +8191,7 @@
               "status": {
                 "properties": {
                   "phase": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -8201,7 +8199,7 @@
                     "type": "boolean"
                   },
                   "reason": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -8226,17 +8224,17 @@
                 }
               },
               "code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "handler": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "host": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -8326,12 +8324,12 @@
                 }
               },
               "method": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -8454,7 +8452,7 @@
                 }
               },
               "zone": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -8470,7 +8468,7 @@
                 }
               },
               "concurrency": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -8499,7 +8497,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -8511,7 +8509,7 @@
                 }
               },
               "schedule": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -8520,7 +8518,7 @@
           "deployment": {
             "properties": {
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -8553,22 +8551,22 @@
               "involved_object": {
                 "properties": {
                   "api_version": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "kind": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "resource_version": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -8580,10 +8578,10 @@
               },
               "message": {
                 "type": "text",
-                "norms": false{% if synthetic_source | default(False) | string | lower == "false" %},
+                "norms": false{% if source_mode != "synthetic" %},
                 "copy_to": [
                   "message"
-                ]{% endif %}{% if synthetic_source | default(False) | string | lower == "true" %},
+                ]{% endif %}{% if source_mode == "synthetic" %},
                 "fields": {
                   "raw": {
                     "type": "keyword"
@@ -8594,27 +8592,27 @@
               "metadata": {
                 "properties": {
                   "generate_name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "namespace": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "resource_version": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "self_link": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -8626,14 +8624,14 @@
                     }
                   },
                   "uid": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "reason": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -8648,7 +8646,7 @@
                 }
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -8773,7 +8771,7 @@
             }
           },
           "namespace": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -8982,7 +8980,7 @@
               "status": {
                 "properties": {
                   "ready": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -9003,17 +9001,17 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "phase": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "storage_class": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -9022,17 +9020,17 @@
           "persistentvolumeclaim": {
             "properties": {
               "access_mode": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "phase": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -9044,12 +9042,12 @@
                 }
               },
               "storage_class": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "volume_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -9178,24 +9176,24 @@
               "status": {
                 "properties": {
                   "phase": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "ready": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "scheduled": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "uid": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -9215,17 +9213,17 @@
                 }
               },
               "code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "handler": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "host": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -9308,7 +9306,7 @@
                 }
               },
               "method": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -9418,7 +9416,7 @@
           "replicaset": {
             "properties": {
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -9453,7 +9451,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -9461,12 +9459,12 @@
                 "type": "double"
               },
               "resource": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -9486,17 +9484,17 @@
                 }
               },
               "code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "handler": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "host": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -9586,17 +9584,17 @@
                 }
               },
               "method": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "operation": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -9648,7 +9646,7 @@
                 }
               },
               "result": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -9735,12 +9733,12 @@
                 "type": "date"
               },
               "external_ip": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "external_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -9748,22 +9746,22 @@
                 "type": "ip"
               },
               "ingress_ip": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "load_balancer_ip": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -9785,7 +9783,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -9917,14 +9915,14 @@
                 "type": "long"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "stat": {
                 "properties": {
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -9943,12 +9941,12 @@
       "log": {
         "properties": {
           "level": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "logger": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -9960,21 +9958,21 @@
                     "type": "long"
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "function": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "original": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -9986,7 +9984,7 @@
                     "type": "long"
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -10001,7 +9999,7 @@
                     "type": "long"
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -10018,7 +10016,7 @@
               "jvm": {
                 "properties": {
                   "version": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -10135,7 +10133,7 @@
       },
       "message": {
         "type": "text",
-        "norms": false{% if synthetic_source | default(False) | string | lower == "true" %},
+        "norms": false{% if source_mode == "synthetic" %},
         "fields": {
           "raw": {
             "type": "keyword"
@@ -10159,7 +10157,7 @@
           "collstats": {
             "properties": {
               "collection": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -10178,7 +10176,7 @@
                 }
               },
               "db": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -10243,7 +10241,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -10335,7 +10333,7 @@
                 }
               },
               "db": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -10870,7 +10868,7 @@
                         "type": "long"
                       },
                       "network_interface": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -11053,7 +11051,7 @@
                         "type": "long"
                       },
                       "hosts": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -11065,7 +11063,7 @@
                         "type": "long"
                       },
                       "hosts": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -11074,12 +11072,12 @@
                   "primary": {
                     "properties": {
                       "host": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
                       "optime": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -11091,7 +11089,7 @@
                         "type": "long"
                       },
                       "hosts": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -11103,7 +11101,7 @@
                         "type": "long"
                       },
                       "hosts": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -11115,12 +11113,12 @@
                         "type": "long"
                       },
                       "hosts": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
                       "optimes": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -11132,7 +11130,7 @@
                         "type": "long"
                       },
                       "hosts": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -11144,7 +11142,7 @@
                         "type": "long"
                       },
                       "hosts": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -11156,7 +11154,7 @@
                         "type": "long"
                       },
                       "hosts": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       }
@@ -11212,7 +11210,7 @@
                 "type": "date"
               },
               "set_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -11969,7 +11967,7 @@
               "storage_engine": {
                 "properties": {
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -12110,7 +12108,7 @@
                 "type": "long"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -12261,7 +12259,7 @@
           "plugin": {
             "properties": {
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -12308,7 +12306,7 @@
                     "type": "long"
                   },
                   "status": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -12325,19 +12323,19 @@
                 }
               },
               "connected": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "evs": {
                 "properties": {
                   "evict": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "state": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -12409,14 +12407,14 @@
                     }
                   },
                   "state": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "ready": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -12746,7 +12744,7 @@
           "server": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -12874,7 +12872,7 @@
       "network": {
         "properties": {
           "application": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -12882,12 +12880,12 @@
             "type": "long"
           },
           "community_id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "direction": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -12895,12 +12893,12 @@
             "type": "ip"
           },
           "iana_number": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -12908,17 +12906,17 @@
             "type": "long"
           },
           "protocol": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "transport": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "type": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -12944,7 +12942,7 @@
                 "type": "long"
               },
               "hostname": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -12969,22 +12967,22 @@
           "geo": {
             "properties": {
               "city_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "continent_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -12992,24 +12990,24 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "hostname": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -13017,19 +13015,19 @@
             "type": "ip"
           },
           "mac": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "os": {
             "properties": {
               "family": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13040,12 +13038,12 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "kernel": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13056,44 +13054,44 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "platform": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "version": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "product": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "serial_number": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "type": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "vendor": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -13104,7 +13102,7 @@
           "performance": {
             "properties": {
               "buffer_pool": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13190,7 +13188,7 @@
                 "type": "long"
               },
               "machine": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13198,7 +13196,7 @@
                 "type": "double"
               },
               "username": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -13212,12 +13210,12 @@
                     "type": "long"
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "online_status": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -13243,14 +13241,14 @@
                     }
                   },
                   "status": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13286,7 +13284,7 @@
       "organization": {
         "properties": {
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -13297,7 +13295,7 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -13306,7 +13304,7 @@
       "os": {
         "properties": {
           "family": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -13317,12 +13315,12 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "kernel": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -13333,17 +13331,17 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "platform": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -13352,27 +13350,27 @@
       "package": {
         "properties": {
           "architecture": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "build_version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "checksum": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "description": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "install_scope": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -13380,22 +13378,22 @@
             "type": "date"
           },
           "license": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "path": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "reference": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -13403,12 +13401,12 @@
             "type": "long"
           },
           "type": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -13435,12 +13433,12 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "process_manager": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13489,7 +13487,7 @@
                 "type": "long"
               },
               "script": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13500,7 +13498,7 @@
                 "type": "date"
               },
               "state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -13513,7 +13511,7 @@
           "activity": {
             "properties": {
               "application_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13523,12 +13521,12 @@
               "client": {
                 "properties": {
                   "address": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "hostname": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -13540,7 +13538,7 @@
               "database": {
                 "properties": {
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -13553,7 +13551,7 @@
                 "type": "long"
               },
               "query": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13561,7 +13559,7 @@
                 "type": "date"
               },
               "state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13577,7 +13575,7 @@
                     "type": "long"
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -13682,7 +13680,7 @@
                 "type": "long"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13803,7 +13801,7 @@
                     "type": "long"
                   },
                   "text": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -13862,7 +13860,7 @@
       "process": {
         "properties": {
           "args": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -13876,7 +13874,7 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -13887,7 +13885,7 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -13897,22 +13895,22 @@
           "hash": {
             "properties": {
               "md5": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "sha1": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "sha256": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "sha512": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -13925,14 +13923,14 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "parent": {
             "properties": {
               "args": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13946,7 +13944,7 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13957,7 +13955,7 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13971,7 +13969,7 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -13993,7 +13991,7 @@
                     "type": "long"
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -14006,7 +14004,7 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -14020,7 +14018,7 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -14044,7 +14042,7 @@
                 "type": "long"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -14057,7 +14055,7 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -14071,7 +14069,7 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -14108,7 +14106,7 @@
               "client_provided": {
                 "properties": {
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -14118,12 +14116,12 @@
                 "type": "long"
               },
               "host": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -14153,7 +14151,7 @@
               "peer": {
                 "properties": {
                   "host": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -14166,7 +14164,7 @@
                 "type": "long"
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -14216,7 +14214,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -14424,7 +14422,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -14488,7 +14486,7 @@
                 }
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -14608,19 +14606,19 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "vhost": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -14693,7 +14691,7 @@
                     }
                   },
                   "allocator": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -14743,7 +14741,7 @@
                   "max": {
                     "properties": {
                       "policy": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -14780,7 +14778,7 @@
                       "bgrewrite": {
                         "properties": {
                           "last_status": {
-                            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                            "type": "keyword"{% if source_mode != "synthetic" %},
                             "ignore_above": 1024
                             {% endif %}
                           }
@@ -14857,7 +14855,7 @@
                       "write": {
                         "properties": {
                           "last_status": {
-                            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                            "type": "keyword"{% if source_mode != "synthetic" %},
                             "ignore_above": 1024
                             {% endif %}
                           }
@@ -14883,7 +14881,7 @@
                             "type": "boolean"
                           },
                           "last_status": {
-                            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                            "type": "keyword"{% if source_mode != "synthetic" %},
                             "ignore_above": 1024
                             {% endif %}
                           },
@@ -14944,7 +14942,7 @@
                         "type": "long"
                       },
                       "link_status": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -14973,7 +14971,7 @@
                     "type": "long"
                   },
                   "role": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -14995,32 +14993,32 @@
               "server": {
                 "properties": {
                   "arch_bits": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "build_id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "config_file": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "gcc_version": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "git_dirty": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "git_sha1": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -15031,17 +15029,17 @@
                     "type": "long"
                   },
                   "mode": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "multiplexing_api": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "run_id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -15194,7 +15192,7 @@
                 }
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -15202,12 +15200,12 @@
                 "type": "long"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -15222,7 +15220,7 @@
                 "type": "long"
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -15238,39 +15236,39 @@
           "data": {
             "properties": {
               "bytes": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "strings": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "hive": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "key": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "path": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "value": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -15282,7 +15280,7 @@
             "type": "ip"
           },
           "user": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -15291,42 +15289,42 @@
       "rule": {
         "properties": {
           "category": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "description": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "reference": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "ruleset": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "uuid": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -15335,7 +15333,7 @@
       "server": {
         "properties": {
           "address": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -15353,7 +15351,7 @@
                         "type": "text",
                         "norms": false
                       }
-                    }{% if synthetic_source | default(False) | string | lower == "false" %},
+                    }{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -15365,29 +15363,29 @@
             "type": "long"
           },
           "domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "geo": {
             "properties": {
               "city_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "continent_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -15395,17 +15393,17 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -15415,7 +15413,7 @@
             "type": "ip"
           },
           "mac": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -15436,24 +15434,24 @@
             "type": "long"
           },
           "registered_domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "top_level_domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "user": {
             "properties": {
               "domain": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "email": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -15464,36 +15462,36 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "group": {
                 "properties": {
                   "domain": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "hash": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -15504,7 +15502,7 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -15515,51 +15513,51 @@
       "service": {
         "properties": {
           "address": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "ephemeral_id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "hostname": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "node": {
             "properties": {
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "state": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "type": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -15568,7 +15566,7 @@
       "source": {
         "properties": {
           "address": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -15586,7 +15584,7 @@
                         "type": "text",
                         "norms": false
                       }
-                    }{% if synthetic_source | default(False) | string | lower == "false" %},
+                    }{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -15598,29 +15596,29 @@
             "type": "long"
           },
           "domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "geo": {
             "properties": {
               "city_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "continent_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "country_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -15628,17 +15626,17 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_iso_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "region_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -15648,7 +15646,7 @@
             "type": "ip"
           },
           "mac": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -15669,24 +15667,24 @@
             "type": "long"
           },
           "registered_domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "top_level_domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "user": {
             "properties": {
               "domain": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "email": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -15697,36 +15695,36 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "group": {
                 "properties": {
                   "domain": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "name": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "hash": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -15737,7 +15735,7 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -15748,7 +15746,7 @@
       "sql": {
         "properties": {
           "driver": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -15771,7 +15769,7 @@
             }
           },
           "query": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -15797,7 +15795,7 @@
                 "type": "long"
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -15806,7 +15804,7 @@
           "cluster": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -15815,7 +15813,7 @@
           "server": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -15836,12 +15834,12 @@
                 "type": "long"
               },
               "role": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -15853,12 +15851,12 @@
           "subscriptions": {
             "properties": {
               "channel": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -15872,7 +15870,7 @@
                 "type": "long"
               },
               "queue": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -16254,7 +16252,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -16272,7 +16270,7 @@
                 }
               },
               "serial_number": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -16308,7 +16306,7 @@
                 "type": "long"
               },
               "device_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -16322,7 +16320,7 @@
                 "type": "long"
               },
               "mount_point": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -16330,7 +16328,7 @@
                 "type": "long"
               },
               "type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -16606,7 +16604,7 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -16674,12 +16672,12 @@
                   "blkio": {
                     "properties": {
                       "id": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
                       "path": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -16719,12 +16717,12 @@
                         }
                       },
                       "id": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
                       "path": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -16768,12 +16766,12 @@
                   "cpuacct": {
                     "properties": {
                       "id": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
                       "path": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -16808,14 +16806,14 @@
                     }
                   },
                   "id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "memory": {
                     "properties": {
                       "id": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -16932,7 +16930,7 @@
                         }
                       },
                       "path": {
-                        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                        "type": "keyword"{% if source_mode != "synthetic" %},
                         "ignore_above": 1024
                         {% endif %}
                       },
@@ -17039,14 +17037,14 @@
                     }
                   },
                   "path": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "cmdline": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 2048
                 {% endif %}
               },
@@ -17135,7 +17133,7 @@
                 }
               },
               "state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -17205,22 +17203,22 @@
                 }
               },
               "level": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "status": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "sync_action": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -17229,17 +17227,17 @@
           "service": {
             "properties": {
               "exec_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "load_state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -17301,7 +17299,7 @@
                 }
               },
               "state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -17309,7 +17307,7 @@
                 "type": "date"
               },
               "sub_state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -17330,7 +17328,7 @@
               "process": {
                 "properties": {
                   "cmdline": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -17339,17 +17337,17 @@
               "remote": {
                 "properties": {
                   "etld_plus_one": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "host": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "host_error": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -17436,43 +17434,43 @@
       "systemd": {
         "properties": {
           "fragment_path": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "unit": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
         }
       },
       "tags": {
-        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+        "type": "keyword"{% if source_mode != "synthetic" %},
         "ignore_above": 1024
         {% endif %}
       },
       "threat": {
         "properties": {
           "framework": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "tactic": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "reference": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -17481,7 +17479,7 @@
           "technique": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -17492,12 +17490,12 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "reference": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -17508,7 +17506,7 @@
       "timeseries": {
         "properties": {
           "instance": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -17517,48 +17515,48 @@
       "tls": {
         "properties": {
           "cipher": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "client": {
             "properties": {
               "certificate": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "certificate_chain": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "hash": {
                 "properties": {
                   "md5": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "sha1": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "sha256": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "issuer": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "ja3": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -17569,24 +17567,24 @@
                 "type": "date"
               },
               "server_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "subject": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "supported_ciphers": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "curve": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -17594,7 +17592,7 @@
             "type": "boolean"
           },
           "next_protocol": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -17604,41 +17602,41 @@
           "server": {
             "properties": {
               "certificate": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "certificate_chain": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "hash": {
                 "properties": {
                   "md5": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "sha1": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "sha256": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
                 }
               },
               "issuer": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "ja3s": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -17649,19 +17647,19 @@
                 "type": "date"
               },
               "subject": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "version_protocol": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -17686,7 +17684,7 @@
                 }
               },
               "mbean": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -17740,7 +17738,7 @@
                 }
               },
               "mbean": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -17786,7 +17784,7 @@
                 }
               },
               "mbean": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -17871,7 +17869,7 @@
           "trace": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -17880,7 +17878,7 @@
           "transaction": {
             "properties": {
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -17925,24 +17923,24 @@
         }
       },
       "type": {
-        "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+        "type": "keyword"{% if source_mode != "synthetic" %},
         "ignore_above": 1024
         {% endif %}
       },
       "url": {
         "properties": {
           "domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "extension": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "fragment": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -17953,7 +17951,7 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -17964,17 +17962,17 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "password": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "path": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -17982,27 +17980,27 @@
             "type": "long"
           },
           "query": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "registered_domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "scheme": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "top_level_domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "username": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -18011,12 +18009,12 @@
       "user": {
         "properties": {
           "domain": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "email": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -18027,36 +18025,36 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "group": {
             "properties": {
               "domain": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "hash": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -18067,7 +18065,7 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -18078,14 +18076,14 @@
           "device": {
             "properties": {
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "name": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -18096,14 +18094,14 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "os": {
             "properties": {
               "family": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -18114,12 +18112,12 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "kernel": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -18130,24 +18128,24 @@
                     "type": "text",
                     "norms": false
                   }
-                }{% if synthetic_source | default(False) | string | lower == "false" %},
+                }{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "platform": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "version": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "version": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -18238,7 +18236,7 @@
                     "type": "long"
                   },
                   "rss": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -18252,7 +18250,7 @@
                     "type": "long"
                   },
                   "status": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
@@ -18301,12 +18299,12 @@
                 }
               },
               "fstype": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -18365,12 +18363,12 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "network_names": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -18395,12 +18393,12 @@
               "host": {
                 "properties": {
                   "hostname": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   },
                   "id": {
-                    "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                    "type": "keyword"{% if source_mode != "synthetic" %},
                     "ignore_above": 1024
                     {% endif %}
                   }
@@ -18451,17 +18449,17 @@
                 }
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "network_names": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "os": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -18472,12 +18470,12 @@
       "vulnerability": {
         "properties": {
           "category": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "classification": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
@@ -18488,34 +18486,34 @@
                 "type": "text",
                 "norms": false
               }
-            }{% if synthetic_source | default(False) | string | lower == "false" %},
+            }{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "enumeration": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "reference": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "report_id": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           },
           "scanner": {
             "properties": {
               "vendor": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
@@ -18533,14 +18531,14 @@
                 "type": "float"
               },
               "version": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }
             }
           },
           "severity": {
-            "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+            "type": "keyword"{% if source_mode != "synthetic" %},
             "ignore_above": 1024
             {% endif %}
           }
@@ -18551,27 +18549,27 @@
           "service": {
             "properties": {
               "display_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "exit_code": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "id": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "path_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -18579,17 +18577,17 @@
                 "type": "long"
               },
               "start_name": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "start_type": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
               "state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -18634,7 +18632,7 @@
                 "type": "long"
               },
               "hostname": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -18677,7 +18675,7 @@
                 "type": "long"
               },
               "server_state": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -18721,7 +18719,7 @@
                 }
               },
               "mode": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               },
@@ -18741,7 +18739,7 @@
                 "type": "date"
               },
               "zxid": {
-                "type": "keyword"{% if synthetic_source | default(False) | string | lower == "false" %},
+                "type": "keyword"{% if source_mode != "synthetic" %},
                 "ignore_above": 1024
                 {% endif %}
               }


### PR DESCRIPTION
This migrates the two tracks that support synthetic _source (`tsdb` and
`nyc_taxis`) to the new way of enabling it via the `mode` parameter in
the mapping configuration of `_source`. This `mode` parameter also
covers disabling `_source` so I've replaced both the
* `synthetic_source: true/false`
* `source_enabled: true/false`
parameters with the newfangled
* `source_mode: stored/synthetic/disabled`
parameter. This is only supported in ES 8.4+, but I don't think we
disable source frequently enough to worry about backwards compatibility
here.

Closes #290