### PR TITLE
Use `null` to reset cluster settings in CCS challenges

### DIFF
--- a/elastic/logs/challenges/cross-clusters-search-and-replication.json
+++ b/elastic/logs/challenges/cross-clusters-search-and-replication.json
@@ -58,9 +58,9 @@
         "path": "/_cluster/settings",
         "body": {
           "persistent": {
-            "indices.recovery.max_bytes_per_sec": -1,
-            "cluster.routing.allocation.node_concurrent_recoveries": -1,
-            "cluster.routing.allocation.node_initial_primaries_recoveries": -1
+            "indices.recovery.max_bytes_per_sec": null,
+            "cluster.routing.allocation.node_concurrent_recoveries": null,
+            "cluster.routing.allocation.node_initial_primaries_recoveries": null
           }
         }
       }

--- a/elastic/logs/challenges/cross-clusters-search-and-snapshot.json
+++ b/elastic/logs/challenges/cross-clusters-search-and-snapshot.json
@@ -138,9 +138,9 @@
         "path": "/_cluster/settings",
         "body": {
           "persistent": {
-            "indices.recovery.max_bytes_per_sec": -1,
-            "cluster.routing.allocation.node_concurrent_recoveries": -1,
-            "cluster.routing.allocation.node_initial_primaries_recoveries": -1
+            "indices.recovery.max_bytes_per_sec": null,
+            "cluster.routing.allocation.node_concurrent_recoveries": null,
+            "cluster.routing.allocation.node_initial_primaries_recoveries": null
           }
         }
       }


### PR DESCRIPTION
`-1` works for some cluster settings, but not others. `null` is a safer option. 