### PR TITLE
Bump checkout GitHub Action to fix warning

### DIFF
--- a/.github/workflows/sync-latest-branch.yml
+++ b/.github/workflows/sync-latest-branch.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: 8.5
 


### PR DESCRIPTION
Turns out there is a warning left: https://github.com/elastic/rally-tracks/actions/runs/3496056500