### PR TITLE
Fix _get_seed_nodes for single node clusters

### DIFF
--- a/elastic/shared/runners/remote_cluster.py
+++ b/elastic/shared/runners/remote_cluster.py
@@ -28,11 +28,26 @@ class ConfigureRemoteClusters(Runner):
 
     @staticmethod
     def _get_seed_nodes(nodes_api_response):
-        return [
-            n["transport_address"]
-            for n in nodes_api_response["nodes"].values()
-            if "remote_cluster_client" in n["roles"] and "master" not in n["roles"]
-        ]
+        seed_nodes = []
+
+        if len(nodes_api_response["nodes"].values()) > 1:
+            # we dont want to target masters on multi node clusters
+            for n in nodes_api_response["nodes"].values():
+                if "remote_cluster_client" in n["roles"] and "master" not in n["roles"]:
+                    seed_nodes.append(n["transport_address"])
+        else:
+            # single node clusters have all roles
+            for n in nodes_api_response["nodes"].values():
+                if "remote_cluster_client" in n["roles"]:
+                    seed_nodes.append(n["transport_address"])
+
+        if len(seed_nodes) < 1:
+            raise BaseException(
+                f"Unable to retrieve any seed nodes for cluster [{nodes_api_response['cluster_name']}]. "
+                "Ensure that the node(s) have the correct 'nodes.roles' assigned."
+            )
+
+        return seed_nodes
 
     async def _configure_remote_cluster(self, local_cluster_client, local_cluster_name, remote_cluster_identifier, remote_seed_nodes):
         local_settings_body = {"persistent": {f"cluster.remote.{remote_cluster_identifier}.seeds": remote_seed_nodes}}

--- a/elastic/tests/runners/remote_cluster_test.py
+++ b/elastic/tests/runners/remote_cluster_test.py
@@ -52,7 +52,7 @@ class TestConfigureRemoteClusters:
         params = {"local-cluster": "local_cluster"}
         return params
 
-    def test_get_seed_nodes(self):
+    def test_get_seed_nodes_multiple_nodes(self):
         nodes_resp = {
             "cluster_name": "cluster_name",
             "nodes": {
@@ -67,6 +67,37 @@ class TestConfigureRemoteClusters:
             },
         }
         assert ConfigureRemoteClusters._get_seed_nodes(nodes_resp) == ["127.0.0.1:39320"]
+
+    def test_get_seed_nodes_single_node(self):
+        nodes_resp = {
+            "cluster_name": "cluster_name",
+            "nodes": {
+                "ZrKjLJ1cT6eXblbjwMkkFA": {
+                    "transport_address": f"127.0.0.1:39320",
+                    "roles": ["master", "data_hot", "remote_cluster_client"],
+                }
+            },
+        }
+        assert ConfigureRemoteClusters._get_seed_nodes(nodes_resp) == ["127.0.0.1:39320"]
+
+    def test_get_seed_nodes_no_nodes(self):
+        nodes_resp = {
+            "cluster_name": "cluster_name",
+            "nodes": {
+                "ZrKjLJ1cT6eXblbjwMkkFA": {
+                    "transport_address": f"127.0.0.1:39320",
+                    "roles": ["data_hot"],
+                }
+            },
+        }
+
+        with pytest.raises(BaseException) as e:
+            ConfigureRemoteClusters._get_seed_nodes(nodes_resp)
+
+        assert (
+            "Unable to retrieve any seed nodes for cluster [cluster_name]. Ensure that the node(s) have the correct "
+            "'nodes.roles' assigned." in str(e)
+        )
 
     @pytest.mark.asyncio
     async def test_configure_remote_cluster(self, setup_es, setup_params):


### PR DESCRIPTION
I'm an idiot and broke single node (i.e. a node with _all_ roles) CCS benchmarks when I merged https://github.com/elastic/rally-tracks/pull/333

I added some tests to cover both scenarios, and I've also properly tested both single and multi-node setups.