### PR TITLE
Add support for mounting searchable snapshots

### DIFF
--- a/elastic/shared/runners/snapshot.py
+++ b/elastic/shared/runners/snapshot.py
@@ -1,0 +1,44 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import fnmatch
+import re
+
+
+async def mount(es, params):
+    repository_name = params["repository"]
+    snapshot_name = params["snapshot"]
+    index_pattern = params.get("index_pattern", "*")
+    rename_pattern = params.get("rename_pattern", "(.*)")
+    rename_replacement = params.get("rename_replacement", "\\1")
+    query_params = params.get("query_params")
+    snapshots = await es.snapshot.get(repository_name, snapshot_name)
+
+    for snapshot in snapshots["snapshots"]:
+        for index in snapshot["indices"]:
+            if fnmatch.fnmatch(index, index_pattern):
+                body = {"index": index}
+                renamed_index = re.sub(rename_pattern, rename_replacement, index)
+                if renamed_index != index:
+                    body = {"index": index, "renamed_index": renamed_index}
+
+                await es.transport.perform_request(
+                    method="POST",
+                    url=f"/_snapshot/{repository_name}/{snapshot_name}/_mount",
+                    body=body,
+                    params=query_params,
+                )

--- a/elastic/tests/runners/snapshot_test.py
+++ b/elastic/tests/runners/snapshot_test.py
@@ -1,0 +1,190 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest import mock
+
+import pytest
+from shared.runners import snapshot
+from tests import as_future
+
+
+@mock.patch("elasticsearch.Elasticsearch")
+@pytest.mark.asyncio
+async def test_mount_snapshot(es):
+    es.snapshot.get.return_value = as_future(
+        {
+            "snapshots": [
+                {
+                    "snapshot": "eventdata-snapshot",
+                    "uuid": "mWJnRABaSh-gdHF3-pexbw",
+                    "indices": [
+                        "elasticlogs-2018-05-03",
+                        "elasticlogs-2018-05-04",
+                        "elasticlogs-2018-06-05",
+                    ],
+                }
+            ]
+        }
+    )
+    # one call for each matching index
+    es.transport.perform_request.side_effect = [
+        as_future(),
+        as_future(),
+    ]
+
+    params = {
+        "repository": "eventdata",
+        "snapshot": "eventdata-snapshot",
+        "index_pattern": "elasticlogs-2018-05-*",
+    }
+
+    await snapshot.mount(es, params=params)
+
+    es.snapshot.get.assert_called_once_with("eventdata", "eventdata-snapshot")
+    es.transport.perform_request.assert_has_calls(
+        [
+            mock.call(
+                method="POST",
+                url="/_snapshot/eventdata/eventdata-snapshot/_mount",
+                body={"index": "elasticlogs-2018-05-03"},
+                params=None,
+            ),
+            mock.call(
+                method="POST",
+                url="/_snapshot/eventdata/eventdata-snapshot/_mount",
+                body={"index": "elasticlogs-2018-05-04"},
+                params=None,
+            ),
+        ]
+    )
+
+
+@mock.patch("elasticsearch.Elasticsearch")
+@pytest.mark.asyncio
+async def test_mount_snapshot_frozen(es):
+    es.snapshot.get.return_value = as_future(
+        {
+            "snapshots": [
+                {
+                    "snapshot": "eventdata-snapshot",
+                    "uuid": "mWJnRABaSh-gdHF3-pexbw",
+                    "indices": [
+                        "elasticlogs-2018-05-03",
+                        "elasticlogs-2018-05-04",
+                        "elasticlogs-2018-05-05",
+                    ],
+                }
+            ],
+        }
+    )
+    # one call for each index
+    es.transport.perform_request.side_effect = [
+        as_future(),
+        as_future(),
+        as_future(),
+    ]
+
+    params = {
+        "repository": "eventdata",
+        "snapshot": "eventdata-snapshot",
+        "query_params": {"storage": "shared_cache"},
+    }
+
+    await snapshot.mount(es, params=params)
+
+    es.snapshot.get.assert_called_once_with("eventdata", "eventdata-snapshot")
+    es.transport.perform_request.assert_has_calls(
+        [
+            mock.call(
+                method="POST",
+                url="/_snapshot/eventdata/eventdata-snapshot/_mount",
+                body={"index": "elasticlogs-2018-05-03"},
+                params={"storage": "shared_cache"},
+            ),
+            mock.call(
+                method="POST",
+                url="/_snapshot/eventdata/eventdata-snapshot/_mount",
+                body={"index": "elasticlogs-2018-05-04"},
+                params={"storage": "shared_cache"},
+            ),
+            mock.call(
+                method="POST",
+                url="/_snapshot/eventdata/eventdata-snapshot/_mount",
+                body={"index": "elasticlogs-2018-05-05"},
+                params={"storage": "shared_cache"},
+            ),
+        ]
+    )
+
+
+@mock.patch("elasticsearch.Elasticsearch")
+@pytest.mark.asyncio
+async def test_mount_snapshot_with_renames(es):
+    es.snapshot.get.return_value = as_future(
+        {
+            "snapshots": [
+                {
+                    "snapshot": "eventdata-snapshot",
+                    "uuid": "mWJnRABaSh-gdHF3-pexbw",
+                    "indices": [
+                        "elasticlogs-2018-05-03",
+                        "elasticlogs-2018-05-04",
+                        "elasticlogs-2018-06-05",
+                    ],
+                }
+            ],
+        }
+    )
+    # one call for each matching index
+    es.transport.perform_request.side_effect = [
+        as_future(),
+        as_future(),
+    ]
+
+    params = {
+        "repository": "eventdata",
+        "snapshot": "eventdata-snapshot",
+        "index_pattern": "elasticlogs-2018-05-*",
+        "rename_pattern": "elasticlogs-(.*)",
+        "rename_replacement": "renamed-logs-\\1",
+    }
+
+    await snapshot.mount(es, params=params)
+
+    es.snapshot.get.assert_called_once_with("eventdata", "eventdata-snapshot")
+    es.transport.perform_request.assert_has_calls(
+        [
+            mock.call(
+                method="POST",
+                url="/_snapshot/eventdata/eventdata-snapshot/_mount",
+                body={
+                    "index": "elasticlogs-2018-05-03",
+                    "renamed_index": "renamed-logs-2018-05-03",
+                },
+                params=None,
+            ),
+            mock.call(
+                method="POST",
+                url="/_snapshot/eventdata/eventdata-snapshot/_mount",
+                body={
+                    "index": "elasticlogs-2018-05-04",
+                    "renamed_index": "renamed-logs-2018-05-04",
+                },
+                params=None,
+            ),
+        ]
+    )


### PR DESCRIPTION
This is copied from https://github.com/elastic/rally-eventdata-track/blob/master/eventdata/runners/mount_searchable_snapshot_runner.py but:

 * this uses a simple function instead of a class
 * stops trying to figure out the response format as Elasticsearch 8.x
   now uses the 7.x format.

This will be used for testing the frozen tier on elastic/logs.
