### PR TITLE
Pin geneve to v0.2.0

### DIFF
--- a/elastic/security/README.md
+++ b/elastic/security/README.md
@@ -134,7 +134,7 @@ Users of this track may use this challenge to execute queries on an existing ind
 
 This challenge executes indexing and querying sequentially. Queries will be issued concurrently until `query_time_period` has elapsed.
 
-### Ratios
+## Ratios
 
 By default, the track generates a dataset by sampling the source corpora randomly according to defined ratios. These ratios can be changed through the parameter `integration_ratios`. 
 

--- a/elastic/security/README.md
+++ b/elastic/security/README.md
@@ -134,6 +134,10 @@ Users of this track may use this challenge to execute queries on an existing ind
 
 This challenge executes indexing and querying sequentially. Queries will be issued concurrently until `query_time_period` has elapsed.
 
+### Generate source events for detection rules (generate-alerts-source-events)
+
+This challenge is a demo usage of Geneve via the `events-emitter-source` parameter source, it generates source events but does not interact with anything else. It's executed as part of the `it/test_security.py` integration tests.
+
 ## Ratios
 
 By default, the track generates a dataset by sampling the source corpora randomly according to defined ratios. These ratios can be changed through the parameter `integration_ratios`. 

--- a/elastic/security/challenges/generate-alerts-source-events.json
+++ b/elastic/security/challenges/generate-alerts-source-events.json
@@ -1,6 +1,6 @@
 {
-  "name": "index-alert-source-events",
-  "description": "Indexes source events generated for detection rules",
+  "name": "generate-alerts-source-events",
+  "description": "Generate source events for detection rules",
   "schedule": [
     {
       "name": "generate-events",

--- a/elastic/security/track.json
+++ b/elastic/security/track.json
@@ -407,7 +407,7 @@
 {% endfor %}
   ],
   "dependencies": [
-    "geneve>=0.0.3",
+    "geneve==0.2.0",
     "pyyaml"
   ],
   "challenges": [

--- a/it/test_security.py
+++ b/it/test_security.py
@@ -39,6 +39,6 @@ class TestSecurity:
         )
         assert ret == 0
 
-    def test_security_index_alert_source_events(self, es_cluster, rally):
-        ret = rally.race(track="elastic/security", challenge="index-alert-source-events", track_params={"number_of_replicas": "0"})
+    def test_security_generate_alerts_source_events(self, es_cluster, rally):
+        ret = rally.race(track="elastic/security", challenge="generate-alerts-source-events", track_params={"number_of_replicas": "0"})
         assert ret == 0


### PR DESCRIPTION
Upgrade geneve in a controlled fashion:

* test the tracks before the upgrade
* avoid overlapping with possibly ongoing investigations
* allow bisecting across geneve upgrades

Related to https://github.com/elastic/elasticsearch-benchmarks/issues/1482.