### PR TITLE
Use keyword arguments for Elasticsearch API methods

### DIFF
--- a/elastic/shared/runners/datastream.py
+++ b/elastic/shared/runners/datastream.py
@@ -44,7 +44,7 @@ async def create(es, params):
             create_data_stream = None
     if create_data_stream:
         logger.debug("Create data stream: [%s]", data_stream)
-        await es.indices.create_data_stream(data_stream)
+        await es.indices.create_data_stream(name=data_stream)
         ops += 1
     return ops, "ops"
 


### PR DESCRIPTION
Positional arguments can't be used with Elasticsearch API methods. Fixed a call where a keword was missing.