### PR TITLE
Add daily schedule and manual trigger to GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 14 * * *'
+  # Allows triggering the job manually
+  workflow_dispatch:
 
 permissions: "read-all"
 


### PR DESCRIPTION
The PR adds daily run of GitHub Actions CI workflow at 14:00 UTC.
The PR also adds an option to trigger the workflow manually.

Related: https://github.com/elastic/rally/pull/1736