### PR TITLE
[dense_vector] Allow configurable index settings

### DIFF
--- a/dense_vector/README.md
+++ b/dense_vector/README.md
@@ -28,4 +28,5 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 1): Number of clients that issue bulk indexing requests.
+* `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `number_of_replicas` (default: 0)

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -10,7 +10,8 @@
     },
     {
       "operation": {
-        "operation-type": "create-index"
+        "operation-type": "create-index",
+        "settings": {{index_settings | default({}) | tojson}}
       }
     },
     {


### PR DESCRIPTION
This commit adds configurable index settings via the track parameter `index_settings`. This something typically supported by most standard tracks which was missing from `dense_vector`.