### PR TITLE
Make touch-* bulk operations heavier in tsdb k8s queries track

### DIFF
--- a/tsdb_k8s_queries/README.md
+++ b/tsdb_k8s_queries/README.md
@@ -84,8 +84,8 @@ elastic-package stack up -d -vvv --version=8.7.1
 This track allows to overwrite the following parameters using `--track-params`:
 
 * `bulk_size` (default: 9000)
-* `touch_bulk_size` (default: 500): The bulk size for bulk requests executed during searching.
-* `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
+* `touch_bulk_size` (default: 50): The bulk size for bulk requests executed during searching.
+* `bulk_indexing_clients` (default: 3): Number of clients that issue bulk indexing requests.
 * `touch_bulk_indexing_clients` (default: 4): Number of clients that issue bulk indexing for the bulk tasks that get executed during searching.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.

--- a/tsdb_k8s_queries/README.md
+++ b/tsdb_k8s_queries/README.md
@@ -84,8 +84,9 @@ elastic-package stack up -d -vvv --version=8.7.1
 This track allows to overwrite the following parameters using `--track-params`:
 
 * `bulk_size` (default: 9000)
+* `touch_bulk_size` (default: 1000): The bulk size for bulk requests executed during searching.
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
-* `concurrent_bulk_indexing_clients` (default: 6): Number of clients that issue bulk indexing for the bulk tasks that get executed during searching.
+* `touch_bulk_indexing_clients` (default: 6): Number of clients that issue bulk indexing for the bulk tasks that get executed during searching.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `number_of_replicas` (default: 0)

--- a/tsdb_k8s_queries/README.md
+++ b/tsdb_k8s_queries/README.md
@@ -85,8 +85,8 @@ This track allows to overwrite the following parameters using `--track-params`:
 
 * `bulk_size` (default: 9000)
 * `touch_bulk_size` (default: 50): The bulk size for bulk requests executed during searching.
-* `bulk_indexing_clients` (default: 3): Number of clients that issue bulk indexing requests.
-* `touch_bulk_indexing_clients` (default: 4): Number of clients that issue bulk indexing for the bulk tasks that get executed during searching.
+* `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
+* `touch_bulk_indexing_clients` (default: 3): Number of clients that issue bulk indexing for the bulk tasks that get executed during searching.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `number_of_replicas` (default: 0)

--- a/tsdb_k8s_queries/README.md
+++ b/tsdb_k8s_queries/README.md
@@ -85,6 +85,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 
 * `bulk_size` (default: 9000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
+* `concurrent_bulk_indexing_clients` (default: 6): Number of clients that issue bulk indexing for the bulk tasks that get executed during searching.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `number_of_replicas` (default: 0)

--- a/tsdb_k8s_queries/README.md
+++ b/tsdb_k8s_queries/README.md
@@ -84,9 +84,9 @@ elastic-package stack up -d -vvv --version=8.7.1
 This track allows to overwrite the following parameters using `--track-params`:
 
 * `bulk_size` (default: 9000)
-* `touch_bulk_size` (default: 1000): The bulk size for bulk requests executed during searching.
+* `touch_bulk_size` (default: 500): The bulk size for bulk requests executed during searching.
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
-* `touch_bulk_indexing_clients` (default: 6): Number of clients that issue bulk indexing for the bulk tasks that get executed during searching.
+* `touch_bulk_indexing_clients` (default: 4): Number of clients that issue bulk indexing for the bulk tasks that get executed during searching.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested.
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `number_of_replicas` (default: 0)

--- a/tsdb_k8s_queries/challenges/default.json
+++ b/tsdb_k8s_queries/challenges/default.json
@@ -93,7 +93,7 @@
               {
                 "name": "touch-pod-1-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{bulk_indexing_clients | default(8)}}
+                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
               },
               {
                 "operation": "cpu_usage_per_pod_{{name}}",
@@ -115,7 +115,7 @@
               {
                 "name": "touch-pod-2-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{bulk_indexing_clients | default(8)}}
+                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
               },
               {
                 "operation": "memory_usage_per_pod_{{name}}",
@@ -137,7 +137,7 @@
               {
                 "name": "touch-pod-3-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{bulk_indexing_clients | default(8)}}
+                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
               },
               {
                 "operation": "status_per_pod_{{name}}",
@@ -159,7 +159,7 @@
               {
                 "name": "touch-pod-4-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{bulk_indexing_clients | default(8)}}
+                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
               },
               {
                 "operation": "tx_network_usage_per_pod_{{name}}",
@@ -181,7 +181,7 @@
               {
                 "name": "touch-container-1-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{bulk_indexing_clients | default(8)}}
+                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
               },
               {
                 "operation": "average_container_cpu_{{name}}",
@@ -203,7 +203,7 @@
               {
                 "name": "touch-container-2-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{bulk_indexing_clients | default(8)}}
+                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
               },
               {
                 "operation": "average_container_memory_usage_{{name}}",
@@ -225,7 +225,7 @@
               {
                 "name": "touch-container-3-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{bulk_indexing_clients | default(8)}}
+                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
               },
               {
                 "operation": "cpu_usage_per_container_{{name}}",
@@ -247,7 +247,7 @@
               {
                 "name": "touch-container-4-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{bulk_indexing_clients | default(8)}}
+                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
               },
               {
                 "operation": "memory_usage_per_container_{{name}}",
@@ -269,7 +269,7 @@
               {
                 "name": "touch-pod-5-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{bulk_indexing_clients | default(8)}}
+                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
               },
               {
                 "operation": "unique_deployment_count_{{name}}",
@@ -291,7 +291,7 @@
               {
                 "name": "touch-container-5-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{bulk_indexing_clients | default(8)}}
+                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
               },
               {
                 "operation": "percentile_cpu_usage_per_container_{{name}}",

--- a/tsdb_k8s_queries/challenges/default.json
+++ b/tsdb_k8s_queries/challenges/default.json
@@ -93,7 +93,7 @@
               {
                 "name": "touch-pod-1-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
+                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
               },
               {
                 "operation": "cpu_usage_per_pod_{{name}}",
@@ -115,7 +115,7 @@
               {
                 "name": "touch-pod-2-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
+                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
               },
               {
                 "operation": "memory_usage_per_pod_{{name}}",
@@ -137,7 +137,7 @@
               {
                 "name": "touch-pod-3-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
+                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
               },
               {
                 "operation": "status_per_pod_{{name}}",
@@ -159,7 +159,7 @@
               {
                 "name": "touch-pod-4-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
+                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
               },
               {
                 "operation": "tx_network_usage_per_pod_{{name}}",
@@ -181,7 +181,7 @@
               {
                 "name": "touch-container-1-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
+                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
               },
               {
                 "operation": "average_container_cpu_{{name}}",
@@ -203,7 +203,7 @@
               {
                 "name": "touch-container-2-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
+                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
               },
               {
                 "operation": "average_container_memory_usage_{{name}}",
@@ -225,7 +225,7 @@
               {
                 "name": "touch-container-3-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
+                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
               },
               {
                 "operation": "cpu_usage_per_container_{{name}}",
@@ -247,7 +247,7 @@
               {
                 "name": "touch-container-4-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
+                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
               },
               {
                 "operation": "memory_usage_per_container_{{name}}",
@@ -269,7 +269,7 @@
               {
                 "name": "touch-pod-5-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
+                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
               },
               {
                 "operation": "unique_deployment_count_{{name}}",
@@ -291,7 +291,7 @@
               {
                 "name": "touch-container-5-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{concurrent_bulk_indexing_clients | default(6)}}
+                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
               },
               {
                 "operation": "percentile_cpu_usage_per_container_{{name}}",

--- a/tsdb_k8s_queries/challenges/default.json
+++ b/tsdb_k8s_queries/challenges/default.json
@@ -93,7 +93,7 @@
               {
                 "name": "touch-pod-1-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
+                "clients": {{touch_bulk_indexing_clients}}
               },
               {
                 "operation": "cpu_usage_per_pod_{{name}}",
@@ -115,7 +115,7 @@
               {
                 "name": "touch-pod-2-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
+                "clients": {{touch_bulk_indexing_clients}}
               },
               {
                 "operation": "memory_usage_per_pod_{{name}}",
@@ -137,7 +137,7 @@
               {
                 "name": "touch-pod-3-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
+                "clients": {{touch_bulk_indexing_clients}}
               },
               {
                 "operation": "status_per_pod_{{name}}",
@@ -159,7 +159,7 @@
               {
                 "name": "touch-pod-4-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
+                "clients": {{touch_bulk_indexing_clients}}
               },
               {
                 "operation": "tx_network_usage_per_pod_{{name}}",
@@ -181,7 +181,7 @@
               {
                 "name": "touch-container-1-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
+                "clients": {{touch_bulk_indexing_clients}}
               },
               {
                 "operation": "average_container_cpu_{{name}}",
@@ -203,7 +203,7 @@
               {
                 "name": "touch-container-2-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
+                "clients": {{touch_bulk_indexing_clients}}
               },
               {
                 "operation": "average_container_memory_usage_{{name}}",
@@ -225,7 +225,7 @@
               {
                 "name": "touch-container-3-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
+                "clients": {{touch_bulk_indexing_clients}}
               },
               {
                 "operation": "cpu_usage_per_container_{{name}}",
@@ -247,7 +247,7 @@
               {
                 "name": "touch-container-4-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
+                "clients": {{touch_bulk_indexing_clients}}
               },
               {
                 "operation": "memory_usage_per_container_{{name}}",
@@ -269,7 +269,7 @@
               {
                 "name": "touch-pod-5-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
+                "clients": {{touch_bulk_indexing_clients}}
               },
               {
                 "operation": "unique_deployment_count_{{name}}",
@@ -291,7 +291,7 @@
               {
                 "name": "touch-container-5-{{name}}",
                 "operation": "touch-container-index",
-                "clients": {{touch_bulk_indexing_clients | default(touch_bulk_indexing_clients_default)}}
+                "clients": {{touch_bulk_indexing_clients}}
               },
               {
                 "operation": "percentile_cpu_usage_per_container_{{name}}",

--- a/tsdb_k8s_queries/challenges/default.json
+++ b/tsdb_k8s_queries/challenges/default.json
@@ -24,6 +24,11 @@
                           "field": "@timestamp",
                           "value": {{'"{{_ingest.timestamp}}"'}}
                       }
+                  },
+                  {
+                    "script": {
+                      "source": "Random r  = new Random();ctx['kubernetes']['pod']['uid'] = 'value-' + r.nextLong();"
+                    }
                   }
               ]
             }
@@ -88,7 +93,7 @@
               {
                 "name": "touch-pod-1-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": 1
+                "clients": {{bulk_indexing_clients | default(8)}}
               },
               {
                 "operation": "cpu_usage_per_pod_{{name}}",
@@ -110,7 +115,7 @@
               {
                 "name": "touch-pod-2-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": 1
+                "clients": {{bulk_indexing_clients | default(8)}}
               },
               {
                 "operation": "memory_usage_per_pod_{{name}}",
@@ -132,7 +137,7 @@
               {
                 "name": "touch-pod-3-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": 1
+                "clients": {{bulk_indexing_clients | default(8)}}
               },
               {
                 "operation": "status_per_pod_{{name}}",
@@ -154,7 +159,7 @@
               {
                 "name": "touch-pod-4-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": 1
+                "clients": {{bulk_indexing_clients | default(8)}}
               },
               {
                 "operation": "tx_network_usage_per_pod_{{name}}",
@@ -176,7 +181,7 @@
               {
                 "name": "touch-container-1-{{name}}",
                 "operation": "touch-container-index",
-                "clients": 1
+                "clients": {{bulk_indexing_clients | default(8)}}
               },
               {
                 "operation": "average_container_cpu_{{name}}",
@@ -198,7 +203,7 @@
               {
                 "name": "touch-container-2-{{name}}",
                 "operation": "touch-container-index",
-                "clients": 1
+                "clients": {{bulk_indexing_clients | default(8)}}
               },
               {
                 "operation": "average_container_memory_usage_{{name}}",
@@ -220,7 +225,7 @@
               {
                 "name": "touch-container-3-{{name}}",
                 "operation": "touch-container-index",
-                "clients": 1
+                "clients": {{bulk_indexing_clients | default(8)}}
               },
               {
                 "operation": "cpu_usage_per_container_{{name}}",
@@ -242,7 +247,7 @@
               {
                 "name": "touch-container-4-{{name}}",
                 "operation": "touch-container-index",
-                "clients": 1
+                "clients": {{bulk_indexing_clients | default(8)}}
               },
               {
                 "operation": "memory_usage_per_container_{{name}}",
@@ -264,7 +269,7 @@
               {
                 "name": "touch-pod-5-{{name}}",
                 "operation": "touch-pod-index",
-                "clients": 1
+                "clients": {{bulk_indexing_clients | default(8)}}
               },
               {
                 "operation": "unique_deployment_count_{{name}}",
@@ -286,7 +291,7 @@
               {
                 "name": "touch-container-5-{{name}}",
                 "operation": "touch-container-index",
-                "clients": 1
+                "clients": {{bulk_indexing_clients | default(8)}}
               },
               {
                 "operation": "percentile_cpu_usage_per_container_{{name}}",

--- a/tsdb_k8s_queries/operations/default.json
+++ b/tsdb_k8s_queries/operations/default.json
@@ -1069,7 +1069,7 @@
   "name": "touch-container-index",
   "operation-type": "bulk",
   "corpora" : "k8s-container",
-  "bulk-size": {{touch_bulk_size | default(touch_bulk_size_default)}},
+  "bulk-size": {{touch_bulk_size}},
   "ingest-percentage": 100,
   "pipeline": "timestamp_pipeline"
 },
@@ -1077,7 +1077,7 @@
   "name": "touch-pod-index",
   "operation-type": "bulk",
   "corpora" : "k8s-pod",
-  "bulk-size": {{touch_bulk_size | default(touch_bulk_size_default)}},
+  "bulk-size": {{touch_bulk_size}},
   "ingest-percentage": 100,
   "pipeline": "timestamp_pipeline"
 }

--- a/tsdb_k8s_queries/operations/default.json
+++ b/tsdb_k8s_queries/operations/default.json
@@ -1069,7 +1069,7 @@
   "name": "touch-container-index",
   "operation-type": "bulk",
   "corpora" : "k8s-container",
-  "bulk-size": {{bulk_size | default(9000)}},
+  "bulk-size": {{touch_bulk_size | default(touch_bulk_size_default)}},
   "ingest-percentage": 100,
   "pipeline": "timestamp_pipeline"
 },
@@ -1077,7 +1077,7 @@
   "name": "touch-pod-index",
   "operation-type": "bulk",
   "corpora" : "k8s-pod",
-  "bulk-size": {{bulk_size | default(9000)}},
+  "bulk-size": {{touch_bulk_size | default(touch_bulk_size_default)}},
   "ingest-percentage": 100,
   "pipeline": "timestamp_pipeline"
 }

--- a/tsdb_k8s_queries/operations/default.json
+++ b/tsdb_k8s_queries/operations/default.json
@@ -1069,7 +1069,7 @@
   "name": "touch-container-index",
   "operation-type": "bulk",
   "corpora" : "k8s-container",
-  "bulk-size": 1,
+  "bulk-size": {{bulk_size | default(9000)}},
   "ingest-percentage": 100,
   "pipeline": "timestamp_pipeline"
 },
@@ -1077,7 +1077,7 @@
   "name": "touch-pod-index",
   "operation-type": "bulk",
   "corpora" : "k8s-pod",
-  "bulk-size": 1,
+  "bulk-size": {{bulk_size | default(9000)}},
   "ingest-percentage": 100,
   "pipeline": "timestamp_pipeline"
 }

--- a/tsdb_k8s_queries/track.json
+++ b/tsdb_k8s_queries/track.json
@@ -4,7 +4,7 @@
 {% set search_warmup_iterations = 50 %}
 {% set target_interval = 4 %}
 {% set touch_bulk_indexing_clients_default = 4 %}
-{% set touch_bulk_size_default = 1000 %}
+{% set touch_bulk_size_default = 500 %}
 
 {% set end_time = "2023-05-16T21:00:00.000Z" %}
 {% set time_intervals = {"15_minutes": ["30s", "2023-05-16T20:45:00.000Z"], "2_hours": ["1m", "2023-05-16T19:00:00.000Z"], "24_hours": ["30m", "2023-05-15T21:00:00.000Z"]} %}

--- a/tsdb_k8s_queries/track.json
+++ b/tsdb_k8s_queries/track.json
@@ -3,6 +3,8 @@
 {% set search_iterations = 20 %} 
 {% set search_warmup_iterations = 50 %}
 {% set target_interval = 4 %}
+{% set touch_bulk_indexing_clients_default = 4 %}
+{% set touch_bulk_size_default = 1000 %}
 
 {% set end_time = "2023-05-16T21:00:00.000Z" %}
 {% set time_intervals = {"15_minutes": ["30s", "2023-05-16T20:45:00.000Z"], "2_hours": ["1m", "2023-05-16T19:00:00.000Z"], "24_hours": ["30m", "2023-05-15T21:00:00.000Z"]} %}

--- a/tsdb_k8s_queries/track.json
+++ b/tsdb_k8s_queries/track.json
@@ -3,8 +3,8 @@
 {% set search_iterations = 20 %} 
 {% set search_warmup_iterations = 50 %}
 {% set target_interval = 4 %}
-{% set touch_bulk_indexing_clients_default = 4 %}
-{% set touch_bulk_size_default = 500 %}
+{% set touch_bulk_indexing_clients_default = 3 %}
+{% set touch_bulk_size_default = 100 %}
 
 {% set end_time = "2023-05-16T21:00:00.000Z" %}
 {% set time_intervals = {"15_minutes": ["30s", "2023-05-16T20:45:00.000Z"], "2_hours": ["1m", "2023-05-16T19:00:00.000Z"], "24_hours": ["30m", "2023-05-15T21:00:00.000Z"]} %}

--- a/tsdb_k8s_queries/track.json
+++ b/tsdb_k8s_queries/track.json
@@ -4,7 +4,7 @@
 {% set search_warmup_iterations = 50 %}
 {% set target_interval = 4 %}
 {% set touch_bulk_indexing_clients_default = 3 %}
-{% set touch_bulk_size_default = 100 %}
+{% set touch_bulk_size_default = 50 %}
 
 {% set end_time = "2023-05-16T21:00:00.000Z" %}
 {% set time_intervals = {"15_minutes": ["30s", "2023-05-16T20:45:00.000Z"], "2_hours": ["1m", "2023-05-16T19:00:00.000Z"], "24_hours": ["30m", "2023-05-15T21:00:00.000Z"]} %}

--- a/tsdb_k8s_queries/track.json
+++ b/tsdb_k8s_queries/track.json
@@ -3,8 +3,8 @@
 {% set search_iterations = 20 %} 
 {% set search_warmup_iterations = 50 %}
 {% set target_interval = 4 %}
-{% set touch_bulk_indexing_clients_default = 3 %}
-{% set touch_bulk_size_default = 50 %}
+{% set touch_bulk_indexing_clients = touch_bulk_indexing_clients | default(3) %}
+{% set touch_bulk_size = touch_bulk_size | default(50) %}
 
 {% set end_time = "2023-05-16T21:00:00.000Z" %}
 {% set time_intervals = {"15_minutes": ["30s", "2023-05-16T20:45:00.000Z"], "2_hours": ["1m", "2023-05-16T19:00:00.000Z"], "24_hours": ["30m", "2023-05-15T21:00:00.000Z"]} %}


### PR DESCRIPTION
The `touch-*` bulk operations are specifically used for indexing while searching, 
which allows us to catch performance issues we otherwise wouldn't see.

This change makes these tasks heavier so that more documents get indexed before
a search-idle shard gets refreshed due to a search. This should give more realistic refresh behaviour.

Before a low number of documents would be indexed between searches (around 5), with this
change thousands of documents with multiple clients should be indexed between searches.
There is usually 4 seconds between each search, this remains unchanged.