### PR TITLE
Revert "Include 'time_series' aggregation tests (#351)"

### DIFF
--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -3,21 +3,6 @@
       "description": "Indexes the whole document corpus.",
       "default": true,
       "schedule": [
-        {
-          "name":"increase-max_buckets_setting",
-          "tags": ["setup"],
-          "operation": {
-            "operation-type": "raw-request",
-            "method": "PUT",
-            "path": "/_cluster/settings",
-            "body": {
-              "transient": {
-                "search.max_buckets" : 300000
-              }
-            },
-            "include-in-reporting": false
-          }
-        },
         {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
         {
           "name": "put-timestamp-pipeline",
@@ -136,36 +121,6 @@
         },
         {
           "operation": "date-histo-entire-range",
-          "warmup-iterations": 50,
-          "iterations": 100
-        },
-        {
-          "operation": "date-histo-memory-usage-hour",
-          "warmup-iterations": 50,
-          "iterations": 100
-        },
-        {
-          "operation": "date-histo-memory-usage-minute",
-          "warmup-iterations": 50,
-          "iterations": 100
-        },
-        {
-          "operation": "auto-date-histo-memory-usage-100",
-          "warmup-iterations": 50,
-          "iterations": 100
-        },
-        {
-          "operation": "auto-date-histo-memory-usage-1000",
-          "warmup-iterations": 50,
-          "iterations": 100
-        },
-        {
-          "operation": "terms-container-name-memory-usage",
-          "warmup-iterations": 50,
-          "iterations": 100
-        },
-        {
-          "operation": "terms-container-image-memory-usage",
           "warmup-iterations": 50,
           "iterations": 100
         }

--- a/tsdb/operations/default.json
+++ b/tsdb/operations/default.json
@@ -1,321 +1,89 @@
-{
-  "name": "index",
-  "operation-type": "bulk",
-  "bulk-size": {{bulk_size | default(5000)}},
-  "ingest-percentage": {{ingest_percentage | default(100)}}
-},
-{
-  "name": "default",
-  "operation-type": "search",
-  "body": {
-    "query": {
-      "match_all": {}
-    }
-  }
-},
-{
-  "name": "default_1k",
-  "operation-type": "search",
-  "body": {
-    "query": {
-      "match_all": {}
+    {
+      "name": "index",
+      "operation-type": "bulk",
+      "bulk-size": {{bulk_size | default(5000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}}
     },
-    "size": 1000
-  }
-},
-{
-  "name": "date-histo-entire-range-1m",
-  "operation-type": "search",
-  "index": "tsdb-1m",
-  "body": {
-    "size": 0,
-    "aggs": {
-      "date": {
-        "date_histogram": {
-          "field": "@timestamp",
-          "fixed_interval": "1m"
+    {
+      "name": "default",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "match_all": {}
         }
       }
-    }
-  }
-},
-{
-  "name": "date-histo-entire-range-1h",
-  "operation-type": "search",
-  "index": "tsdb-1h",
-  "body": {
-    "size": 0,
-    "aggs": {
-      "date": {
-        "date_histogram": {
-          "field": "@timestamp",
-          "fixed_interval": "1h"
-        }
-      }
-    }
-  }
-},
-{
-  "name": "date-histo-entire-range-1d",
-  "operation-type": "search",
-  "index": "tsdb-1d",
-  "body": {
-    "size": 0,
-    "aggs": {
-      "date": {
-        "date_histogram": {
-          "field": "@timestamp",
-          "fixed_interval": "1d"
-        }
-      }
-    }
-  }
-},
-{
-  "name": "date-histo-entire-range",
-  "operation-type": "search",
-  "index": "tsdb",
-  "body": {
-    "size": 0,
-    "aggs": {
-      "date": {
-        "date_histogram": {
-          "field": "@timestamp",
-          "fixed_interval": "1d"
-        }
-      }
-    }
-  }
-},
-{
-  "name": "date-histo-memory-usage-hour",
-  "operation-type": "search",
-  {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
-  "index": "k8s",
-  {%- else %}
-  "index": "tsdb",
-  {% endif %}
-  "body": {
-    "size": 0,
-    "aggs": {
-      "by_date": {
-        "date_histogram": {
-          "field": "@timestamp",
-          "fixed_interval": "1h"
+    },
+    {
+      "name": "default_1k",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "match_all": {}
         },
+        "size": 1000
+      }
+    },
+    {
+      "name": "date-histo-entire-range-1m",
+      "operation-type": "search",
+      "index": "tsdb-1m",
+      "body": {
+        "size": 0,
         "aggs": {
-          "ts": {
-            "time_series": {
-              "keyed": false
-            },
-            "aggs": {
-              "total_memory_usage_by_date": {
-                "sum": {
-                  "field": "kubernetes.container.memory.usage.bytes"
-                }
-              }
+          "date": {
+            "date_histogram": {
+              "field": "@timestamp",
+              "fixed_interval": "1m"
             }
-          },
-          "min_total_memory_usage_by_date": {
-            "min_bucket": {
-              "buckets_path": "ts>total_memory_usage_by_date"
+          }
+        }
+      }
+    },
+    {
+      "name": "date-histo-entire-range-1h",
+      "operation-type": "search",
+      "index": "tsdb-1h",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "@timestamp",
+              "fixed_interval": "1h"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "date-histo-entire-range-1d",
+      "operation-type": "search",
+      "index": "tsdb-1d",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "@timestamp",
+              "fixed_interval": "1d"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "date-histo-entire-range",
+      "operation-type": "search",
+      "index": "tsdb",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "date": {
+            "date_histogram": {
+              "field": "@timestamp",
+              "fixed_interval": "1d"
             }
           }
         }
       }
     }
-  }
-},
-{
-  "name": "date-histo-memory-usage-minute",
-  "operation-type": "search",
-  {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
-  "index": "k8s",
-  {%- else %}
-  "index": "tsdb",
-  {% endif %}
-  "body": {
-    "size": 0,
-    "aggs": {
-      "by_date": {
-        "date_histogram": {
-          "field": "@timestamp",
-          "fixed_interval": "1m"
-        },
-        "aggs": {
-          "ts": {
-            "time_series": {
-              "keyed": false
-            },
-            "aggs": {
-              "total_memory_usage_by_date": {
-                "sum": {
-                  "field": "kubernetes.container.memory.usage.bytes"
-                }
-              }
-            }
-          },
-          "min_total_memory_usage_by_date": {
-            "min_bucket": {
-              "buckets_path": "ts>total_memory_usage_by_date"
-            }
-          }
-        }
-      }
-    }
-  }
-},
-{
-  "name": "auto-date-histo-memory-usage-100",
-  "operation-type": "search",
-  {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
-  "index": "k8s",
-  {%- else %}
-  "index": "tsdb",
-  {% endif %}
-  "body": {
-    "size": 0,
-    "aggs": {
-      "by_date": {
-        "auto_date_histogram": {
-          "field": "@timestamp",
-          "buckets": "100"
-        },
-        "aggs": {
-          "ts": {
-            "time_series": {
-              "keyed": false
-            },
-            "aggs": {
-              "total_memory_usage_by_date": {
-                "sum": {
-                  "field": "kubernetes.container.memory.usage.bytes"
-                }
-              }
-            }
-          },
-          "min_total_memory_usage_by_date": {
-            "min_bucket": {
-              "buckets_path": "ts>total_memory_usage_by_date"
-            }
-          }
-        }
-      }
-    }
-  }
-},
-{
-  "name": "auto-date-histo-memory-usage-1000",
-  "operation-type": "search",
-  {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
-  "index": "k8s",
-  {%- else %}
-  "index": "tsdb",
-  {% endif %}
-  "body": {
-    "size": 0,
-    "aggs": {
-      "by_date": {
-        "auto_date_histogram": {
-          "field": "@timestamp",
-          "buckets": "1000"
-        },
-        "aggs": {
-          "ts": {
-            "time_series": {
-              "keyed": false
-            },
-            "aggs": {
-              "total_memory_usage_by_date": {
-                "sum": {
-                  "field": "kubernetes.container.memory.usage.bytes"
-                }
-              }
-            }
-          },
-          "min_total_memory_usage_by_date": {
-            "min_bucket": {
-              "buckets_path": "ts>total_memory_usage_by_date"
-            }
-          }
-        }
-      }
-    }
-  }
-},
-{
-  "name": "terms-container-name-memory-usage",
-  "operation-type": "search",
-  {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
-  "index": "k8s",
-  {%- else %}
-  "index": "tsdb",
-  {% endif %}
-  "body": {
-    "size": 0,
-    "aggs": {
-      "container_name": {
-        "terms": {
-          "field": "kubernetes.container.name"
-        },
-        "aggs": {
-          "ts": {
-            "time_series": {
-              "keyed": false
-            },
-            "aggs": {
-              "total_memory_usage_by_container_name": {
-                "sum": {
-                  "field": "kubernetes.container.memory.usage.bytes"
-                }
-              }
-            }
-          },
-          "min_total_memory_usage_by_container_name": {
-            "min_bucket": {
-              "buckets_path": "ts>total_memory_usage_by_container_name"
-            }
-          }
-        }
-      }
-    }
-  }
-},
-{
-  "name": "terms-container-image-memory-usage",
-  "operation-type": "search",
-  {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
-  "index": "k8s",
-  {%- else %}
-  "index": "tsdb",
-  {% endif %}
-  "body": {
-    "size": 0,
-    "aggs": {
-      "container_image": {
-        "terms": {
-          "field": "kubernetes.container.image"
-        },
-        "aggs": {
-          "ts": {
-            "time_series": {
-              "keyed": false
-            },
-            "aggs": {
-              "total_memory_usage_by_container_image": {
-                "sum": {
-                  "field": "kubernetes.container.memory.usage.bytes"
-                }
-              }
-            }
-          },
-          "min_total_memory_usage_by_container_image": {
-            "min_bucket": {
-              "buckets_path": "ts>total_memory_usage_by_container_image"
-            }
-          }
-        }
-      }
-    }
-  }
-}


### PR DESCRIPTION
This reverts commit 1209733fae6f2557d71a5a6e4a9f022f873160a3, the `date-histo-memory-usage-minute` task trips the `too_many_buckets_exception` circuit breaker:
```
08:48:13 [ERROR] Cannot race. Error in load generator [0]
08:48:13 	Cannot run task [date-histo-memory-usage-minute]: Request returned an error. Error type: transport, Description: search_phase_execution_exception ({'error': {'root_cause': [], 'type': 'search_phase_execution_exception', 'reason': '', 'phase': 'fetch', 'grouped': True, 'failed_shards': [], 'caused_by': {'type': 'too_many_buckets_exception', 'reason': 'Trying to create too many buckets. Must be less than or equal to: [300000] but this number of buckets was exceeded. This limit can be set by changing the [search.max_buckets] cluster level setting.', 'max_buckets': 300000}}, 'status': 503})
```