### PR TITLE
Support frozen tier logging benchmarks

### DIFF
--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -22,14 +22,14 @@
         "clients": {{ p_bulk_indexing_clients }},
         "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
       },
+      {
+        "name": "compression-stats",
+        "operation": {
+          "operation-type": "compression-statistics",
+          "param-source": "create-datastream-source"
+        }
+      },
     {% endif %}
-    {
-      "name": "compression-stats",
-      "operation": {
-        "operation-type": "compression-statistics",
-        "param-source": "create-datastream-source"
-      }
-    },
     {
       "name": "logging-queries",
       "parallel": {

--- a/elastic/logs/challenges/logging-snapshot-mount.json
+++ b/elastic/logs/challenges/logging-snapshot-mount.json
@@ -1,0 +1,33 @@
+{
+  "name": "logging-snapshot-mount",
+  "description": "Mounts searchable snapshots as partial indices to test the frozen tier.",
+  "parameters": {
+    "generate-data": false
+  },
+  "schedule": [
+    {
+      "name": "register-snapshot-repository",
+      "operation": {
+        "operation-type": "create-snapshot-repository",
+        "repository": "{{ p_snapshot_repo_name }}",
+        "body": {
+          "type": {{ p_snapshot_repo_type | tojson }},
+          "settings": {{ p_snapshot_repo_settings | tojson(indent=2)}}
+        }
+      }
+    },
+    {
+      "name": "mount-searchable-snapshot",
+      "operation": {
+        "operation-type": "mount-searchable-snapshot",
+        "repository": "{{ p_snapshot_repo_name }}",
+        "snapshot": "{{ p_snapshot_name }}",
+        "index_pattern": ".ds-logs-*",
+        "rename_pattern": "^.ds-",
+        "rename_replacement": "",
+        "storage": "shared_cache",
+        "ignore_index_settings": ["index.hidden"]
+      }
+    }
+  ]
+}

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -30,7 +30,8 @@
     "bucket": snapshot_bucket | default("test-bucket"),
     "client": "default",
     "base_path": snapshot_base_path | default("observability/logging"),
-    "max_snapshot_bytes_per_sec": -1
+    "max_snapshot_bytes_per_sec": -1,
+    "readonly": snapshot_repo_readonly | default(false)
 }))%}
 {% set p_snapshot_name = (snapshot_name | default("logging-test")) %}
 {% set p_restore_data_streams = (restore_data_streams | default("logs-*")) %}

--- a/elastic/logs/track.py
+++ b/elastic/logs/track.py
@@ -29,6 +29,7 @@ from shared.parameter_sources.templates import (
     ComposableTemplateParamSource,
 )
 from shared.runners import datastream
+from shared.runners import snapshot
 from shared.runners.bulk import RawBulkIndex
 from shared.runners.ilm import create_ilm
 from shared.runners.slm import create_slm
@@ -75,6 +76,8 @@ def register(registry):
     registry.register_runner("create-pipeline", create_pipeline, async_runner=True)
 
     registry.register_runner("raw-bulk", RawBulkIndex(), async_runner=True)
+
+    registry.register_runner("mount-searchable-snapshot", snapshot.mount, async_runner=True)
 
     registry.register_scheduler("workflow-scheduler", WorkflowScheduler)
     registry.register_scheduler("timestamp-throttler", TimestampThrottler)

--- a/elastic/shared/runners/snapshot.py
+++ b/elastic/shared/runners/snapshot.py
@@ -1,0 +1,50 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import fnmatch
+import re
+
+
+async def mount(es, params):
+    repository_name = params["repository"]
+    snapshot_name = params["snapshot"]
+    index_pattern = params.get("index_pattern", "*")
+    rename_pattern = params.get("rename_pattern", "(.*)")
+    rename_replacement = params.get("rename_replacement", "\\1")
+    ignore_index_settings = params.get("ignore_index_settings")
+    storage = params.get("storage")
+    query_params = params.get("query_params", {})
+    snapshots = await es.snapshot.get(repository_name, snapshot_name)
+
+    for snapshot in snapshots["snapshots"]:
+        for index in snapshot["indices"]:
+            if fnmatch.fnmatch(index, index_pattern):
+                body = {"index": index}
+                renamed_index = re.sub(rename_pattern, rename_replacement, index)
+                if renamed_index != index:
+                    body = {"index": index, "renamed_index": renamed_index}
+
+                if ignore_index_settings:
+                    body["ignore_index_settings"] = ignore_index_settings
+
+                await es.searchable_snapshots.mount(
+                    repository=repository_name,
+                    snapshot=snapshot_name,
+                    body=body,
+                    storage=storage,
+                    wait_for_completion=True,
+                )

--- a/elastic/tests/runners/snapshot_test.py
+++ b/elastic/tests/runners/snapshot_test.py
@@ -29,7 +29,7 @@ async def test_mount_snapshot(es):
         {
             "snapshots": [
                 {
-                    "snapshot": "eventdata-snapshot",
+                    "snapshot": "logging-snapshot",
                     "uuid": "mWJnRABaSh-gdHF3-pexbw",
                     "indices": [
                         "elasticlogs-2018-05-03",
@@ -47,27 +47,27 @@ async def test_mount_snapshot(es):
     ]
 
     params = {
-        "repository": "eventdata",
-        "snapshot": "eventdata-snapshot",
+        "repository": "logging",
+        "snapshot": "logging-snapshot",
         "index_pattern": "elasticlogs-2018-05-*",
         "ignore_index_settings": ["index.hidden"],
     }
 
     await snapshot.mount(es, params=params)
 
-    es.snapshot.get.assert_called_once_with("eventdata", "eventdata-snapshot")
+    es.snapshot.get.assert_called_once_with("logging", "logging-snapshot")
     es.searchable_snapshots.mount.assert_has_calls(
         [
             mock.call(
-                repository="eventdata",
-                snapshot="eventdata-snapshot",
+                repository="logging",
+                snapshot="logging-snapshot",
                 body={"index": "elasticlogs-2018-05-03", "ignore_index_settings": ["index.hidden"],},
                 storage=None,
                 wait_for_completion=True,
             ),
             mock.call(
-                repository="eventdata",
-                snapshot="eventdata-snapshot",
+                repository="logging",
+                snapshot="logging-snapshot",
                 body={"index": "elasticlogs-2018-05-04", "ignore_index_settings": ["index.hidden"],},
                 storage=None,
                 wait_for_completion=True,
@@ -83,7 +83,7 @@ async def test_mount_snapshot_frozen(es):
         {
             "snapshots": [
                 {
-                    "snapshot": "eventdata-snapshot",
+                    "snapshot": "logging-snapshot",
                     "uuid": "mWJnRABaSh-gdHF3-pexbw",
                     "indices": [
                         "elasticlogs-2018-05-03",
@@ -102,33 +102,33 @@ async def test_mount_snapshot_frozen(es):
     ]
 
     params = {
-        "repository": "eventdata",
-        "snapshot": "eventdata-snapshot",
+        "repository": "logging",
+        "snapshot": "logging-snapshot",
         "storage": "shared_cache",
     }
 
     await snapshot.mount(es, params=params)
 
-    es.snapshot.get.assert_called_once_with("eventdata", "eventdata-snapshot")
+    es.snapshot.get.assert_called_once_with("logging", "logging-snapshot")
     es.searchable_snapshots.mount.assert_has_calls(
         [
             mock.call(
-                repository="eventdata",
-                snapshot="eventdata-snapshot",
+                repository="logging",
+                snapshot="logging-snapshot",
                 body={"index": "elasticlogs-2018-05-03"},
                 storage="shared_cache",
                 wait_for_completion=True,
             ),
             mock.call(
-                repository="eventdata",
-                snapshot="eventdata-snapshot",
+                repository="logging",
+                snapshot="logging-snapshot",
                 body={"index": "elasticlogs-2018-05-04"},
                 storage="shared_cache",
                 wait_for_completion=True,
             ),
             mock.call(
-                repository="eventdata",
-                snapshot="eventdata-snapshot",
+                repository="logging",
+                snapshot="logging-snapshot",
                 body={"index": "elasticlogs-2018-05-05"},
                 storage="shared_cache",
                 wait_for_completion=True,
@@ -144,7 +144,7 @@ async def test_mount_snapshot_with_renames(es):
         {
             "snapshots": [
                 {
-                    "snapshot": "eventdata-snapshot",
+                    "snapshot": "logging-snapshot",
                     "uuid": "mWJnRABaSh-gdHF3-pexbw",
                     "indices": [
                         "elasticlogs-2018-05-03",
@@ -162,8 +162,8 @@ async def test_mount_snapshot_with_renames(es):
     ]
 
     params = {
-        "repository": "eventdata",
-        "snapshot": "eventdata-snapshot",
+        "repository": "logging",
+        "snapshot": "logging-snapshot",
         "index_pattern": "elasticlogs-2018-05-*",
         "rename_pattern": "elasticlogs-(.*)",
         "rename_replacement": "renamed-logs-\\1",
@@ -171,12 +171,12 @@ async def test_mount_snapshot_with_renames(es):
 
     await snapshot.mount(es, params=params)
 
-    es.snapshot.get.assert_called_once_with("eventdata", "eventdata-snapshot")
+    es.snapshot.get.assert_called_once_with("logging", "logging-snapshot")
     es.searchable_snapshots.mount.assert_has_calls(
         [
             mock.call(
-                repository="eventdata",
-                snapshot="eventdata-snapshot",
+                repository="logging",
+                snapshot="logging-snapshot",
                 body={
                     "index": "elasticlogs-2018-05-03",
                     "renamed_index": "renamed-logs-2018-05-03",
@@ -185,8 +185,8 @@ async def test_mount_snapshot_with_renames(es):
                 wait_for_completion=True,
             ),
             mock.call(
-                repository="eventdata",
-                snapshot="eventdata-snapshot",
+                repository="logging",
+                snapshot="logging-snapshot",
                 body={
                     "index": "elasticlogs-2018-05-04",
                     "renamed_index": "renamed-logs-2018-05-04",

--- a/elastic/tests/runners/snapshot_test.py
+++ b/elastic/tests/runners/snapshot_test.py
@@ -1,0 +1,198 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest import mock
+
+import pytest
+from shared.runners import snapshot
+from tests import as_future
+
+
+@mock.patch("elasticsearch.Elasticsearch")
+@pytest.mark.asyncio
+async def test_mount_snapshot(es):
+    es.snapshot.get.return_value = as_future(
+        {
+            "snapshots": [
+                {
+                    "snapshot": "eventdata-snapshot",
+                    "uuid": "mWJnRABaSh-gdHF3-pexbw",
+                    "indices": [
+                        "elasticlogs-2018-05-03",
+                        "elasticlogs-2018-05-04",
+                        "elasticlogs-2018-06-05",
+                    ],
+                }
+            ]
+        }
+    )
+    # one call for each matching index
+    es.searchable_snapshots.mount.side_effect = [
+        as_future(),
+        as_future(),
+    ]
+
+    params = {
+        "repository": "eventdata",
+        "snapshot": "eventdata-snapshot",
+        "index_pattern": "elasticlogs-2018-05-*",
+        "ignore_index_settings": ["index.hidden"],
+    }
+
+    await snapshot.mount(es, params=params)
+
+    es.snapshot.get.assert_called_once_with("eventdata", "eventdata-snapshot")
+    es.searchable_snapshots.mount.assert_has_calls(
+        [
+            mock.call(
+                repository="eventdata",
+                snapshot="eventdata-snapshot",
+                body={"index": "elasticlogs-2018-05-03", "ignore_index_settings": ["index.hidden"],},
+                storage=None,
+                wait_for_completion=True,
+            ),
+            mock.call(
+                repository="eventdata",
+                snapshot="eventdata-snapshot",
+                body={"index": "elasticlogs-2018-05-04", "ignore_index_settings": ["index.hidden"],},
+                storage=None,
+                wait_for_completion=True,
+            ),
+        ]
+    )
+
+
+@mock.patch("elasticsearch.Elasticsearch")
+@pytest.mark.asyncio
+async def test_mount_snapshot_frozen(es):
+    es.snapshot.get.return_value = as_future(
+        {
+            "snapshots": [
+                {
+                    "snapshot": "eventdata-snapshot",
+                    "uuid": "mWJnRABaSh-gdHF3-pexbw",
+                    "indices": [
+                        "elasticlogs-2018-05-03",
+                        "elasticlogs-2018-05-04",
+                        "elasticlogs-2018-05-05",
+                    ],
+                }
+            ],
+        }
+    )
+    # one call for each index
+    es.searchable_snapshots.mount.side_effect = [
+        as_future(),
+        as_future(),
+        as_future(),
+    ]
+
+    params = {
+        "repository": "eventdata",
+        "snapshot": "eventdata-snapshot",
+        "storage": "shared_cache",
+    }
+
+    await snapshot.mount(es, params=params)
+
+    es.snapshot.get.assert_called_once_with("eventdata", "eventdata-snapshot")
+    es.searchable_snapshots.mount.assert_has_calls(
+        [
+            mock.call(
+                repository="eventdata",
+                snapshot="eventdata-snapshot",
+                body={"index": "elasticlogs-2018-05-03"},
+                storage="shared_cache",
+                wait_for_completion=True,
+            ),
+            mock.call(
+                repository="eventdata",
+                snapshot="eventdata-snapshot",
+                body={"index": "elasticlogs-2018-05-04"},
+                storage="shared_cache",
+                wait_for_completion=True,
+            ),
+            mock.call(
+                repository="eventdata",
+                snapshot="eventdata-snapshot",
+                body={"index": "elasticlogs-2018-05-05"},
+                storage="shared_cache",
+                wait_for_completion=True,
+            ),
+        ]
+    )
+
+
+@mock.patch("elasticsearch.Elasticsearch")
+@pytest.mark.asyncio
+async def test_mount_snapshot_with_renames(es):
+    es.snapshot.get.return_value = as_future(
+        {
+            "snapshots": [
+                {
+                    "snapshot": "eventdata-snapshot",
+                    "uuid": "mWJnRABaSh-gdHF3-pexbw",
+                    "indices": [
+                        "elasticlogs-2018-05-03",
+                        "elasticlogs-2018-05-04",
+                        "elasticlogs-2018-06-05",
+                    ],
+                }
+            ],
+        }
+    )
+    # one call for each matching index
+    es.searchable_snapshots.mount.side_effect = [
+        as_future(),
+        as_future(),
+    ]
+
+    params = {
+        "repository": "eventdata",
+        "snapshot": "eventdata-snapshot",
+        "index_pattern": "elasticlogs-2018-05-*",
+        "rename_pattern": "elasticlogs-(.*)",
+        "rename_replacement": "renamed-logs-\\1",
+    }
+
+    await snapshot.mount(es, params=params)
+
+    es.snapshot.get.assert_called_once_with("eventdata", "eventdata-snapshot")
+    es.searchable_snapshots.mount.assert_has_calls(
+        [
+            mock.call(
+                repository="eventdata",
+                snapshot="eventdata-snapshot",
+                body={
+                    "index": "elasticlogs-2018-05-03",
+                    "renamed_index": "renamed-logs-2018-05-03",
+                },
+                storage=None,
+                wait_for_completion=True,
+            ),
+            mock.call(
+                repository="eventdata",
+                snapshot="eventdata-snapshot",
+                body={
+                    "index": "elasticlogs-2018-05-04",
+                    "renamed_index": "renamed-logs-2018-05-04",
+                },
+                storage=None,
+                wait_for_completion=True,
+            ),
+        ]
+    )


### PR DESCRIPTION
This does two things:

 * add a runner that can mount partial indices
 * add a challenge calling that runner

While the runner should eventually be in Rally and I think I should have targeted the master branch, I would be happy to get some intial feedback here.