### PR TITLE
Add recall to dense vector track

### DIFF
--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -126,6 +126,41 @@
       "warmup-iterations": 100,
       "iterations": 1000,
       "clients": 1
+    },
+    {
+      "name": "knn-recall-10-100",
+      "operation": "knn-recall-10-100",
+      "warmup-iterations": 0,
+      "iterations": 1000,
+      "clients": 1
+    },
+    {
+      "name": "knn-recall-100-1000",
+      "operation": "knn-recall-100-1000",
+      "warmup-iterations": 0,
+      "iterations": 1000,
+      "clients": 1
+    },
+    {
+      "name": "knn-recall-10-10",
+      "operation": "knn-recall-10-10",
+      "warmup-iterations": 0,
+      "iterations": 1000,
+      "clients": 1
+    },
+    {
+      "name": "knn-recall-100-100",
+      "operation": "knn-recall-100-100",
+      "warmup-iterations": 0,
+      "iterations": 1000,
+      "clients": 1
+    },
+    { 
+      "name": "knn-recall-1000-1000",
+      "operation": "knn-recall-1000-1000",
+      "warmup-iterations": 0,
+      "iterations": 1000,
+      "clients": 1
     }
   ]
 }

--- a/dense_vector/operations/default.json
+++ b/dense_vector/operations/default.json
@@ -18,4 +18,39 @@
   "param-source": "knn-param-source",
   "k": 10,
   "exact": true
+},
+{
+  "name": "knn-recall-10-100",
+  "operation-type": "knn-recall",
+  "param-source": "knn-recall-param-source",
+  "k": 10,
+  "num-candidates": 100
+},
+{
+  "name": "knn-recall-100-1000",
+  "operation-type": "knn-recall",
+  "param-source": "knn-recall-param-source",
+  "k": 100,
+  "num-candidates": 1000
+},
+{
+  "name": "knn-recall-10-10",
+  "operation-type": "knn-recall",
+  "param-source": "knn-recall-param-source",
+  "k": 10,
+  "num-candidates": 10
+},
+{
+  "name": "knn-recall-100-100",
+  "operation-type": "knn-recall",
+  "param-source": "knn-recall-param-source",
+  "k": 100,
+  "num-candidates": 100
+},
+{
+  "name": "knn-recall-1000-1000",
+  "operation-type": "knn-recall",
+  "param-source": "knn-recall-param-source",
+  "k": 1000,
+  "num-candidates": 1000
 }

--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-
 class KnnParamSource:
     def __init__(self, track, params, **kwargs):
         # choose a suitable index: if there is only one defined for this track
@@ -55,6 +54,87 @@ class KnnParamSource:
         self._iters += 1
         return result
 
+# For each query this will generate both the knn query and the equivalent
+# score script query. The two queries can then be executed and used
+# to gauge the accuracy of the knn query.
+class KnnRecallParamSource:
+    def __init__(self, track, params, **kwargs):
+        if len(track.indices) == 1:
+            default_index = track.indices[0].name
+        else:
+            default_index = "_all"
+
+        self._index_name = params.get("index", default_index)
+        self._cache = params.get("cache", False)
+        self._params = params
+
+        cwd = os.path.dirname(__file__)
+        with open(os.path.join(cwd, "queries.json"), "r") as file:
+            lines = file.readlines()
+        self._queries = [json.loads(line) for line in lines]
+        self._iters = 0
+        self.infinite = True
+
+    def partition(self, partition_index, total_partitions):
+        return self
+
+    def params(self):
+        result = {"index": self._index_name, "cache": self._params.get("cache", False), "size": self._params.get("k", 10)}
+        result["script_body"] = {
+            "query": {
+                "script_score": {
+                    "query": {"match_all": {}},
+                    "script": {
+                        "source": "cosineSimilarity(params.query, 'vector') + 1.0",
+                        "params": {"query": self._queries[self._iters]},
+                    },
+                }
+            },
+            "_source": False,
+        }
+        result["knn_body"] = {
+            "knn": {
+                "field": "vector",
+                "query_vector": self._queries[self._iters],
+                "k": self._params.get("k", 10),
+                "num_candidates": self._params.get("num-candidates", 100),
+            },
+            "_source": False,
+        }
+        self._iters += 1
+        return result
+
+# Used in tandem with the KnnRecallParamSource. This executes both a knn query
+# and an equivalent score script query. Results are then compared to gauge
+# the accuracy of the knn query.
+class KnnRecallRunner:
+    async def __call__(self, es, params):
+        knn_result = await es.search(
+            body=params["knn_body"], 
+            index=params["index"], 
+            request_cache=params["cache"], 
+            size=params["size"]
+        )
+        script_result = await es.search(
+            body=params["script_body"], 
+            index=params["index"], 
+            request_cache=params["cache"], 
+            size=params["size"]
+        )
+        knn_hits = {hit["_id"] for hit in knn_result["hits"]["hits"]}
+        script_hits = {hit["_id"] for hit in script_result["hits"]["hits"]}
+        intersection = knn_hits.intersection(script_hits)
+        return {
+            "k": params["knn_body"]["knn"]["k"],
+            "num_candidates": params["knn_body"]["knn"]["num_candidates"],
+            "recall": len(intersection)
+        }
+
+    def __repr__(self, *args, **kwargs):
+        return "knn-recall"
 
 def register(registry):
     registry.register_param_source("knn-param-source", KnnParamSource)
+    registry.register_param_source("knn-recall-param-source", KnnRecallParamSource)
+    registry.register_runner("knn-recall", KnnRecallRunner(), async_runner=True)
+


### PR DESCRIPTION
Recall in dense vectors is a measurement of accuracy between an approximate knn search and a brute force script score. Accuracy can be measured by figuring out the count of the intersection between the documents returned by both queries and divided by the size of the script score query. k should match size for this to be meaningful.

This change adds a new track runner (knn-recall) and a new params source (knn-recall-params-source) to support collecting new data added to the meta field in the form of `k`, `num-candidates`, and `recall` which can be used to determine how accurate a specific query was.

The source document generated for the metrics store entries for this runner look like the following:

```
"_source" : {
          "@timestamp" : 1670429366132,
          "relative-time" : 829.0115890558809,
          "race-id" : "85da22bb-762b-4c5c-9f07-b7760d8b9245",
          "race-timestamp" : "20221207T153222Z",
          "environment" : "local",
          "track" : "dense_vector",
          "challenge" : "index-and-search",
          "car" : "defaults",
          "name" : "latency",
          "value" : 246.23832199722528,
          "unit" : "ms",
          "sample-type" : "normal",
          "meta" : {
            "attribute_xpack.installed" : "true",
            "source_revision" : "a334a530efa1460872ebb2bf53706cba3fbdac9e",
            "distribution_version" : "8.7.0-SNAPSHOT",
            "distribution_flavor" : "default",
            "k" : 10,
            "num_candidates" : 100,
            "recall" : 10,
            "success" : true
          },
          "task" : "knn-recall-10-100",
          "operation" : "knn-recall-10-100",
          "operation-type" : "knn-recall"
        }
```

