### PR TITLE
Make base_path static

### DIFF
--- a/elastic/logs/challenges/many-shards-snapshots.json
+++ b/elastic/logs/challenges/many-shards-snapshots.json
@@ -24,8 +24,8 @@
       },
       "clients": {{ p_bulk_indexing_clients }}
     },
-    {# randomize base path to avoid clashes when running concurrent benchmarks #}
-      {% set _=p_snapshot_repo_settings.update({"base_path":"many-shards-"+((now|int)|string)}) %}
+  {# TODO randomize base path to avoid clashes when running concurrent benchmarks after https://github.com/elastic/rally-tracks/issues/337 #}
+    {# % set _=p_snapshot_repo_settings.update({"base_path":"many-shards-"+((now|int)|string)}) % #}
     {
       "name": "register-snapshot-repository",
       "operation": {


### PR DESCRIPTION
In #303 we added a safety net for running concurrent many shards snapshot challenges to the same bucket. Unfortunately the override applied for all `base_path`, including critically the non-many-shards challenges, rendering the base_path unconfigurable. I think we should still do this, but wait until #337 in order to do this as cleanly as possible.

This PR removes the base_path override by commenting with reference to the upstream issue we're dependent on.