### PR TITLE
[dense-vector] Load queries only once in memory

### DIFF
--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -22,6 +22,7 @@ class KnnParamSource:
             for line in file:
                 self._queries.append(json.loads(line))
         self._iters = 0
+        self.infinite = True
 
     def partition(self, partition_index, total_partitions):
         return self
@@ -70,6 +71,7 @@ class KnnRecallParamSource:
         self._cache = params.get("cache", False)
         self._params = params
         self._queries = []
+        self.infinite = True
 
         cwd = os.path.dirname(__file__)
         with open(os.path.join(cwd, "queries.json"), "r") as file:

--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -15,13 +15,13 @@ class KnnParamSource:
         self._cache = params.get("cache", False)
         self._exact_scan = params.get("exact", False)
         self._params = params
+        self._queries = []
 
         cwd = os.path.dirname(__file__)
         with open(os.path.join(cwd, "queries.json"), "r") as file:
-            lines = file.readlines()
-        self._queries = [json.loads(line) for line in lines]
+            for line in file:
+                self._queries.append(json.loads(line))
         self._iters = 0
-        self.infinite = True
 
     def partition(self, partition_index, total_partitions):
         return self
@@ -69,12 +69,13 @@ class KnnRecallParamSource:
         self._index_name = params.get("index", default_index)
         self._cache = params.get("cache", False)
         self._params = params
+        self._queries = []
 
         cwd = os.path.dirname(__file__)
         with open(os.path.join(cwd, "queries.json"), "r") as file:
-            lines = file.readlines()
-        self._queries = [json.loads(line) for line in lines]
-        self.infinite = True
+            # TODO take a random set of 20 queries instead
+            for line in file:
+                self._queries.append(json.loads(line))
 
     def partition(self, partition_index, total_partitions):
         return self


### PR DESCRIPTION
With this commit we use only one in-memory structure to store the dense_vector track queries (4MiB).