### PR TITLE
Add wait-until-merges-finish to noaa aggs challenge

### DIFF
--- a/noaa/challenges/default.json
+++ b/noaa/challenges/default.json
@@ -224,6 +224,19 @@
           "operation": "refresh",
           "clients": 1
         },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
         {% include 'aggs-tasks.json' %}
       ]
     }


### PR DESCRIPTION
To make it consistent with other challenges and add stability to the challenge.