### PR TITLE
Fix dependency issue for endpoint tests

### DIFF
--- a/elastic/Makefile
+++ b/elastic/Makefile
@@ -59,7 +59,7 @@ install: venv-create
 	# install pytest for tests
 	. $(VENV_ACTIVATE_FILE); pip3 install pytest==6.2.5 pytest-benchmark==3.2.2
 	# install dependencies for tests
-	. $(VENV_ACTIVATE_FILE); pip3 install geneve==0.0.3 pytest-asyncio==0.18.1 'https://github.com/elastic/package-assets/archive/main.tar.gz'
+	. $(VENV_ACTIVATE_FILE); pip3 install geneve==0.0.3 pytest-asyncio==0.18.1 'git+https://github.com/elastic/package-assets.git@main'
 	# install (latest) Rally for smoke tests
 	. $(VENV_ACTIVATE_FILE); pip3 install git+ssh://git@github.com/elastic/rally.git --use-feature=2020-resolver
 

--- a/elastic/Makefile
+++ b/elastic/Makefile
@@ -59,7 +59,7 @@ install: venv-create
 	# install pytest for tests
 	. $(VENV_ACTIVATE_FILE); pip3 install pytest==6.2.5 pytest-benchmark==3.2.2
 	# install dependencies for tests
-	. $(VENV_ACTIVATE_FILE); pip3 install geneve==0.0.3 pytest-asyncio==0.18.1
+	. $(VENV_ACTIVATE_FILE); pip3 install geneve==0.0.3 pytest-asyncio==0.18.1 'https://github.com/elastic/package-assets/archive/main.tar.gz'
 	# install (latest) Rally for smoke tests
 	. $(VENV_ACTIVATE_FILE); pip3 install git+ssh://git@github.com/elastic/rally.git --use-feature=2020-resolver
 

--- a/elastic/Makefile
+++ b/elastic/Makefile
@@ -59,7 +59,7 @@ install: venv-create
 	# install pytest for tests
 	. $(VENV_ACTIVATE_FILE); pip3 install pytest==6.2.5 pytest-benchmark==3.2.2
 	# install dependencies for tests
-	. $(VENV_ACTIVATE_FILE); pip3 install geneve==0.0.3 pytest-asyncio==0.18.1 'git+https://github.com/elastic/package-assets.git@main'
+	. $(VENV_ACTIVATE_FILE); pip3 install geneve==0.0.3 pytest-asyncio==0.18.1 git+https://github.com/elastic/package-assets.git
 	# install (latest) Rally for smoke tests
 	. $(VENV_ACTIVATE_FILE); pip3 install git+ssh://git@github.com/elastic/rally.git --use-feature=2020-resolver
 

--- a/elastic/tests/parameter_sources/__init__.py
+++ b/elastic/tests/parameter_sources/__init__.py
@@ -38,7 +38,7 @@ class EmptyTrack:
         self.root = os.path.join(cwd, "..", "..")
 
 
-class StaticTrack:
+class StaticTrack(EmptyTrack):
     def __init__(
         self,
         name="test_track",


### PR DESCRIPTION
The following two changes (along with a `make install`) resolved failing tests for me