### PR TITLE
elastic/logs: Fix 0 indexed docs for postgresql-logs and redis-slowlogs

### DIFF
--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -72,14 +72,15 @@
         "mysql-error-logs": 0.01
       }
     },
-    "kafka": {
+    "postgresql": {
       "corpora": {
-        "kafka-logs": 0.025
+        "postgresql-logs": 0.025
       }
     },
     "redis": {
       "corpora": {
-        "redis-app-logs": 0.01
+        "redis-app-logs": 0.01,
+        "redis-app-slowlogs": 0.025
       }
     },
     "system": {

--- a/it/test_logs.py
+++ b/it/test_logs.py
@@ -45,7 +45,7 @@ def params(updates=None):
 class TestLogs:
     def test_logs_fails_if_assets_not_installed(self, es_cluster, rally, capsys):
         ret = rally.race(track="elastic/logs", exclude_tasks="tag:setup")
-        message = "Index templates missing for packages: ['apache', 'kafka', 'mysql', 'nginx', 'redis', 'system']"
+        message = "Index templates missing for packages: ['apache', 'kafka', 'mysql', 'nginx', 'postgresql', 'redis', 'system']"
         stdout = capsys.readouterr().out
         assert message in stdout
         assert ret != 0


### PR DESCRIPTION
This PR corrects an [observed bulk indexing issue](https://github.com/elastic/elasticsearch-benchmarks/issues/1212#issuecomment-1307865814) for the postgresql.log and redis.slowlog data streams where each is receiving 0 documents. The before and after runs below were executed in test mode. Logging snapshots are missing data for these two data streams and will need to be regenerated for query benchmarks.

### Rally Invocation

```sh
$ esrally race --track-path=$TPATH --challenge=logging-indexing --pipeline=benchmark-only --test-mode --kill-running-processes --target-hosts $THOST --client-option=$COPTS
``` 

### Before PR

```diff
GET /_cat/indices?v=null&s=docs.count:asc

health status index                                                 uuid                   pri rep docs.count docs.deleted store.size pri.store.size
-green  open   .ds-logs-postgresql.log-default-2022.12.28-000001     y_GELswWSLuvlRwNp8VGKA   1   1          0            0       450b           225b
-green  open   .ds-logs-redis.slowlog-default-2022.12.28-000001      jmRElvoOSEOC9hWsz17WFg   1   1          0            0       450b           225b
green  open   .ds-logs-mysql.slowlog-default-2022.12.28-000001      9hajLJ_5TsCO-nTgKHHiHA   1   1       2500            0      2.7mb            1mb
green  open   .ds-logs-mysql.error-default-2022.12.28-000001        bCIpoL3QTuOYE2c0Al4jTw   1   1       3617            0      1.8mb        938.5kb
green  open   .ds-logs-nginx.error-default-2022.12.28-000001        OHRiGpi1Q4yZ1SdGGiMM3w   1   1       7000            0      2.5mb          1.4mb
green  open   .ds-logs-apache.error-default-2022.12.28-000001       5nvbDtuMSLyBh-TrN8HaHg   1   1       9500            0      3.3mb          1.6mb
green  open   .ds-logs-kafka.log-default-2022.12.28-000001          8ibO7tZnTTu3I78pA2wnqQ   1   1      11000            0      2.7mb          1.3mb
green  open   .ds-logs-apache.access-default-2022.12.28-000001      34-gBuAmTxuC9MBHSWtAcA   1   1      13500            0      4.4mb          2.3mb
green  open   .ds-logs-redis.log-default-2022.12.28-000001          BgDQZJnfSsKpWKTBigdurA   1   1      16500            0      2.6mb          1.5mb
green  open   .ds-logs-system.auth-default-2022.12.28-000001        aGCRytfqRCm3zXgshS20Yw   1   1      17000            0      6.6mb          3.3mb
green  open   .ds-logs-nginx.access-default-2022.12.28-000001       DSU-MEeKSgW56vwSNmIbaA   1   1      28628            0     13.4mb          6.7mb
green  open   .ds-logs-system.syslog-default-2022.12.28-000001      ORsXVrQ4Su2dHNWzjLal8g   1   1      36376            0      9.2mb          4.6mb
green  open   .ds-logs-k8-application.log-default-2022.12.28-000001 8WZ2tVdmTQmNUjk6UncaRQ   1   1     328996            0    111.6mb         55.8mb
```

### After PR

```diff
GET /_cat/indices?v=null&s=docs.count:asc

health status index                                                 uuid                   pri rep docs.count docs.deleted store.size pri.store.size
green  open   .ds-logs-nginx.error-default-2022.12.28-000001        clpA8edASPqBzpoGXSW59w   1   1       2500            0      1.8mb        854.2kb
+green  open   .ds-logs-postgresql.log-default-2022.12.28-000001     4wiOIvFXQbuEUxi3yr38Ng   1   1       7066            0      2.1mb            1mb
green  open   .ds-logs-mysql.slowlog-default-2022.12.28-000001      c_-sB5rUSMev-3jvHLwwcw   1   1       8562            0      2.7mb          1.4mb
green  open   .ds-logs-mysql.error-default-2022.12.28-000001        RryGLHveT2GkG52qI35zwQ   1   1       9000            0      1.8mb        935.7kb
green  open   .ds-logs-apache.error-default-2022.12.28-000001       VcVhNu5dT7-qgZjDOMiZ-A   1   1       9624            0      2.8mb          1.6mb
green  open   .ds-logs-kafka.log-default-2022.12.28-000001          MFiszLhKSl6PuqdadZmUKw   1   1      13000            0      3.5mb          1.7mb
green  open   .ds-logs-apache.access-default-2022.12.28-000001      7aKL2VXySXiYqHK2e6LfNQ   1   1      13500            0      7.4mb          3.6mb
green  open   .ds-logs-system.auth-default-2022.12.28-000001        -0fz5Gu0R-exL-zIxiJm1Q   1   1      16500            0      6.5mb          3.2mb
+green  open   .ds-logs-redis.slowlog-default-2022.12.28-000001      8iEYo2bcR1umTvkHwNP5nQ   1   1      17310            0      8.8mb          4.4mb
green  open   .ds-logs-redis.log-default-2022.12.28-000001          Voy4D6ruRq67-F-uoUjsWQ   1   1      20000            0      3.8mb          1.9mb
green  open   .ds-logs-nginx.access-default-2022.12.28-000001       9yL6xC-iQgi_btIm5kMUvg   1   1      28000            0     21.5mb         10.8mb
green  open   .ds-logs-system.syslog-default-2022.12.28-000001      D6LVoClUSqabxINiXJ_t4A   1   1      34000            0      8.7mb          4.3mb
green  open   .ds-logs-k8-application.log-default-2022.12.28-000001 6gKiirjnTkWpv8szaZ7GVA   1   1     309566            0    104.1mb           52mb
```