### PR TITLE
logs: Add disable_pipelines indexing parameter

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -239,7 +239,7 @@ The following parameters are available:
 * `bulk_indexing_clients` (default: 8) - The number of clients issuing indexing requests.
 * `bulk_size` (default: 1000) - The number of documents to send per indexing request.
 * `throttle_indexing` (default: `false`) - Whether indexing should be throttled to the rate determined by `raw_data_volume_per_day`, assuming a uniform distribution of data, or whether indexing should go as fast as possible. 
-* `disable_pipelines` (default: `false`) - Toggle ingest node pipelines. 
+* `disable_pipelines` (default: `false`) - Toggle ingest node pipelines. This parameter is experimental and is to be used with indexing-only challenges.
 
 ### Querying parameters
 

--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -239,6 +239,7 @@ The following parameters are available:
 * `bulk_indexing_clients` (default: 8) - The number of clients issuing indexing requests.
 * `bulk_size` (default: 1000) - The number of documents to send per indexing request.
 * `throttle_indexing` (default: `false`) - Whether indexing should be throttled to the rate determined by `raw_data_volume_per_day`, assuming a uniform distribution of data, or whether indexing should go as fast as possible. 
+* `disable_pipelines` (default: `false`) - Toggle ingest node pipelines. 
 
 ### Querying parameters
 

--- a/elastic/logs/tasks/index-setup.json
+++ b/elastic/logs/tasks/index-setup.json
@@ -1,3 +1,4 @@
+{%- if disable_pipelines is not true %}
 {
   "name":"insert-pipelines",
   "tags": ["setup"],
@@ -6,6 +7,7 @@
     "param-source": "add-track-path"
   }
 },
+{%- endif %}
 {
   "name": "insert-ilm",
   "tags": ["setup"],

--- a/elastic/logs/templates/component/.fleet_component_template-1.json
+++ b/elastic/logs/templates/component/.fleet_component_template-1.json
@@ -2,7 +2,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "final_pipeline": ".fleet_final_pipeline-1"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-apache.access.json
+++ b/elastic/logs/templates/composable/logs-apache.access.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-apache.access-1.3.0"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-apache.error.json
+++ b/elastic/logs/templates/composable/logs-apache.error.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-apache.error-1.3.0"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -22,7 +22,9 @@
             "message"
           ]
         },
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-k8-app",
+        {%- endif %}
         "number_of_routing_shards": "30"
       }
     },

--- a/elastic/logs/templates/composable/logs-kafka.log.json
+++ b/elastic/logs/templates/composable/logs-kafka.log.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-kafka.log-0.5.0"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-mysql.error.json
+++ b/elastic/logs/templates/composable/logs-mysql.error.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-mysql.error-1.1.0"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-mysql.slowlog.json
+++ b/elastic/logs/templates/composable/logs-mysql.slowlog.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-mysql.slowlog-1.1.0"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-nginx.access.json
+++ b/elastic/logs/templates/composable/logs-nginx.access.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-nginx.access-1.2.0"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-nginx.error.json
+++ b/elastic/logs/templates/composable/logs-nginx.error.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-nginx.error-1.2.0"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-postgresql.log.json
+++ b/elastic/logs/templates/composable/logs-postgresql.log.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-postgresql.log-1.2.0"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-redis.log.json
+++ b/elastic/logs/templates/composable/logs-redis.log.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-redis.log-1.1.0"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-redis.slowlog.json
+++ b/elastic/logs/templates/composable/logs-redis.slowlog.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-redis.slowlog-1.1.0"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-system.auth.json
+++ b/elastic/logs/templates/composable/logs-system.auth.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-system.auth-1.6.4"
+        {%- endif %}
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-system.syslog.json
+++ b/elastic/logs/templates/composable/logs-system.syslog.json
@@ -5,7 +5,9 @@
   "template": {
     "settings": {
       "index": {
+        {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-system.syslog-1.6.4"
+        {%- endif %}
       }
     },
     "mappings": {


### PR DESCRIPTION
Add the capability to disable ingest node pipelines to fulfill the [first stage](https://github.com/elastic/elasticsearch-benchmarks/issues/1002) requirement for benchmarking stateless Elasticsearch.

* Disable ingest node pipelines if `disable_pipelines: true`.
* Do not load ingest node pipelines if `disable_pipelines: true`.
* Update the README.

