### PR TITLE
dense_vector: store refresh-after-index metrics in rally-results

### DIFF
--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -77,7 +77,8 @@
       "name": "refresh-after-update",
       "operation": {
         "operation-type": "refresh",
-        "request-timeout": 1000
+        "request-timeout": 1000,
+        "include-in-reporting": true
       }
     },
     {

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -36,7 +36,8 @@
       "name": "refresh-after-index",
       "operation": {
         "operation-type": "refresh",
-        "request-timeout": 1000
+        "request-timeout": 1000,
+        "include-in-reporting": true
       }
     },
     {


### PR DESCRIPTION
index-append can appear deceptively fast because the HNSW graph can be
built during refresh, so we want refresh times too.