### PR TITLE
Configurable number of replicas for dense_vector track

### DIFF
--- a/dense_vector/README.md
+++ b/dense_vector/README.md
@@ -28,3 +28,4 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 1): Number of clients that issue bulk indexing requests.
+* `number_of_replicas` (default: 0)

--- a/dense_vector/index.json
+++ b/dense_vector/index.json
@@ -2,7 +2,7 @@
   "settings": {
     "index": {
       "number_of_shards": 2,
-      "number_of_replicas": 0
+      "number_of_replicas": {{number_of_replicas | default(0)}}
     }
   },
   "mappings": {


### PR DESCRIPTION
This is important as running benchmarks against serverless requires at least 1 replica, hence this parameter needs to be at least configurable.