### PR TITLE
Exclude sort by field operations when runtime fields are benchmarked in http_logs

### DIFF
--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -184,6 +184,7 @@
           "iterations": 100,
           "target-throughput": 2
         },
+{%- if not runtime_fields is defined %}
         {
           "operation": "sort_keyword_can_match_shortcut",
           "warmup-iterations": 200,
@@ -208,6 +209,7 @@
           "iterations": 100,
           "target-throughput": 2
         },
+{%- endif %}
         {
           "name": "force-merge-1-seg",
           "operation": {


### PR DESCRIPTION
With #357 I introduced new challenges to benchmark sort by field with and without can_match enabled. These break the http_logs track when it's run with `runtime_fields:true` parameter because the fields I am sorting on are not mapped.

With this PR we don't execute such operations when in runtime_fields mode.