### PR TITLE
Revert "http_logs: use suitable date formater for @timestamp (#388)"

### DIFF
--- a/http_logs/index-runtime-fields.json
+++ b/http_logs/index-runtime-fields.json
@@ -11,7 +11,7 @@
     },
     "properties": {
       "@timestamp": {
-        "format": "strict_date_optional_time",
+        "format": "strict_date_optional_time||epoch_second",
         "type": "date"
       },
       "message": {

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -11,7 +11,7 @@
     },
     "properties": {
       "@timestamp": {
-        "format": "epoch_second",
+        "format": "strict_date_optional_time||epoch_second",
         "type": "date"
       },
       "message": {

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -122,8 +122,8 @@
               {
                 "range": {
                   "@timestamp": {
-                    "gte": {{query_range_ts_start | tojson}},
-                    "lt": {{query_range_ts_end | tojson}}
+                    "gte": "1998-05-01T00:00:00Z",
+                    "lt": "1998-05-02T00:00:00Z"
                   }
                 }
               },
@@ -156,8 +156,8 @@
               {
                 "range": {
                   "@timestamp": {
-                    "gte": {{query_range_ts_start | tojson}},
-                    "lt": {{query_range_ts_end | tojson}}
+                    "gte": "1998-05-01T00:00:00Z",
+                    "lt": "1998-05-02T00:00:00Z"
                   }
                 }
               },
@@ -232,7 +232,7 @@
         "sort" : [
           {"@timestamp" : "desc"}
         ],
-        "search_after": [{{search_after_ts | tojson}}]
+        "search_after": ["1998-06-10"]
       }
     },
     {
@@ -260,7 +260,7 @@
         "sort" : [
           {"@timestamp" : "asc"}
         ],
-        "search_after": [{{search_after_ts | tojson}}]
+        "search_after": ["1998-06-10"]
       }
     },
     {

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -3,14 +3,8 @@
 
 {%- if runtime_fields is defined %}
   {% set index_body = 'index-runtime-fields.json' %}
-  {% set query_range_ts_start = "1998-05-01T00:00:00Z" %}
-  {% set query_range_ts_end = "1998-05-02T00:00:00Z" %}
-  {% set search_after_ts = "1998-06-10" %}
 {%- else %}
   {% set index_body = 'index.json' %}
-  {% set query_range_ts_start = "893980800" %}
-  {% set query_range_ts_end = "894067200" %}
-  {% set search_after_ts = "897436800" %}
 {%- endif %}
 {
   "version": 2,


### PR DESCRIPTION
This reverts commit cffc8641055233485b9d1c9a773b1303c7c5313f due to cryptic nightly failures.

cc @inqueue 