### PR TITLE
tsdb: set default source mode to synthetic

### DIFF
--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -151,7 +151,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
-* `source_mode` (default: stored): Should the `_source` be `stored` to disk exactly as sent (the default), thrown away (`disabled`), or reconstructed on the fly (`synthetic`)
+* `source_mode` (default: synthetic): Should the `_source` be `stored` to disk exactly as sent (the Elasticsearch default outside of TSDB mode), thrown away (`disabled`), or reconstructed on the fly (`synthetic`)
 * `index_mode` (default: time_series): Whether to make a standard index (`standard`) or time series index (`time_series`)
 * `codec` (default: default): The codec to use compressing the index. `default` uses more space and less cpu. `best_compression` uses less space and more cpu.
 * `ingest_mode` (default: index) Should be `data_stream` to benchmark ingesting into a tsdb data stream.

--- a/tsdb/index-mappings.json
+++ b/tsdb/index-mappings.json
@@ -5174,7 +5174,7 @@
           },
           "message": {
             "type": "text",
-            "norms": false{% if source_mode == "synthetic" %},
+            "norms": false{% if p_source_mode == "synthetic" %},
             "store": true
             {% endif %}
           },
@@ -8521,7 +8521,7 @@
               },
               "message": {
                 "type": "text",
-                "norms": false,{% if source_mode != "synthetic" %}
+                "norms": false,{% if p_source_mode != "synthetic" %}
                 "copy_to": [
                   "message"
                 ]{% else %}
@@ -10143,7 +10143,7 @@
       },
       "message": {
         "type": "text",
-        "norms": false{% if source_mode == "synthetic" %},
+        "norms": false{% if p_source_mode == "synthetic" %},
         "store": true
         {% endif %}
       },

--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -1,5 +1,6 @@
 {% import "rally.helpers" as rally with context %}
-
+{# TODO By default, source_mode should be "synthetic" if index_mode == "time_series" else "stored" #}
+{% set p_source_mode = (source_mode | default("synthetic")) %}
 {
   "index_patterns": ["k8s*"],
   "data_stream": {},
@@ -22,7 +23,7 @@
         "version": "7.6.2"
       },
       "_source": {
-        "mode": {{ source_mode | default("stored") | tojson }}
+        "mode": {{ p_source_mode | tojson }}
       },
       "dynamic_templates": [
         {

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -1,5 +1,6 @@
 {% import "rally.helpers" as rally with context %}
-
+{# TODO By default, source_mode should be "synthetic" if index_mode == "time_series" else "stored" #}
+{% set p_source_mode = (source_mode | default("synthetic")) %}
 {
   "settings": {
     "index": {
@@ -31,7 +32,7 @@
       "version": "7.6.2"
     },
     "_source": {
-      "mode": {{ source_mode | default("stored") | tojson }}
+      "mode": {{ p_source_mode | tojson }}
     },
     "dynamic_templates": [
       {
@@ -545,7 +546,7 @@
         "strings_as_keyword": {
           "match_mapping_type": "string",
           "mapping": {
-            "type": "keyword"{% if source_mode != "synthetic" %},"ignore_above": 1024{% endif %}
+            "type": "keyword"{% if p_source_mode != "synthetic" %},"ignore_above": 1024{% endif %}
           }
         }
       }


### PR DESCRIPTION
Now that Elasticsearch [enforces synthetic source mode for TSDB](https://github.com/elastic/elasticsearch/pull/93380), let's allow all challenges to work with default values, which meant setting the default source mode to `synthetic`. In future work, we want to rely on Elasticsearch to set the default source mode.

Tested with:

 * esrally race --revision=9babcc9bb9a277174d43fa5c583268f642a83983 --track-path=$HOME/src/rally-tracks/tsdb --test-mode --on-error=abort --kill-running-processes
 * esrally race --revision=9babcc9bb9a277174d43fa5c583268f642a83983 --track-path=$HOME/src/rally-tracks/tsdb --test-mode --on-error=abort --kill-running-processes --track-params=index_mode:standard,source_mode:synthetic
 * esrally race --revision=9babcc9bb9a277174d43fa5c583268f642a83983 --track-path=$HOME/src/rally-tracks/tsdb --test-mode --on-error=abort --kill-running-processes --track-params=index_mode:standard,source_mode:stored

And I checked that the index settings were as expected. This should fix the rally-tracks compatibility tests.