### PR TITLE
Remove data-url property

### DIFF
--- a/geonames/track.json
+++ b/geonames/track.json
@@ -2,7 +2,6 @@
 {
   "version": 2,
   "description": "POIs from Geonames",
-  "data-url": "http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/geonames",
   "indices": [
     {
       "name": "geonames",


### PR DESCRIPTION
I believe this single line caused lot of people (me included) to think we were still using S3.