### PR TITLE
http_logs: set the date formatter for @timestamp

### DIFF
--- a/http_logs/index-runtime-fields.json
+++ b/http_logs/index-runtime-fields.json
@@ -11,7 +11,7 @@
     },
     "properties": {
       "@timestamp": {
-        "format": "strict_date_optional_time||epoch_second",
+        "format": "strict_date_optional_time",
         "type": "date"
       },
       "message": {

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -11,7 +11,11 @@
     },
     "properties": {
       "@timestamp": {
+        {%- if ingest_pipeline is defined and ingest_pipeline == "grok" %}
+        "format": "strict_date_optional_time",
+        {%- else %}
         "format": "epoch_second",
+        {%- endif %}
         "type": "date"
       },
       "message": {

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -11,7 +11,7 @@
     },
     "properties": {
       "@timestamp": {
-        "format": "strict_date_optional_time||epoch_second",
+        "format": "epoch_second",
         "type": "date"
       },
       "message": {

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -122,8 +122,8 @@
               {
                 "range": {
                   "@timestamp": {
-                    "gte": "1998-05-01T00:00:00Z",
-                    "lt": "1998-05-02T00:00:00Z"
+                    "gte": {{query_range_ts_start | tojson}},
+                    "lt": {{query_range_ts_end | tojson}}
                   }
                 }
               },
@@ -156,8 +156,8 @@
               {
                 "range": {
                   "@timestamp": {
-                    "gte": "1998-05-01T00:00:00Z",
-                    "lt": "1998-05-02T00:00:00Z"
+                    "gte": {{query_range_ts_start | tojson}},
+                    "lt": {{query_range_ts_end | tojson}}
                   }
                 }
               },
@@ -232,7 +232,7 @@
         "sort" : [
           {"@timestamp" : "desc"}
         ],
-        "search_after": ["1998-06-10"]
+        "search_after": [{{search_after_ts | tojson}}]
       }
     },
     {
@@ -260,7 +260,7 @@
         "sort" : [
           {"@timestamp" : "asc"}
         ],
-        "search_after": ["1998-06-10"]
+        "search_after": [{{search_after_ts | tojson}}]
       }
     },
     {

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -3,8 +3,14 @@
 
 {%- if runtime_fields is defined %}
   {% set index_body = 'index-runtime-fields.json' %}
+  {% set query_range_ts_start = "1998-05-01T00:00:00Z" %}
+  {% set query_range_ts_end = "1998-05-02T00:00:00Z" %}
+  {% set search_after_ts = "1998-06-10" %}
 {%- else %}
   {% set index_body = 'index.json' %}
+  {% set query_range_ts_start = "893980800" %}
+  {% set query_range_ts_end = "894067200" %}
+  {% set search_after_ts = "897436800" %}
 {%- endif %}
 {
   "version": 2,


### PR DESCRIPTION
This PR reverts https://github.com/elastic/rally-tracks/pull/389, a revert of https://github.com/elastic/rally-tracks/pull/388, so it is a revert of a revert. In addition, it fixes the target index mapping for ISO 8601 when setting the `ingest_pipeline` track parameter to `grok`. Here is how it ends up:

* The track will use only ISO 8601 format via `strict_date_optional_time` for `@timestamp` for runtime fields or `ingest_pipeline: grok`. Both runtime fields and the ingest pipeline configurations will use the unparsed corpora which contain ISO 8601 formatted dates.
* The track will use epoch seconds (`epoch_second`) all other times; that is when executing against the parsed corpora. 