### PR TITLE
Synthetic _source support in so_vectors

### DIFF
--- a/so_vector/challenges/default.json
+++ b/so_vector/challenges/default.json
@@ -38,12 +38,12 @@
       "include-in-reporting": true
     },
     {
-      "operation": "default",
+      "operation": "fetch_10",
       "warmup-iterations": 50,
       "iterations": 100
     },
     {
-      "operation": "default_1k",
+      "operation": "fetch_1000",
       "warmup-iterations": 50,
       "iterations": 100
     },

--- a/so_vector/challenges/default.json
+++ b/so_vector/challenges/default.json
@@ -38,6 +38,16 @@
       "include-in-reporting": true
     },
     {
+      "operation": "default",
+      "warmup-iterations": 50,
+      "iterations": 100
+    },
+    {
+      "operation": "default_1k",
+      "warmup-iterations": 50,
+      "iterations": 100
+    },
+    {
       "name": "knn-search-10-50-match-all",
       "operation": "knn-search-10-50-match-all",
       "warmup-iterations": 100,

--- a/so_vector/index.json
+++ b/so_vector/index.json
@@ -5,7 +5,7 @@
   },
   "mappings": {
     "_source": {
-      "excludes": ["titleVector"]
+      "mode": {{ source_mode | default("stored") | tojson }}
     },
     "properties": {
       "userId": {
@@ -22,6 +22,7 @@
       },
       "title": {
         "type": "text"
+        {% if source_mode == "synthetic" %},"store": true{% endif %}
       },
       "titleVector": {
         "type": "dense_vector",
@@ -34,6 +35,7 @@
       },
       "body": {
         "type": "text"
+        {% if source_mode == "synthetic" %},"store": true{% endif %}
       }
     }
   }

--- a/so_vector/operations/default.json
+++ b/so_vector/operations/default.json
@@ -1,4 +1,23 @@
 {
+  "name": "default",
+  "operation-type": "search",
+  "body": {
+    "query": {
+      "match_all": {}
+    }
+  }
+},
+{
+  "name": "default_1k",
+  "operation-type": "search",
+  "body": {
+    "query": {
+      "match_all": {}
+    },
+    "size": 1000
+  }
+},
+{
   "name": "knn-search-10-50-acceptedAnswerId",
   "operation-type": "raw-request",
   "path": "/vectors/_knn_search",

--- a/so_vector/operations/default.json
+++ b/so_vector/operations/default.json
@@ -1,5 +1,5 @@
 {
-  "name": "default",
+  "name": "fetch_10",
   "operation-type": "search",
   "body": {
     "query": {
@@ -8,7 +8,7 @@
   }
 },
 {
-  "name": "default_1k",
+  "name": "fetch_1000",
   "operation-type": "search",
   "body": {
     "query": {


### PR DESCRIPTION
This modifies the `so_vectors` track to support synthetic _source and to test fetch performance on docs that are hot in the disk cache.