### PR TITLE
Fix template issues in the k8s_metrics track

### DIFF
--- a/k8s_metrics/challenges/default.json
+++ b/k8s_metrics/challenges/default.json
@@ -31,7 +31,8 @@
     {
       "name": "create-track-composable-templates",
       "operation": {
-        "operation-type": "create-composable-template"
+        "operation-type": "create-composable-template",
+        "template": "metrics-kubernetes.pod-template"
       }
     },
     {
@@ -80,7 +81,8 @@
     {
       "name": "create-track-component-templates",
       "operation": {
-        "operation-type": "create-component-template"
+        "operation-type": "create-component-template",
+        "template": "metrics-kubernetes.pod-template"
       }
     },
     {
@@ -153,7 +155,8 @@
     {
       "name": "create-track-composable-templates",
       "operation": {
-        "operation-type": "create-composable-template"
+        "operation-type": "create-composable-template",
+        "template": "metrics-kubernetes.pod-template"
       }
     },
     {

--- a/k8s_metrics/templates/metrics-kubernetes.pod@custom.json
+++ b/k8s_metrics/templates/metrics-kubernetes.pod@custom.json
@@ -5,12 +5,11 @@
       "lifecycle": {},
       "settings": {
         "index": {
-          "fast_refresh": true,
           "number_of_shards": {{number_of_shards | default(1)}},
           "number_of_replicas": {{number_of_replicas | default(1)}},
-          {% if refresh_interval %}
+          {%- if refresh_interval %}
           "refresh_interval": "{{refresh_interval}}",
-          {% endif %}
+          {%- endif %}
           "codec": "best_compression",
           "mapping": {
             "total_fields": {


### PR DESCRIPTION
This PR addresses template loading issues in the k8_metrics track as neither component nor composable templates are loading in the current state.

* 9ec41a02d1eeb738e8ec68698c7590123ad2c07c corrects the Jinja template to address the failed loading of component templates.
* 4a2852b487bcd380c9f1cf1ca9a388e57697b56d specifies loading of a single composable template to get around an issue created by https://github.com/elastic/elasticsearch/pull/97417. It means the track challenge `append-no-conflicts-metrics-with-fast-refresh` will not work with `fast_refresh` enabled until a solution can be achieved.