### PR TITLE
k8s_metrics: add fast refresh indexing and search challenges

### DIFF
--- a/k8s_metrics/README.md
+++ b/k8s_metrics/README.md
@@ -75,3 +75,21 @@ Index a metrics document corpus while indexing a small Kibana corpus to a separa
 * `number_of_replicas` (default: `1`)
 * `number_of_shards` (default: `1`)
 * `refresh_interval` (default: `unset`)
+
+### `fast-refresh-index-only`
+
+Index a small Kibana corpus to a system index with fast refresh enabled. This challenge can be executed against serverless Elasticsearch and requires the `kibana_system` security role for the authenticated user.
+
+#### Parameters
+
+* `fast_refresh_clients` (default: `1`)
+* `fast_refresh_indexing_throughput` (default: `3`)
+
+### `fast-refresh-index-with-search`
+
+Index a small Kibana corpus to a system index with fast refresh enabled, and simultaneously perform searches on the index. This challenge can be executed against serverless Elasticsearch and requires the `kibana_system` security role for the authenticated user.
+
+#### Parameters
+
+* `fast_refresh_clients` (default: `1`)
+* `fast_refresh_indexing_throughput` (default: `3`)

--- a/k8s_metrics/challenges/default.json
+++ b/k8s_metrics/challenges/default.json
@@ -255,4 +255,182 @@
       }
     }
   ]
+},
+{
+  "name": "fast-refresh-index-only",
+  "description": "Index to a fast refresh system index.",
+  "schedule": [
+    {
+      "name": "delete-fast-refresh-index",
+      "operation": {
+        "operation-type": "delete-index",
+        "index": ".kibana_k8s_metrics"
+      }
+    },
+    {
+      "operation": "create-fast-refresh-index"
+    },
+    {
+      "name": "check-cluster-health",
+      "operation": {
+        "operation-type": "cluster-health",
+        "request-params": {
+          "wait_for_status": "{{cluster_health | default('green')}}",
+          "wait_for_no_relocating_shards": "true"
+        },
+        "retry-until-success": true
+      }
+    },
+    {
+      "operation": "fast-refresh-index",
+      "clients": {{fast_refresh_clients | default(1)}},
+      "target-throughput": {{fast_refresh_indexing_throughput | default(3)}}
+    }
+  ]
+},
+{
+  "name": "fast-refresh-index-with-search",
+  "description": "Index to a fast refresh system index while searching the index.",
+  "schedule": [
+    {
+      "name": "delete-fast-refresh-index",
+      "operation": {
+        "operation-type": "delete-index",
+        "index": ".kibana_k8s_metrics"
+      }
+    },
+    {
+      "operation": "create-fast-refresh-index"
+    },
+    {
+      "name": "check-cluster-health",
+      "operation": {
+        "operation-type": "cluster-health",
+        "request-params": {
+          "wait_for_status": "{{cluster_health | default('green')}}",
+          "wait_for_no_relocating_shards": "true"
+        },
+        "retry-until-success": true
+      }
+    },
+    {
+      "parallel": {
+        "completed-by": "fast-refresh-index",
+        "tasks": [
+          {
+            "operation": "fast-refresh-index",
+            "clients": {{fast_refresh_clients | default(1)}},
+            "target-throughput": {{fast_refresh_indexing_throughput | default(3)}}
+          },
+          {
+            "name": "search-fast-refresh-index",
+            "operation": {
+              "operation-type": "composite",
+              "requests": [
+                {
+                  "stream": [
+                    {
+                      "name": "search-system",
+                      "operation-type": "search",
+                      "detailed-results": "true",
+                      "index": ".kibana_k8s_metrics",
+                      "cache": "false",
+                      "body": {
+                        "_source": [
+                          "type"
+                        ],
+                        "query": {
+                          "bool": {
+                            "filter": [
+                              {
+                                "term": {
+                                  "type": "dashboard"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "search-system",
+                      "operation-type": "search",
+                      "detailed-results": "true",
+                      "index": ".kibana_k8s_metrics",
+                      "cache": "false",
+                      "body": {
+                        "_source": [
+                          "type"
+                        ],
+                        "query": {
+                          "bool": {
+                            "filter": [
+                              {
+                                "term": {
+                                  "type": "index"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "search-system",
+                      "operation-type": "search",
+                      "detailed-results": "true",
+                      "index": ".kibana_k8s_metrics",
+                      "cache": "false",
+                      "body": {
+                        "_source": [
+                          "type"
+                        ],
+                        "query": {
+                          "bool": {
+                            "filter": [
+                              {
+                                "term": {
+                                  "type": "tag"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "search-system",
+                      "operation-type": "search",
+                      "detailed-results": "true",
+                      "index": ".kibana_k8s_metrics",
+                      "cache": "false",
+                      "body": {
+                        "_source": [
+                          "type"
+                        ],
+                        "query": {
+                          "bool": {
+                            "filter": [
+                              {
+                                "term": {
+                                  "type": "search"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "warmup-time-period": 60,
+            "time-period": 99999,
+            "target-interval": 5
+          }
+        ]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Add two challenges to the k8s_metrics track for search-after-write benchmarking: `fast-refresh-index-only` and `fast-refresh-index-with-search`.

* Add fast-refresh-index-only
* Add fast-refresh-index-with-search
* Use warmup-time-period
* Use target-interval
* Add queries

ES-6044 relates