### PR TITLE
http_logs: use only epoch_second format for @timestamp

### DIFF
--- a/http_logs/index-runtime-fields.json
+++ b/http_logs/index-runtime-fields.json
@@ -11,7 +11,7 @@
     },
     "properties": {
       "@timestamp": {
-        "format": "strict_date_optional_time||epoch_second",
+        "format": "epoch_second",
         "type": "date"
       },
       "message": {

--- a/http_logs/index-runtime-fields.json
+++ b/http_logs/index-runtime-fields.json
@@ -11,7 +11,7 @@
     },
     "properties": {
       "@timestamp": {
-        "format": "epoch_second",
+        "format": "strict_date_optional_time",
         "type": "date"
       },
       "message": {

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -11,7 +11,7 @@
     },
     "properties": {
       "@timestamp": {
-        "format": "strict_date_optional_time||epoch_second",
+        "format": "epoch_second",
         "type": "date"
       },
       "message": {

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -122,8 +122,8 @@
               {
                 "range": {
                   "@timestamp": {
-                    "gte": "1998-05-01T00:00:00Z",
-                    "lt": "1998-05-02T00:00:00Z"
+                    "gte": {{query_range_ts_start | tojson}},
+                    "lt": {{query_range_ts_end | tojson}}
                   }
                 }
               },
@@ -156,8 +156,8 @@
               {
                 "range": {
                   "@timestamp": {
-                    "gte": "1998-05-01T00:00:00Z",
-                    "lt": "1998-05-02T00:00:00Z"
+                    "gte": {{query_range_ts_start | tojson}},
+                    "lt": {{query_range_ts_end | tojson}}
                   }
                 }
               },
@@ -232,7 +232,7 @@
         "sort" : [
           {"@timestamp" : "desc"}
         ],
-        "search_after": ["1998-06-10"]
+        "search_after": [{{search_after_ts | tojson}}]
       }
     },
     {
@@ -260,7 +260,7 @@
         "sort" : [
           {"@timestamp" : "asc"}
         ],
-        "search_after": ["1998-06-10"]
+        "search_after": [{{search_after_ts | tojson}}]
       }
     },
     {

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -3,8 +3,14 @@
 
 {%- if runtime_fields is defined %}
   {% set index_body = 'index-runtime-fields.json' %}
+  {% set query_range_ts_start = "1998-05-01T00:00:00Z" %}
+  {% set query_range_ts_end = "1998-05-02T00:00:00Z" %}
+  {% set search_after_ts = "1998-06-10" %}
 {%- else %}
   {% set index_body = 'index.json' %}
+  {% set query_range_ts_start = "893980800" %}
+  {% set query_range_ts_end = "894067200" %}
+  {% set search_after_ts = "897436800" %}
 {%- endif %}
 {
   "version": 2,


### PR DESCRIPTION
This PR updates the index and runtime mapping for the HTTP Logs track. Set the `@timestamp` date format to `epoch_second` as it is in the corpus. For runtime fields, use the generic date format parser `strict_date_optional_time` to align with the runtime fields-specific corpus.

#### Sample

```json
{"@timestamp": 894034934, "clientip":"211.62.0.0", "request": "GET /images/dburton.jpg HTTP/1.0", "status": 200, "size": 12009}
```