### PR TITLE
Do not merge! PR to investigate the CI failures in #405

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
 
   rally-tracks-compat:
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v3

--- a/tsdb_k8s_queries/README.md
+++ b/tsdb_k8s_queries/README.md
@@ -1,5 +1,7 @@
 ## TSDB k8s query track
 
+Change this text to make a PR. DO NOT MERGE
+
 The main goal of the TSDB k8s query track is to measure the performance of common k8s integration search requests.
 The queries, index templates and corpus data try to match production as close as possible.
 


### PR DESCRIPTION
#405 is timing out on the `tsdb_k8s_queries` track waiting for cluster health.

The first test is check to find if the CI failures are caused by something in #405