### PR TITLE
Support DLM in the Logging Track

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -218,6 +218,7 @@ The following parameters are available:
 * `start_date` (default: `2020-01-01` ) - The start date of the data. The `end_date` minus this value will determine the time range assigned to the data and also directly impact the total volume indexed. Must be less than the `end_date`.
 * `end_date` (default: `2020-01-02` ) - The end date of the data. This value minus the `start_date` will determine the time range assigned to the data and also directly impact the total volume indexed. Must be greater than the `start_date`.
 * `corpora_uri_base` (default: `https://rally-tracks.elastic.co`) - Specify the base location of the datasets used by this track.
+* `lifecycle` (default: `ilm`) - Specifies the lifecycle management feature to use for data streams. Use `ilm` for index lifecycle management or `dlm` for data lifecycle management. `dlm` is required for benchmarking Serverless Elasticsearch.
 
 ### Data Download Parameters
 

--- a/elastic/logs/tasks/index-setup.json
+++ b/elastic/logs/tasks/index-setup.json
@@ -8,6 +8,7 @@
   }
 },
 {%- endif %}
+{%- if not lifecycle or lifecycle == "ilm" %}
 {
   "name": "insert-ilm",
   "tags": ["setup"],
@@ -16,6 +17,7 @@
     "param-source": "add-track-path"
   }
 },
+{%- endif %}
 {
   "name": "delete-all-datastreams",
   "tags": ["setup"],

--- a/elastic/logs/templates/component/logs-apache.access@settings.json
+++ b/elastic/logs/templates/component/logs-apache.access@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/logs-apache.error@settings.json
+++ b/elastic/logs/templates/component/logs-apache.error@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/logs-kafka.log@settings.json
+++ b/elastic/logs/templates/component/logs-kafka.log@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/logs-mysql.error@settings.json
+++ b/elastic/logs/templates/component/logs-mysql.error@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/logs-mysql.slowlog@settings.json
+++ b/elastic/logs/templates/component/logs-mysql.slowlog@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/logs-nginx.access@settings.json
+++ b/elastic/logs/templates/component/logs-nginx.access@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/logs-nginx.error@settings.json
+++ b/elastic/logs/templates/component/logs-nginx.error@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/logs-postgresql.log@settings.json
+++ b/elastic/logs/templates/component/logs-postgresql.log@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/logs-redis.log@settings.json
+++ b/elastic/logs/templates/component/logs-redis.log@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/logs-redis.slowlog@settings.json
+++ b/elastic/logs/templates/component/logs-redis.slowlog@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/logs-system.auth@settings.json
+++ b/elastic/logs/templates/component/logs-system.auth@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/logs-system.syslog@settings.json
+++ b/elastic/logs/templates/component/logs-system.syslog@settings.json
@@ -2,9 +2,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/logs/templates/component/track-data-stream-lifecycle.json
+++ b/elastic/logs/templates/component/track-data-stream-lifecycle.json
@@ -9,9 +9,7 @@
       }
     }
 {%- elif lifecycle == "dlm" -%}
-    "lifecycle": {
-      "data_retention": "30d"
-    }
+    "lifecycle": {}
 {%- endif -%}
   }
 }

--- a/elastic/logs/templates/component/track-lifecycle.json
+++ b/elastic/logs/templates/component/track-lifecycle.json
@@ -1,0 +1,17 @@
+{
+  "template": {
+{% if not lifecycle or lifecycle == "ilm" -%}
+    "settings": {
+      "index": {
+        "lifecycle": {
+          "name": "logs"
+        }
+      }
+    }
+{%- elif lifecycle == "dlm" -%}
+    "lifecycle": {
+      "data_retention": "30d"
+    }
+{%- endif -%}
+  }
+}

--- a/elastic/logs/templates/composable/logs-apache.access.json
+++ b/elastic/logs/templates/composable/logs-apache.access.json
@@ -520,7 +520,7 @@
     "logs-apache.access@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-apache.access.json
+++ b/elastic/logs/templates/composable/logs-apache.access.json
@@ -519,7 +519,8 @@
     "logs-apache.access@settings",
     "logs-apache.access@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-apache.error.json
+++ b/elastic/logs/templates/composable/logs-apache.error.json
@@ -476,7 +476,7 @@
     "logs-apache.error@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-apache.error.json
+++ b/elastic/logs/templates/composable/logs-apache.error.json
@@ -475,7 +475,8 @@
     "logs-apache.error@settings",
     "logs-apache.error@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -1998,7 +1998,7 @@
   "composed_of": [
     "logs-mappings",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -5,9 +5,6 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
         "codec": "best_compression",
         "mapping": {
           "total_fields": {
@@ -2000,7 +1997,8 @@
   },
   "composed_of": [
     "logs-mappings",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-kafka.log.json
+++ b/elastic/logs/templates/composable/logs-kafka.log.json
@@ -285,7 +285,8 @@
     "logs-kafka.log@settings",
     "logs-kafka.log@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-kafka.log.json
+++ b/elastic/logs/templates/composable/logs-kafka.log.json
@@ -286,7 +286,7 @@
     "logs-kafka.log@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-mysql.error.json
+++ b/elastic/logs/templates/composable/logs-mysql.error.json
@@ -303,7 +303,8 @@
     "logs-mysql.error@settings",
     "logs-mysql.error@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-mysql.error.json
+++ b/elastic/logs/templates/composable/logs-mysql.error.json
@@ -304,7 +304,7 @@
     "logs-mysql.error@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-mysql.slowlog.json
+++ b/elastic/logs/templates/composable/logs-mysql.slowlog.json
@@ -449,7 +449,7 @@
     "logs-mysql.slowlog@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-mysql.slowlog.json
+++ b/elastic/logs/templates/composable/logs-mysql.slowlog.json
@@ -448,7 +448,8 @@
     "logs-mysql.slowlog@settings",
     "logs-mysql.slowlog@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-nginx.access.json
+++ b/elastic/logs/templates/composable/logs-nginx.access.json
@@ -459,7 +459,8 @@
     "logs-nginx.access@settings",
     "logs-nginx.access@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-nginx.access.json
+++ b/elastic/logs/templates/composable/logs-nginx.access.json
@@ -460,7 +460,7 @@
     "logs-nginx.access@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-nginx.error.json
+++ b/elastic/logs/templates/composable/logs-nginx.error.json
@@ -295,7 +295,7 @@
     "logs-nginx.error@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-nginx.error.json
+++ b/elastic/logs/templates/composable/logs-nginx.error.json
@@ -294,7 +294,8 @@
     "logs-nginx.error@settings",
     "logs-nginx.error@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-postgresql.log.json
+++ b/elastic/logs/templates/composable/logs-postgresql.log.json
@@ -406,7 +406,7 @@
     "logs-postgresql.log@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-postgresql.log.json
+++ b/elastic/logs/templates/composable/logs-postgresql.log.json
@@ -405,7 +405,8 @@
     "logs-postgresql.log@settings",
     "logs-postgresql.log@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-redis.log.json
+++ b/elastic/logs/templates/composable/logs-redis.log.json
@@ -277,7 +277,7 @@
     "logs-redis.log@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-redis.log.json
+++ b/elastic/logs/templates/composable/logs-redis.log.json
@@ -276,7 +276,8 @@
     "logs-redis.log@settings",
     "logs-redis.log@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-redis.slowlog.json
+++ b/elastic/logs/templates/composable/logs-redis.slowlog.json
@@ -258,7 +258,7 @@
     "logs-redis.slowlog@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-redis.slowlog.json
+++ b/elastic/logs/templates/composable/logs-redis.slowlog.json
@@ -257,7 +257,8 @@
     "logs-redis.slowlog@settings",
     "logs-redis.slowlog@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-system.auth.json
+++ b/elastic/logs/templates/composable/logs-system.auth.json
@@ -471,7 +471,8 @@
     "logs-system.auth@settings",
     "logs-system.auth@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-system.auth.json
+++ b/elastic/logs/templates/composable/logs-system.auth.json
@@ -472,7 +472,7 @@
     "logs-system.auth@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-system.syslog.json
+++ b/elastic/logs/templates/composable/logs-system.syslog.json
@@ -295,7 +295,8 @@
     "logs-system.syslog@settings",
     "logs-system.syslog@custom",
     ".fleet_component_template-1",
-    "track-custom-mappings"
+    "track-custom-mappings",
+    "track-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/templates/composable/logs-system.syslog.json
+++ b/elastic/logs/templates/composable/logs-system.syslog.json
@@ -296,7 +296,7 @@
     "logs-system.syslog@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
-    "track-lifecycle"
+    "track-data-stream-lifecycle"
   ],
   "priority": 200,
   "_meta": {

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -293,8 +293,8 @@
         "template": "./templates/component/auditbeat-mappings.json"
     },
     {
-      "name": "track-lifecycle",
-      "template": "./templates/component/track-lifecycle.json"
+      "name": "track-data-stream-lifecycle",
+      "template": "./templates/component/track-data-stream-lifecycle.json"
     }
   ],
   "composable-templates": [

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -291,6 +291,10 @@
     {
         "name": "auditbeat-mappings",
         "template": "./templates/component/auditbeat-mappings.json"
+    },
+    {
+      "name": "track-lifecycle",
+      "template": "./templates/component/track-lifecycle.json"
     }
   ],
   "composable-templates": [


### PR DESCRIPTION
Data Lifecycle Management (DLM) will be optional for stateful Elasticsearch and required for serverless. This commit aims to add DLM support to the Logging track:

* Add a `lifecycle` parameter for Index Lifecycle Management (`ilm`) or Data Lifecycle Management (`dlm`).
* Add a new component template named `track-lifecycle.json`. ILM or DLM will be enabled based on the value of the `lifecycle` parameter.
* Remove the ILM configuration from individual data stream component templates.
* Reference the `track-lifecycle` component template in each data stream composable template.

Unlike ILM, DLM does not use policies. Instead, data retention is specified per data stream (as applied in the templates) and the criteria for rollover is specified in cluster settings. For this iteration, the track will rely on DLM defaults in cluster settings:

```http
GET /_cluster/settings?include_defaults=true&filter_path=**.dlm.*

{
  "defaults": {
    "cluster": {
      "dlm": {
        "default": {
          "rollover": "max_age=auto,max_primary_shard_size=50gb,min_docs=1,max_primary_shard_docs=200000000"
        }
      }
    },
    "indices": {
      "dlm": {
        "poll_interval": "10m"
      }
    }
  }
}
```

@gmarouli, I hope you don't mind me adding you to review how DLM is configured. Please indicate if I have overlooked any assumptions. Thanks!