### PR TITLE
updating with new track with 10k pods

### DIFF
--- a/tsdb_k8s_queries/track.json
+++ b/tsdb_k8s_queries/track.json
@@ -35,25 +35,25 @@
   "corpora": [
     {
       "name": "k8s-pod",
-      "base-url": "https://storage.googleapis.com/cloudnative-rally/rally2",
+      "base-url": "https://storage.googleapis.com/cloudnative-rally/rally3",
       "documents": [
         {
           "target-data-stream": "k8s-pod",
           "source-file": "doc-ds-metrics-kubernetes.pod.json.bz2",
           "document-count": 8640000,
-          "uncompressed-bytes": 92527939683
+          "uncompressed-bytes": 92412567091
         }
       ]
     },
     {
       "name": "k8s-container",
-      "base-url": "https://storage.googleapis.com/cloudnative-rally/rally2",
+      "base-url": "https://storage.googleapis.com/cloudnative-rally/rally3",
       "documents": [
         {
           "target-data-stream": "k8s-container",
           "source-file": "doc-ds-metrics-kubernetes.container.json.bz2",
           "document-count": 8640000,
-          "uncompressed-bytes": 95910250198
+          "uncompressed-bytes": 96149278913
         }
       ]
     }


### PR DESCRIPTION
Updating the specific rally with new corpora.

The new corpus includes 10k pods 

```bash
cat doc-ds-metrics-kubernetes.pod.json | jq '.kubernetes.pod.name' | sort -u > pod.txt

cat pod.txt| wc -l
   10000
```
