### PR TITLE
Add a split corpora to TSDB to allow sequential indexing

### DIFF
--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -155,6 +155,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `index_mode` (default: time_series): Whether to make a standard index (`standard`) or time series index (`time_series`)
 * `codec` (default: default): The codec to use compressing the index. `default` uses more space and less cpu. `best_compression` uses less space and more cpu.
 * `ingest_mode` (default: index) Should be `data_stream` to benchmark ingesting into a tsdb data stream.
+* `corpus` (default: full) Should be `split` to use a corpus split in 16 to be used with 16 indexing clients and index mostly in @timestamp order.
 
 ### License
 

--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -155,7 +155,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `index_mode` (default: time_series): Whether to make a standard index (`standard`) or time series index (`time_series`)
 * `codec` (default: default): The codec to use compressing the index. `default` uses more space and less cpu. `best_compression` uses less space and more cpu.
 * `ingest_mode` (default: index) Should be `data_stream` to benchmark ingesting into a tsdb data stream.
-* `corpus` (default: full) Should be `split` to use a corpus split in 16 to be used with 16 indexing clients and index mostly in @timestamp order.
+* `corpus` (default: full) Should be `split16` to use a corpus split in 16 to be used with 16 indexing clients and index mostly in @timestamp order.
 
 ### License
 

--- a/tsdb/_tools/split.py
+++ b/tsdb/_tools/split.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Split a documents.json files in X parts
+# https://github.com/elastic/rally/issues/1650#issuecomment-1378344368
+
+import contextlib
+import sys
+
+path = sys.argv[1]
+n_splits = int(sys.argv[2])
+
+
+with contextlib.ExitStack() as stack, open(path, "r") as f:
+    full_filenames = [f"documents-split-{i}.json" for i in range(n_splits)]
+    short_filenames = [f"documents-split-{i}-1k.json" for i in range(n_splits)]
+
+    full_output_files = [stack.enter_context(open(fname, "w")) for fname in full_filenames]
+    short_output_files = [stack.enter_context(open(fname, "w")) for fname in short_filenames]
+
+    for i, line in enumerate(f):
+        if i % 1_000_000 == 0:
+            print(i)
+        full_output_files[i % n_splits].write(line)
+        if i < n_splits * 1000:
+            short_output_files[i % n_splits].write(line)

--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -29,7 +29,7 @@
     {
       "name": "tsdb",
       "base-url": "https://rally-tracks.elastic.co/tsdb",
-      {%- if corpus is defined and corpus == "split" %}
+      {%- if corpus is defined and corpus == "split16" %}
         "documents": [
           {
             "source-file": "documents-split-0.json.bz2",

--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -29,13 +29,98 @@
     {
       "name": "tsdb",
       "base-url": "https://rally-tracks.elastic.co/tsdb",
-      "documents": [
-        {
-          "source-file": "documents.json.bz2",
-          "document-count": 116633698,
-          "uncompressed-bytes": 132046338827
-        }
-      ]
+      {%- if corpus is defined and corpus == "split" %}
+        "documents": [
+          {
+            "source-file": "documents-split-0.json.bz2",
+            "document-count": 7289607,
+            "uncompressed-bytes": 8252385790
+          },
+          {
+            "source-file": "documents-split-1.json.bz2",
+            "document-count": 7289607,
+            "uncompressed-bytes": 8252715218
+          },
+          {
+            "source-file": "documents-split-2.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8252482193
+          },
+          {
+            "source-file": "documents-split-3.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8253066083
+          },
+          {
+            "source-file": "documents-split-4.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8252686254
+          },
+          {
+            "source-file": "documents-split-5.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8252842205
+          },
+          {
+            "source-file": "documents-split-6.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8252839714
+          },
+          {
+            "source-file": "documents-split-7.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8253327643
+          },
+          {
+            "source-file": "documents-split-8.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8252994659
+          },
+          {
+            "source-file": "documents-split-9.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8253163552
+          },
+          {
+            "source-file": "documents-split-10.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8252932917
+          },
+          {
+            "source-file": "documents-split-11.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8252752704
+          },
+          {
+            "source-file": "documents-split-12.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8253251862
+          },
+          {
+            "source-file": "documents-split-13.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8253166730
+          },
+          {
+            "source-file": "documents-split-14.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8252927958
+          },
+          {
+            "source-file": "documents-split-15.json.bz2",
+            "document-count": 7289606,
+            "uncompressed-bytes": 8252803345
+          }
+        ]
+      {%- else %}
+        "documents": [
+          {
+            "source-file": "documents.json.bz2",
+            "document-count": 116633698,
+            "uncompressed-bytes": 132046338827
+          }
+        ]
+      {%- endif %}
     }
   ],
   "operations": [


### PR DESCRIPTION
As detailed here: https://github.com/elastic/rally/issues/1650

Can be tested with `esrally race --distribution-version=8.6.0 --track-path=$HOME/src/rally-tracks/tsdb --track-params="corpus:split,bulk_indexing_clients:16"`