### PR TITLE
add refresh_interval parameter to tsdb track

### DIFF
--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -180,6 +180,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
+* `refresh_interval` (default not defined)
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `source_mode` (default: synthetic): Should the `_source` be `stored` to disk exactly as sent (the Elasticsearch default outside of TSDB mode), thrown away (`disabled`), or reconstructed on the fly (`synthetic`)
 * `index_mode` (default: time_series): Whether to make a standard index (`standard`) or time series index (`time_series`)

--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -9,6 +9,9 @@
       "index": {
         "number_of_shards": {{number_of_shards | default(1)}},
         "number_of_replicas": {{number_of_replicas | default(0)}},
+        {% if refresh_interval %}
+        "refresh_interval": {{refresh_interval}},
+        {% endif %}
         "mapping.total_fields.limit": 10000,
         "codec": "{{codec | default('default')}}",
         "mode": "{{index_mode | default('time_series')}}",

--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -10,7 +10,7 @@
         "number_of_shards": {{number_of_shards | default(1)}},
         "number_of_replicas": {{number_of_replicas | default(0)}},
         {% if refresh_interval %}
-        "refresh_interval": {{refresh_interval}},
+        "refresh_interval": "{{refresh_interval}}",
         {% endif %}
         "mapping.total_fields.limit": 10000,
         "codec": "{{codec | default('default')}}",

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -9,6 +9,9 @@
       "mapping.total_fields.limit": 10000,
       "codec": "{{codec | default('default')}}",
       "mode": "{{index_mode | default('time_series')}}",
+      {% if refresh_interval %}
+      "refresh_interval": "{{refresh_interval}}",
+      {% endif %}
       {% if index_mode | default('time_series') is equalto 'time_series' %}
       "routing_path": [
         "metricset.name",


### PR DESCRIPTION
Allows for measuring what overhead adding a static refresh interval has on indexing throughput.