### PR TITLE
Support refresh_interval for elastic/logs

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -237,6 +237,7 @@ The following parameters are available:
 
 * `number_of_shards` (default: 1) - The number of primary shards to set per Data Stream. The same value is used for all Data Streams.
 * `number_of_replicas` (default: 1) - The number of replicas to set per Data Stream. The same value is used for all Data Streams.
+* `refresh_interval` (default: unset) - The Data Stream refresh interval. It is unset by default to use the Elasticsearch default refresh interval.
 * `bulk_indexing_clients` (default: 8) - The number of clients issuing indexing requests.
 * `bulk_size` (default: 1000) - The number of documents to send per indexing request.
 * `throttle_indexing` (default: `false`) - Whether indexing should be throttled to the rate determined by `raw_data_volume_per_day`, assuming a uniform distribution of data, or whether indexing should go as fast as possible. 

--- a/elastic/logs/templates/component/logs-apache.access@custom.json
+++ b/elastic/logs/templates/component/logs-apache.access@custom.json
@@ -4,6 +4,9 @@
       "index": {
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval %},
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
       }
     }
   },

--- a/elastic/logs/templates/component/logs-apache.error@custom.json
+++ b/elastic/logs/templates/component/logs-apache.error@custom.json
@@ -4,6 +4,9 @@
       "index": {
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval %},
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
       }
     }
   },

--- a/elastic/logs/templates/component/logs-kafka.log@custom.json
+++ b/elastic/logs/templates/component/logs-kafka.log@custom.json
@@ -4,6 +4,9 @@
       "index": {
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval %},
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
       }
     }
   },

--- a/elastic/logs/templates/component/logs-mysql.error@custom.json
+++ b/elastic/logs/templates/component/logs-mysql.error@custom.json
@@ -4,6 +4,9 @@
       "index": {
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval %},
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
       }
     }
   },

--- a/elastic/logs/templates/component/logs-mysql.slowlog@custom.json
+++ b/elastic/logs/templates/component/logs-mysql.slowlog@custom.json
@@ -4,6 +4,9 @@
       "index": {
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval %},
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
       }
     }
   },

--- a/elastic/logs/templates/component/logs-nginx.access@custom.json
+++ b/elastic/logs/templates/component/logs-nginx.access@custom.json
@@ -4,6 +4,9 @@
         "index": {
           "number_of_shards": "{{ number_of_shards | default(1) }}",
           "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+          {%- if refresh_interval %},
+          "refresh_interval": "{{ refresh_interval }}"
+          {%- endif %}
         }
       }
     },

--- a/elastic/logs/templates/component/logs-nginx.error@custom.json
+++ b/elastic/logs/templates/component/logs-nginx.error@custom.json
@@ -4,6 +4,9 @@
       "index": {
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval %},
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
       }
     }
   },

--- a/elastic/logs/templates/component/logs-postgresql.log@custom.json
+++ b/elastic/logs/templates/component/logs-postgresql.log@custom.json
@@ -4,6 +4,9 @@
       "index": {
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval %},
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
       }
     }
   },

--- a/elastic/logs/templates/component/logs-redis.log@custom.json
+++ b/elastic/logs/templates/component/logs-redis.log@custom.json
@@ -4,6 +4,9 @@
       "index": {
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval %},
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
       }
     }
   },

--- a/elastic/logs/templates/component/logs-redis.slowlog@custom.json
+++ b/elastic/logs/templates/component/logs-redis.slowlog@custom.json
@@ -4,6 +4,9 @@
       "index": {
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval %},
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
       }
     }
   },

--- a/elastic/logs/templates/component/logs-system.auth@custom.json
+++ b/elastic/logs/templates/component/logs-system.auth@custom.json
@@ -4,6 +4,9 @@
       "index": {
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval %},
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
       }
     }
   },

--- a/elastic/logs/templates/component/logs-system.syslog@custom.json
+++ b/elastic/logs/templates/component/logs-system.syslog@custom.json
@@ -4,6 +4,9 @@
       "index": {
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval %},
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
       }
     }
   },


### PR DESCRIPTION
Setting the `index.refresh_interval` is useful for serverless benchmarks. 

With this PR:
* Support `refresh_interval` as a track parameter for elastic/logs.
* Leave `refresh_interval` unset by default. 

All data streams in elastic/logs use the same `index.*` settings, therefore it makes sense to refactor them into a single component template, perhaps in a future PR.