### PR TITLE
Fix deprecation warnings in sync GitHub Action

### DIFF
--- a/.github/workflows/sync-latest-branch.yml
+++ b/.github/workflows/sync-latest-branch.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Sync upstream changes
         id: sync
-        uses: aormsby/Fork-Sync-With-Upstream-action@v3.0
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
         with:
           target_sync_branch: 8.5
           target_repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/aormsby/Fork-Sync-With-Upstream-action/releases/tag/v3.4

See the warnings here: https://github.com/elastic/rally-tracks/actions/runs/3490070322