### PR TITLE
Fix small mistake in tsdb_k8s_queries benchmark.

### DIFF
--- a/tsdb_k8s_queries/operations/default.json
+++ b/tsdb_k8s_queries/operations/default.json
@@ -901,7 +901,7 @@
           "filter": [
             {
               "match_phrase": {
-                "data_stream.dataset": "kubernetes.state_pod"
+                "data_stream.dataset": "kubernetes.pod"
               }
             },
             {


### PR DESCRIPTION
Changed data_stream.dataset filter in `status_per_pod_*` queries from `kubernetes.state_pod` to `kubernetes.pod`.

The `kubernetes.state_pod` value doesn't exist in the two data streams and therefor the this query currently never yields any result. This change should fix that.