### PR TITLE
Add detailed results to CCS queries 

### DIFF
--- a/elastic/logs/challenges/cross-clusters-search.json
+++ b/elastic/logs/challenges/cross-clusters-search.json
@@ -57,6 +57,7 @@
                 "param-source": "workflow-selector",
                 "workflow": {{workflow | tojson }},
                 "workflow-target": {{ target_index | tojson }},
+                "detailed-results": true,
                 "task-offset": {{ loop.index }},
                 "request-params": {{ p_query_request_params | tojson(indent=2) }}
               },
@@ -73,6 +74,7 @@
                 "param-source": "workflow-selector",
                 "workflow": {{workflow | tojson }},
                 "workflow-target": {{ target_index | tojson }},
+                "detailed-results": true,
                 "task-offset": {{ loop.index }},
                 "request-params": {
                     "ccs_minimize_roundtrips": false

--- a/elastic/shared/parameter_sources/workflow_selector.py
+++ b/elastic/shared/parameter_sources/workflow_selector.py
@@ -62,7 +62,9 @@ class WorkflowSelectorParamSource:
         # for testing purposes only we allow a configurable now function
         self._utc_now = kwargs.get("utc_now", datetime.utcnow)
         self._init_date = self._utc_now().replace(tzinfo=timezone.utc)
-        self._detailed_results = track.selected_challenge_or_default.parameters.get("detailed-results", False)
+        self._detailed_results = params.get(
+            "detailed-results", track.selected_challenge_or_default.parameters.get("detailed-results", False)
+        )
         self._workflow_target = params.get(
             "workflow-target",
             track.selected_challenge_or_default.parameters.get("workflow-target"),


### PR DESCRIPTION
With the merging of https://github.com/elastic/rally/pull/1618 and https://github.com/elastic/rally/pull/1619 we add the collection of shard meta-data for each search request with the intention of allowing us to visualise the number of shards hit and skipped by each query, an important metric for CCS behaviour. 