### PR TITLE
Reset the query iterator when all queries are exhausted

### DIFF
--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -54,6 +54,8 @@ class KnnParamSource:
                 "_source": False,
             }
         self._iters += 1
+        if self._iters >= len(self._queries):
+            self._iters = 0
         return result
 
 


### PR DESCRIPTION
If the benchmarked Elasticsearch instance is fast enough, rally might iterate through all the queries.

If that occurs, an error happens like this:
```
  File "<snip>/.rally/benchmarks/tracks/default/dense_vector/track.py", line 50, in params
    "query_vector": self._queries[self._iters],

IndexError: list index out of range
```

This commit resets the iterator back to `0` when we exceed the number of queries available.