### PR TITLE
Separate many-shards snapshot repo settings to its own dict

### DIFF
--- a/elastic/logs/challenges/many-shards-snapshots.json
+++ b/elastic/logs/challenges/many-shards-snapshots.json
@@ -24,7 +24,7 @@
       },
       "clients": {{ p_bulk_indexing_clients }}
     },
-    {# mutate a copy so as not to override in other challenges#}
+    {# mutate a copy so as not to override in other challenges. shallow copy is ok since we're changing a top-level element.' #}
       {% set many_shards_snapshot_repo_settings = p_snapshot_repo_settings.copy() %}
     {# randomize base path to avoid clashes when running concurrent benchmarks #}
       {% set _=many_shards_snapshot_repo_settings.update({"base_path":"many-shards-"+((now|int)|string)}) %}


### PR DESCRIPTION
In a similar spirit to #338, but working. Currently, all snapshot base paths in any `elastic/logs` challenge are set to `many-shards-{epoch}`, not just the many shards challenge. This change causes only the settings for that challenge to be mutated for concurrency, as the existing comment notes.