### PR TITLE
[ESQL] Add more tests to the ESQL challenge

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -828,7 +828,6 @@
           "warmup-iterations": 10,
           "iterations": 50
         },
-
         {
           "operation": "avg_amount_group_by_keyword_aggregation",
           "clients": 1,
@@ -859,7 +858,6 @@
           "warmup-iterations": 10,
           "iterations": 50
         }, 
-
         {
           "operation": "sort_by_ts_query",
           "clients": 1,

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -669,8 +669,8 @@
       ]
     },
     {
-      "name": "compute-engine",
-      "description": "Checks the performance of compute engine",
+      "name": "esql",
+      "description": "Performance benchmarks for the ESQL compute engine",
       "default": false,
       "schedule": [
         {
@@ -739,6 +739,36 @@
           "iterations": 50
         },
         {
+          "operation": "avg_passenger_count_filtered_aggregation",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_passenger_count_filtered_esql_shard_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_passenger_count_filtered_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_passenger_count_filtered_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_passenger_count_filtered_esql_shard_partitioning_with_task_parallelism",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
           "operation": "avg_tip_percent_aggregation",
           "clients": 1,
           "warmup-iterations": 10,
@@ -794,6 +824,68 @@
         },
         {
           "operation": "avg_amount_group_by_integer_esql_shard_partitioning_with_task_parallelism",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+
+        {
+          "operation": "avg_amount_group_by_keyword_aggregation",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_amount_group_by_keyword_esql_shard_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_amount_group_by_keyword_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_amount_group_by_keyword_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_amount_group_by_keyword_esql_shard_partitioning_with_task_parallelism",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        }, 
+
+        {
+          "operation": "sort_by_ts_query",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "sort_by_ts_esql_shard_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "sort_by_ts_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "sort_by_ts_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "sort_by_ts_esql_shard_partitioning_with_task_parallelism",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -767,6 +767,36 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
+        },
+        {
+          "operation": "avg_amount_group_by_integer_aggregation",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_amount_group_by_integer_esql_shard_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_amount_group_by_integer_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_amount_group_by_integer_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_amount_group_by_integer_esql_shard_partitioning_with_task_parallelism",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
         }
       ]
     }

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -734,6 +734,7 @@
     {
       "name": "avg_tip_percent_aggregation",
       "operation-type": "search",
+      "request-timeout": 120,
       "body": {
         "size": 0,
         "runtime_mappings": {
@@ -805,6 +806,7 @@
     {
       "name": "avg_amount_group_by_integer_aggregation",
       "operation-type": "search",
+      "request-timeout": 120,
       "body": {
         "size": 0,
         "aggs": {
@@ -878,6 +880,7 @@
     {
       "name": "avg_amount_group_by_keyword_aggregation",
       "operation-type": "search",
+      "request-timeout": 120,
       "body": {
         "size": 0,
         "aggs": {
@@ -1046,6 +1049,7 @@
       "operation-type": "raw-request",
       "method": "POST",
       "path": "/_esql",
+      "request-timeout": 120,
       "body": {
         "query" : "from nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance| limit 1000",
         "pragma" : {
@@ -1058,6 +1062,7 @@
       "operation-type": "raw-request",
       "method": "POST",
       "path": "/_esql",
+      "request-timeout": 120,
       "body": {
         "query" : "from nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance| limit 1000",
         "pragma" : {
@@ -1070,6 +1075,7 @@
       "operation-type": "raw-request",
       "method": "POST",
       "path": "/_esql",
+      "request-timeout": 120,
       "body": {
         "query" : "from nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance| limit 1000",
         "pragma" : {
@@ -1082,6 +1088,7 @@
       "operation-type": "raw-request",
       "method": "POST",
       "path": "/_esql",
+      "request-timeout": 120,
       "body": {
         "query" : "from nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance| limit 1000",
         "pragma" : {

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -801,5 +801,80 @@
           "add_task_parallelism_above_query" : true
         }
       }
-    }
+    },
 
+    {
+      "name": "avg_amount_group_by_integer_aggregation",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+            "by_passenger_count": {
+                "terms": {
+                    "field": "passenger_count",
+                    "order": {
+                        "_key": "asc"
+                    }
+                },
+                "aggs": {
+                    "avg_total_amount": {
+                        "avg": {
+                            "field": "total_amount"
+                        }
+                    }
+                }
+            }
+        }
+      }
+    },
+    {
+      "name": "avg_amount_group_by_integer_esql_shard_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count",
+        "pragma" : {
+          "data_partitioning" : "shard"
+        }
+      }
+    },
+
+
+    {
+      "name": "avg_amount_group_by_integer_esql_segment_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count",
+        "pragma" : {
+          "data_partitioning" : "segment"
+        }
+      }
+    },
+    {
+      "name": "avg_amount_group_by_integer_esql_doc_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count",
+        "pragma" : {
+          "data_partitioning" : "doc"
+        }
+      }
+    },
+    {
+      "name": "avg_amount_group_by_integer_esql_shard_partitioning_with_task_parallelism",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count",
+        "pragma" : {
+          "data_partitioning" : "shard",
+          "add_task_parallelism_above_query" : true
+        }
+      }
+    }

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -1029,7 +1029,6 @@
         }
       }
     },
-
     {
       "name": "sort_by_ts_query",
       "operation-type": "search",

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -802,7 +802,6 @@
         }
       }
     },
-
     {
       "name": "avg_amount_group_by_integer_aggregation",
       "operation-type": "search",
@@ -839,8 +838,6 @@
         }
       }
     },
-
-
     {
       "name": "avg_amount_group_by_integer_esql_segment_partitioning",
       "operation-type": "raw-request",
@@ -872,6 +869,222 @@
       "path": "/_esql",
       "body": {
         "query" : "from nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count",
+        "pragma" : {
+          "data_partitioning" : "shard",
+          "add_task_parallelism_above_query" : true
+        }
+      }
+    },
+    {
+      "name": "avg_amount_group_by_keyword_aggregation",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "aggs": {
+            "by_rate_code_id": {
+                "terms": {
+                    "field": "rate_code_id",
+                    "order": {
+                        "_key": "asc"
+                    }
+                },
+                "aggs": {
+                    "avg_total_amount": {
+                        "avg": {
+                            "field": "total_amount"
+                        }
+                    }
+                }
+            }
+        }
+      }
+    },
+    {
+      "name": "avg_amount_group_by_keyword_esql_shard_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id",
+        "pragma" : {
+          "data_partitioning" : "shard"
+        }
+      }
+    },
+    {
+      "name": "avg_amount_group_by_keyword_esql_segment_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id",
+        "pragma" : {
+          "data_partitioning" : "segment"
+        }
+      }
+    },
+    {
+      "name": "avg_amount_group_by_keyword_esql_doc_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id",
+        "pragma" : {
+          "data_partitioning" : "doc"
+        }
+      }
+    },
+    {
+      "name": "avg_amount_group_by_keyword_esql_shard_partitioning_with_task_parallelism",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id",
+        "pragma" : {
+          "data_partitioning" : "shard",
+          "add_task_parallelism_above_query" : true
+        }
+      }
+    },
+    {
+      "name": "avg_passenger_count_filtered_aggregation",
+      "operation-type": "search",
+      "body": {
+        "size": 0,
+        "query": {
+            "bool": {
+                "filter": [
+                    {
+                        "term": {
+                            "rate_code_id": "2"
+                        }
+                    },
+                    {
+                        "range": {
+                            "total_amount": {
+                                "gt": 60
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "aggs": {
+            "avg_passenger_count": {
+                "avg": {
+                    "field": "passenger_count"
+                }
+            }
+        }
+      }
+    },
+    {
+      "name": "avg_passenger_count_filtered_esql_shard_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | where total_amount > 60 and rate_code_id==\"2\"| stats avg(passenger_count)",
+        "pragma" : {
+          "data_partitioning" : "shard"
+        }
+      }
+    },
+    {
+      "name": "avg_passenger_count_filtered_esql_segment_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | where total_amount > 60 and rate_code_id==\"2\"| stats avg(passenger_count)",
+        "pragma" : {
+          "data_partitioning" : "segment"
+        }
+      }
+    },
+    {
+      "name": "avg_passenger_count_filtered_esql_doc_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | where total_amount > 60 and rate_code_id==\"2\"| stats avg(passenger_count)",
+        "pragma" : {
+          "data_partitioning" : "doc"
+        }
+      }
+    },
+    {
+      "name": "avg_passenger_count_filtered_esql_shard_partitioning_with_task_parallelism",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | where total_amount > 60 and rate_code_id==\"2\"| stats avg(passenger_count)",
+        "pragma" : {
+          "data_partitioning" : "shard",
+          "add_task_parallelism_above_query" : true
+        }
+      }
+    },
+
+    {
+      "name": "sort_by_ts_query",
+      "operation-type": "search",
+      "body": {
+        "size": 1000,
+        "_source": false,
+        "fields": ["pickup_datetime", "dropoff_datetime", "trip_distance"],
+        "sort": {
+            "pickup_datetime": "desc"
+        }
+      }
+    },
+    {
+      "name": "sort_by_ts_esql_shard_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance| limit 1000",
+        "pragma" : {
+          "data_partitioning" : "shard"
+        }
+      }
+    },
+    {
+      "name": "sort_by_ts_esql_segment_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance| limit 1000",
+        "pragma" : {
+          "data_partitioning" : "segment"
+        }
+      }
+    },
+    {
+      "name": "sort_by_ts_esql_doc_partitioning",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance| limit 1000",
+        "pragma" : {
+          "data_partitioning" : "doc"
+        }
+      }
+    },
+    {
+      "name": "sort_by_ts_esql_shard_partitioning_with_task_parallelism",
+      "operation-type": "raw-request",
+      "method": "POST",
+      "path": "/_esql",
+      "body": {
+        "query" : "from nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance| limit 1000",
         "pragma" : {
           "data_partitioning" : "shard",
           "add_task_parallelism_above_query" : true


### PR DESCRIPTION
Add more tests to the ESQL challenge for the nyc taxis dataset. 

As a baseline for measuring performance, we are using the current aggregations framework, so that we can compare performance between ESQL and the existing functionality.

The following benchmarks are added: 

#### Filtered avg `passenger_count`
This query can be compared with the already existing non-filtered avg `passenger_count` 

```
from nyc_taxis | where total_amount > 1 and rate_code_id=="2" | stats avg(passenger_count), count(passenger_count)
```

#### Average `total_amount` grouped by `integer` field `passenger_count`
```
from nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count
```

#### Average `total_amount` grouped by a low cardinality`keyword` field `rate_code_id`
```
from nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id
```

#### Retrieve resultes sorted by timestamp field
```
from nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance| limit 1000
```

### Different partitioning methods

Each benchmark is executed with all combinations of different partitioning methods and consequently a different parallelization strategies:

- Current aggs framework through the `_search` endpoint. Query runs on a single thread as the index has only on 1 shard
- The `_esql` endpoint using partitioning by shard. This also runs on a single thread so we can compare performance with the existing aggs
- The `_esql` endpoint partitioned by segment. 
- The `_esql` endpoint using doc partitioning
- The `_esql` endpoint using shard partitioning, enabling task parallelization