### PR TITLE
tsdb: Fix split16 to avoid indexing 14 docs from the end

### DIFF
--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -114,9 +114,9 @@ TMPDIR=tmp ~/Downloads/jlsort/target/release/jlsort -k '@timestamp' data-anonymi
 rm -rf tmp
 ```
 
-Finally you'll also need a deduped version of the data in order to to support the `ingest_mode` that 
-benchmarks ingesting into a tsdb data stream (`data_stream`). Use the `dedupe.py` tool in the 
-`_tools` directory. This tool needs `data-sorted.json` as input via standard in and generates a 
+Finally you'll also need a deduped version of the data in order to to support the `ingest_mode` that
+benchmarks ingesting into a tsdb data stream (`data_stream`). Use the `dedupe.py` tool in the
+`_tools` directory. This tool needs `data-sorted.json` as input via standard in and generates a
 deduped variant via standard out.
 
 ```
@@ -140,6 +140,36 @@ pbzip2 documents.json
 ```
 
 Now upload all of that to the AWS location from `track.json`.
+
+### Generating the split16 corpus
+
+By default, with N indexing clients Rally will split documents.json in N parts and bulk index from
+them in parallel. As a result, by default ingest is not done in order, which makes TSDB sorting
+appear more costly than it really is. To work around this issue, we rearrange the original corpora
+by splitting it in 16 parts (the number of indexing clients we use in practice in benchmarks) so
+that indexing is done in roughly order.
+
+To generate that corpus, first split the data in 16 files:
+
+```
+_tools/split.py ~/.rally/benchmarks/data/tsdb/documents.json 16
+```
+
+Note that this is a destructive operation! It will drop up to 15 documents so that the resulting
+file contains a number of documents that is a multiple of 16 to ensure that Rally will split the
+file as expected.
+
+Now generate a single file again out of the splits:
+
+```
+cat documents-split-0.json documents-split-1.json documents-split-2.json documents-split-3.json documents-split-4.json documents-split-5.json documents-split-6.json documents-split-7.json documents-split-8.json documents-split-9.json documents-split-10.json documents-split-11.json documents-split-12.json documents-split-13.json documents-split-14.json documents-split-15.json > documents-split16-v2.json
+```
+
+The versioning (v2 here) ensures that nobody will use an old version of that corpus by accident.
+
+Finally, as shown above, you can now then generate the 1k documents version, run pbzip2 on both
+versions and upload the two resulting files to AWS.
+
 
 ### Parameters
 

--- a/tsdb/_tools/split.py
+++ b/tsdb/_tools/split.py
@@ -7,19 +7,22 @@ import contextlib
 import sys
 
 path = sys.argv[1]
+# This is the number of documents in the default corpus
+TOTAL_DOCS = 116633698
 n_splits = int(sys.argv[2])
+q, r = divmod(total_docs, n_splits)
+wanted_docs = q * n_splits
 
 
 with contextlib.ExitStack() as stack, open(path, "r") as f:
     full_filenames = [f"documents-split-{i}.json" for i in range(n_splits)]
-    short_filenames = [f"documents-split-{i}-1k.json" for i in range(n_splits)]
-
     full_output_files = [stack.enter_context(open(fname, "w")) for fname in full_filenames]
-    short_output_files = [stack.enter_context(open(fname, "w")) for fname in short_filenames]
 
     for i, line in enumerate(f):
         if i % 1_000_000 == 0:
             print(i)
+
         full_output_files[i % n_splits].write(line)
-        if i < n_splits * 1000:
-            short_output_files[i % n_splits].write(line)
+
+        if i + 1 == wanted_docs:
+            break

--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -32,9 +32,10 @@
       {%- if corpus is defined and corpus == "split16" %}
         "documents": [
           {
-            "source-file": "documents-split16.json.bz2",
-            "document-count": 116633698,
-            "uncompressed-bytes": 132046338827
+            "source-file": "documents-split16-v2.json.bz2",
+            {# deleted 2 docs to get to multiple of 16 #}
+            "document-count": 116633696,
+            "uncompressed-bytes": 132046335865
           }
         ]
       {%- else %}
@@ -42,7 +43,7 @@
           {
             "source-file": "documents.json.bz2",
             "document-count": 116633698,
-            "uncompressed-bytes": 138721940450
+            "uncompressed-bytes": 132046338827
           }
         ]
       {%- endif %}


### PR DESCRIPTION
We drop 2 documents from the corpus so that the document count is a multiple of 16 which will allow Rally to split at exact boundaries.

To confirm the fix, I've run the following queries at 2% of indexing and nothing from 2021-04-29 got indexed:

```json
% curl http://localhost:39200/tsdb/_search --data-binary @d.json -H 'Content-Type: application/json' | jq .                                                   
{                                                                                                                                                              
  "took": 2557,                                                                
  "timed_out": false,                                                          
  "_shards": {                                                                                                                                                 
    "total": 1,                                                                
    "successful": 1,                                                                                                                                           
    "skipped": 0,                                                                                                                                              
    "failed": 0                                                                                                                                                
  },                                                                                                                                                           
  "hits": {                                                                    
    "total": {                                                                 
      "value": 10000,                                                          
      "relation": "gte"                                                        
    },                                                                         
    "max_score": null,                                                         
    "hits": []                                                                                                                                                 
  },                                                                           
  "aggregations": {                                                            
    "NAME": {                                                                  
      "buckets": [                                                             
        {                                                                      
          "key_as_string": "2021-04-28T17:00:00.000Z",                         
          "key": 1619629200000,                                                
          "doc_count": 2099499                                                 
        },                                                                     
        {                                                                      
          "key_as_string": "2021-04-28T18:00:00.000Z",                         
          "key": 1619632800000,                                                
          "doc_count": 484385                                                  
        }                                                                      
      ]                                                                                                                                                        
    }                                                                          
  }                                                                                                                                                            
}
```

with d.json having the following contents:

```json
{
  "size": 0,
  "aggs": {
    "NAME": {
      "date_histogram": {
        "field": "@timestamp",
        "calendar_interval": "hour"
      }
    }
  }
}
```

