### PR TITLE
Include metrics for create-snapshots in summary/rally-results index

### DIFF
--- a/elastic/logs/challenges/many-shards-snapshots.json
+++ b/elastic/logs/challenges/many-shards-snapshots.json
@@ -51,7 +51,8 @@
             "ignore_unavailable": true,
             "include_global_state": false,
             "metadata": {{ p_snapshot_metadata | tojson }}
-          }
+          },
+          "include-in-reporting": true
         }
       },
       {% endfor %}


### PR DESCRIPTION
This commit instructs the `create-snapshot` operation, used by the
`elastic/logs`/`many-shards-snapshots` challenge, to record metrics in final results.

The create-snapshot[^1] operation is an administrative
operation[^2] (Rally docs need fixing, to reflect it) and thus doesn't
record metrics in the summary or `rally-results` by default.

This change is needed, because currently we have to rely on the
`rally-metrics` index for the visualization
`nightly-elastic-logs/many-shards-snapshots-create-average` in the
nightly benchmark results[^3]; however this index is
periodically pruned, and, thus, we should instead visualize
based on metrics stored in `rally-results`.

[^1]: https://esrally.readthedocs.io/en/stable/track.html#create-snapshot
[^2]: https://github.com/elastic/rally/blob/6edfa43895c426a92670fdde58b0f85fa7d1dfe6/esrally/track/track.py#L712
[^3]: https://elasticsearch-benchmarks.elastic.co/#tracks/many-shards-snapshots/nightly/default/30d