### PR TITLE
Add max_num_segments parameter for force_merge operation to all tracks

### DIFF
--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -86,7 +86,7 @@
       "operation": {
         "operation-type": "force-merge",
         "mode" : "polling",
-        "max-num-segments": 1,
+        "max-num-segments": {{ max_num_segments | default(1) }},
         "request-timeout": 7200,
         "include-in-reporting": true
       }

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -37,7 +37,7 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "max-num-segments": 1,
+            "max-num-segments": {{ max_num_segments | default(1) }},
             "request-timeout": 7200
           }
         },

--- a/nested/challenges/default.json
+++ b/nested/challenges/default.json
@@ -38,6 +38,7 @@
         {
           "operation": {
             "operation-type": "force-merge",
+            "max-num-segments": {{ max_num_segments | default(1) }},
             "request-timeout": 7200
           }
         },

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -38,6 +38,7 @@
         {
           "operation": {
             "operation-type": "force-merge",
+            "max-num-segments": {{ max_num_segments | default(1) }},
             "request-timeout": 7200
           }
         },

--- a/pmc/challenges/default.json
+++ b/pmc/challenges/default.json
@@ -47,6 +47,7 @@
         {
           "operation": {
             "operation-type": "force-merge",
+            "max-num-segments": {{ max_num_segments | default(1) }},
             "request-timeout": 7200
           }
         },


### PR DESCRIPTION
Not all tracks currently allow configuring the maximum number of segments for
a force merge operation.  Merging to a single segment can be very expensive and
is not always necessary for a benchmark.  This commit makes the number of 
segments targetted by a force merge configurable in all tracks in the repo.