### PR TITLE
Refactor elastic/logs runners to suit forthcoming client upgrade

### DIFF
--- a/elastic/shared/runners/datastream.py
+++ b/elastic/shared/runners/datastream.py
@@ -100,7 +100,7 @@ async def rollover(es, params):
     # expand the data_streams into a list as we cant use wildcard in rollover
     response = await es.indices.get_data_stream(name=data_stream)
     for ds_stream in response["data_streams"]:
-        rollover_response = await es.indices.rollover(ds_stream["name"], body={"conditions": conditions})
+        rollover_response = await es.indices.rollover(alias=ds_stream["name"], body={"conditions": conditions})
         logger.debug(
             "Rolled over [%s] - old index: [%s], new index: [%s]",
             rollover_response["old_index"],
@@ -114,7 +114,7 @@ async def shards(es, params):
     number_of_replicas = mandatory(params, "number-of-replicas", "set-data-stream-shards")
     data_stream = mandatory(params, "data-stream", "set-shards-datastream")
     await es.indices.put_settings(
-        {"number_of_replicas": number_of_replicas},
+        body={"number_of_replicas": number_of_replicas},
         index=data_stream,
     )
     return 1, "ops"

--- a/elastic/shared/runners/ilm.py
+++ b/elastic/shared/runners/ilm.py
@@ -35,7 +35,12 @@ async def create_ilm(es, params):
             name = os.path.splitext(os.path.basename(p))[0]
             with open(p, "r") as f:
                 policy = {"policy": json.load(f)["policy"]}  # only `policy` is allowed
-            await es.ilm.put_lifecycle(name, body=policy)
+            try:
+                await es.ilm.put_lifecycle(name=name, policy=policy)
+            # method signature changed in es client >8.x
+            except TypeError:
+                await es.ilm.put_lifecycle(name, body=policy)
+
             policy_num += 1
 
     return policy_num, "ops"

--- a/elastic/shared/runners/ilm.py
+++ b/elastic/shared/runners/ilm.py
@@ -35,10 +35,6 @@ async def create_ilm(es, params):
             name = os.path.splitext(os.path.basename(p))[0]
             with open(p, "r") as f:
                 policy = {"policy": json.load(f)["policy"]}  # only `policy` is allowed
-            try:
-                await es.ilm.put_lifecycle(name=name, policy=policy)
-            # method signature changed in es client >8.x
-            except TypeError:
                 await es.ilm.put_lifecycle(name, body=policy)
 
             policy_num += 1

--- a/elastic/shared/runners/ilm.py
+++ b/elastic/shared/runners/ilm.py
@@ -35,7 +35,7 @@ async def create_ilm(es, params):
             name = os.path.splitext(os.path.basename(p))[0]
             with open(p, "r") as f:
                 policy = {"policy": json.load(f)["policy"]}  # only `policy` is allowed
-                await es.ilm.put_lifecycle(name, body=policy)
+            await es.ilm.put_lifecycle(name, body=policy)
 
             policy_num += 1
 

--- a/elastic/shared/runners/pipelines.py
+++ b/elastic/shared/runners/pipelines.py
@@ -34,7 +34,7 @@ async def create_pipeline(es, params):
             name = os.path.splitext(os.path.basename(p))[0]
             with open(p, "r") as f:
                 pipeline = json.load(f)
-            await es.ingest.put_pipeline(name, body=pipeline)
+            await es.ingest.put_pipeline(id=name, body=pipeline)
             pipeline_num += 1
 
     return pipeline_num, "ops"

--- a/elastic/shared/runners/remote_cluster.py
+++ b/elastic/shared/runners/remote_cluster.py
@@ -3,7 +3,6 @@ import copy
 
 from esrally.driver.runner import Runner, runner_for, unwrap
 
-
 """
 Runners for configuring a typical CCS/CCR architecture, where we have a central 'local' cluster and many 'remote'
 clusters.

--- a/elastic/shared/runners/slm.py
+++ b/elastic/shared/runners/slm.py
@@ -28,6 +28,6 @@ async def create_slm(es, params):
         policy_name = os.path.splitext(os.path.basename(policy_path))[0]
         with open(policy_path, "r") as policy_file:
             policy = json.load(policy_file)
-            await slm.put_lifecycle(policy_name, body=policy)
+            await slm.put_lifecycle(policy_id=policy_name, body=policy)
             policy_num += 1
     return policy_num, "ops"

--- a/elastic/shared/runners/slm.py
+++ b/elastic/shared/runners/slm.py
@@ -28,6 +28,6 @@ async def create_slm(es, params):
         policy_name = os.path.splitext(os.path.basename(policy_path))[0]
         with open(policy_path, "r") as policy_file:
             policy = json.load(policy_file)
-            await slm.put_lifecycle(policy_id=policy_name, body=policy)
-            policy_num += 1
+        await slm.put_lifecycle(policy_id=policy_name, body=policy)
+        policy_num += 1
     return policy_num, "ops"

--- a/elastic/shared/runners/snapshot.py
+++ b/elastic/shared/runners/snapshot.py
@@ -28,7 +28,7 @@ async def mount(es, params):
     ignore_index_settings = params.get("ignore_index_settings")
     storage = params.get("storage")
     query_params = params.get("query_params", {})
-    snapshots = await es.snapshot.get(repository_name, snapshot_name)
+    snapshots = await es.snapshot.get(repository=repository_name, snapshot=snapshot_name)
 
     for snapshot in snapshots["snapshots"]:
         for index in snapshot["indices"]:

--- a/elastic/tests/runners/snapshot_test.py
+++ b/elastic/tests/runners/snapshot_test.py
@@ -55,7 +55,7 @@ async def test_mount_snapshot(es):
 
     await snapshot.mount(es, params=params)
 
-    es.snapshot.get.assert_called_once_with("logging", "logging-snapshot")
+    es.snapshot.get.assert_called_once_with(repository="logging", snapshot="logging-snapshot")
     es.searchable_snapshots.mount.assert_has_calls(
         [
             mock.call(
@@ -115,7 +115,7 @@ async def test_mount_snapshot_frozen(es):
 
     await snapshot.mount(es, params=params)
 
-    es.snapshot.get.assert_called_once_with("logging", "logging-snapshot")
+    es.snapshot.get.assert_called_once_with(repository="logging", snapshot="logging-snapshot")
     es.searchable_snapshots.mount.assert_has_calls(
         [
             mock.call(
@@ -177,7 +177,7 @@ async def test_mount_snapshot_with_renames(es):
 
     await snapshot.mount(es, params=params)
 
-    es.snapshot.get.assert_called_once_with("logging", "logging-snapshot")
+    es.snapshot.get.assert_called_once_with(repository="logging", snapshot="logging-snapshot")
     es.searchable_snapshots.mount.assert_has_calls(
         [
             mock.call(


### PR DESCRIPTION
In https://github.com/elastic/rally/pull/1669 we'll upgrade the ES client from 7.x to 8.x. As part of this upgrade some of the runners need to explicitly pass keyword arguments (unnamed args not supported), and some of the exception handling has changed.

This commit refactors the exception handling (luckily only one spot),
and converts the runners to use named arguments. Luckily it appears
there's only one place the method signature has changed, meaning 
all but one of the runner changes are BWC.