### PR TITLE
Remove unnecessary wait-until-merges-finish

### DIFF
--- a/elastic/security/tasks/index-setup.json
+++ b/elastic/security/tasks/index-setup.json
@@ -73,18 +73,4 @@
     },
     "retry-until-success": true
   }
-},
-{
-  "name": "wait-until-merges-finish",
-  "tags": ["setup"],
-  "operation": {
-    "operation-type": "index-stats",
-    "index": "_all",
-    "condition": {
-      "path": "_all.total.merges.current",
-      "expected-value": 0
-    },
-    "retry-until-success": true,
-    "include-in-reporting": false
-  }
 }


### PR DESCRIPTION
wait-until-merges-finish is called before any indexing and force merge is called.