### PR TITLE
Update so_vector track to report refresh

### DIFF
--- a/so_vector/challenges/default.json
+++ b/so_vector/challenges/default.json
@@ -34,8 +34,11 @@
     },
     {
       "name": "refresh-after-index",
-      "operation": "refresh",
-      "include-in-reporting": true
+      "operation": {
+        "operation-type": "refresh",
+        "request-timeout": 1000,
+        "include-in-reporting": true
+      }
     },
     {
       "name": "knn-search-10-50-match-all",


### PR DESCRIPTION
refresh operation wasn't being reported as intended.
Relates to: https://github.com/elastic/rally-tracks/issues/272