### PR TITLE
Only run tsdb aggregations when index.mode=time_series

### DIFF
--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -138,8 +138,9 @@
           "operation": "date-histo-entire-range",
           "warmup-iterations": 50,
           "iterations": 100
-        },
-        {
+        }
+        {% if index_mode | default('time_series') is equalto 'time_series' and skip_running_tsdb_aggs is not defined %}
+        ,{
           "operation": "date-histo-memory-usage-hour",
           "warmup-iterations": 50,
           "iterations": 100
@@ -169,6 +170,7 @@
           "warmup-iterations": 50,
           "iterations": 100
         }
+        {% endif %}
       ]
     },
     {


### PR DESCRIPTION
and added a escape hatch to skip running tsdb aggregations.
The latter is useful since benchmarking tsdb queries take a while and when
for example only index performance is benchmarked then it makes sense to
skip running tsdb aggregations.