### PR TITLE
Lower target throughput for 'painless_static' operation

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -118,7 +118,7 @@
           "operation": "painless_static",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 1.4
+          "target-throughput": 1.1
         },
         {
           "operation": "painless_dynamic",


### PR DESCRIPTION
Starting April 29th the `painless_static` operation's `service_time` increased by ~20-30%. This increase in `service_time` means we can no longer meet the target throughput of `1.4` queries per-second, resulting in queueing at the client side:
```
1000/1.4 = 714ms
```

With this commit we lower the target throughput to 1.1:
```
1000/1.1 = 909ms
```

This chart shows the nightly service time over the course of each benchmark for the last week:
![image](https://user-images.githubusercontent.com/54515790/229938684-fa62f500-8545-45e8-b7bd-e244f8526ec2.png)
