### PR TITLE
Require pyyaml for elastic/security

### DIFF
--- a/elastic/security/track.json
+++ b/elastic/security/track.json
@@ -407,7 +407,8 @@
 {% endfor %}
   ],
   "dependencies": [
-    "geneve>=0.0.3"
+    "geneve>=0.0.3",
+    "pyyaml"
   ],
   "challenges": [
     {{ rally.collect(parts="challenges/*.json") }}


### PR DESCRIPTION
This commit fixes `rally-tracks-compat` in CI tests.

Background:

The elastic/security track (in `events_emitter.py`) imports `yaml`, but it doesn't explicitly depend on it in `track.json` (and neither does Rally require it).

 So far things worked because `pyyaml` was required in the older version
 (`0.0.3`) of Geneve but recently[^1] a new version (`0.1.1`) got
 released that removed the `pyyaml` dependency[^2] (under the good
 `geneve` uses `ruamel.yaml`).

 Since then, we have `rally-tracks-compat` failures[^3]:

 ```
 Running command: [esrally race --track="elastic/security" --challenge="index-alert-source-events" --track-repository="/var/lib/jenkins/workspace/elastic+rally+pull-request+rally-tracks-compat/.rally/benchmarks/tracks/rally-tracks-compat" --track-revision="master" --configuration-name="pytest" --enable-assertions --kill-running-processes --on-error="abort" --pipeline="benchmark-only" --target-hosts="127.0.0.1:19200" --test-mode --track-params="number_of_replicas:0"]
 12:14:02 FAILED                                                                   [ 97%]

 12:15:01 [ERROR] Cannot race. Error in load generator [0]
 12:15:01 	No module named 'yaml'
 ```

 [^1]: https://github.com/elastic/geneve/tags
 [^2]: https://github.com/elastic/geneve/commit/1f8304ff44b9707c315def34c2ca4b72f00ba9fe
 [^3]: https://elasticsearch-ci.elastic.co/job/elastic+rally+pull-request+rally-tracks-compat/160/console