### PR TITLE
Help debug rally-tracks-compat timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,15 @@ jobs:
         run: python -m pip install .[develop]
       - name: "Run tests"
         run: hatch -v -e it run test
+        timeout-minutes: 120
         env:
           # elastic/endpoint fetches assets from GitHub, authenticate to avoid
           # being rate limited
           ASSETS_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            +      # Artifact will show up under "Artifacts" in the "Summary" page of runs
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: rally-tracks-compat-logs
+          path: /home/runner/.rally/logs/
+          if-no-files-found: error


### PR DESCRIPTION
By timing out after 2 hours (not 6) and uploading the Rally logs to the build. We do that upload in Rally already (https://github.com/elastic/rally/blob/7c8f6c7ee8a6d789c1c42a9d9914983c40a64420/.github/workflows/ci.yml#L76-L82) and I tested those changes on the ELSER PR.