### PR TITLE
Dense vector to use polling mode for force merge call

### DIFF
--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -84,6 +84,8 @@
     {
       "operation": {
         "operation-type": "force-merge",
+        "mode" : "polling",
+        
         "max-num-segments": 1,
         "request-timeout": 7200,
         "include-in-reporting": true


### PR DESCRIPTION
I experienced cases where force merge takes a long time and causes timeout issues, this should improve the situation.