### PR TITLE
Add initial autoscaling benchmark

### DIFF
--- a/nyc_taxis/challenges/common/autoscale-schedule.json
+++ b/nyc_taxis/challenges/common/autoscale-schedule.json
@@ -1,0 +1,55 @@
+{
+  "name": "delete-index",
+  "operation": {
+    "operation-type": "delete-index"
+  }
+},
+{
+  "name": "create-index",
+  "operation": {
+    "operation-type": "create-index",
+    "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
+      "index.store.type": "{{store_type | default('fs')}}",
+      "index.codec": "best_compression",
+      "index.refresh_interval": "30s",
+      "index.translog.flush_threshold_size": "4g"
+    }{%- endif %}
+  }
+},
+{
+  "name": "check-cluster-health",
+  "operation": {
+    "operation-type": "cluster-health",
+    "index": "nyc_taxis",
+    "request-params": {
+      "wait_for_status": "{{cluster_health | default('green')}}"
+    },
+    "retry-until-success": true
+  }
+}
+{%- set p_as_bulk_step_count = as_bulk_step_count | default(1) %}
+{%- set p_as_bulk_clients_base = as_bulk_clients_base | default(8) %}
+{%- set p_as_downscale_factor = as_downscale_factor | default(3) %}
+{%- set p_as_bulk_iterations = as_bulk_iterations | default(1) %}
+{%- set p_ingest_percentage = ingest_percentage | default(100) %}
+{%- for step in range(1, p_as_bulk_step_count + 1, 1) %},
+    {%- if step % p_as_downscale_factor == 0 %}
+        {%- set task_label = "base" %}
+        {%- set bulk_clients = p_as_bulk_clients_base %}
+        {%- set p_ingest_percentage = p_ingest_percentage * 0.5 %}
+        {%- set p_as_bulk_iterations = 1 %}
+    {%- else %}
+        {%- set task_label = "step" %}
+        {%- set bulk_clients = p_as_bulk_clients_base * step %}
+    {%- endif %}
+{
+  "name": "bulk-{{step}}-{{bulk_clients}}clients-{{task_label}}",
+  "clients": {{bulk_clients}},
+  "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+  "operation": {
+    "operation-type": "bulk",
+    "bulk-size": {{bulk_size | default(10000)}},
+    "ingest-percentage": {{p_ingest_percentage|int}}
+  }
+}
+{%- endfor %}

--- a/nyc_taxis/challenges/common/autoscale-schedule.json
+++ b/nyc_taxis/challenges/common/autoscale-schedule.json
@@ -29,15 +29,15 @@
 }
 {%- set p_as_bulk_step_count = as_bulk_step_count | default(1) %}
 {%- set p_as_bulk_clients_base = as_bulk_clients_base | default(8) %}
-{%- set p_as_downscale_factor = as_downscale_factor | default(3) %}
+{%- set p_as_reduce_factor = as_reduce_factor | default(3) %}
 {%- set p_ingest_percentage = ingest_percentage | default(100) %}
 {%- for step in range(1, p_as_bulk_step_count + 1, 1) %},
-    {%- if step % p_as_downscale_factor == 0 %}
-        {%- set task_label = "base" %}
+    {%- if step % p_as_reduce_factor == 0 %}
+        {%- set task_label = "reduced" %}
         {%- set bulk_clients = p_as_bulk_clients_base %}
         {%- set p_ingest_percentage = p_ingest_percentage * 0.5 %}
     {%- else %}
-        {%- set task_label = "step" %}
+        {%- set task_label = "full" %}
         {%- set bulk_clients = p_as_bulk_clients_base * step %}
     {%- endif %}
 {

--- a/nyc_taxis/challenges/common/autoscale-schedule.json
+++ b/nyc_taxis/challenges/common/autoscale-schedule.json
@@ -27,7 +27,7 @@
     "retry-until-success": true
   }
 }
-{%- set p_as_bulk_step_count = as_bulk_step_count | default(1) %}
+{%- set p_as_bulk_step_count = as_bulk_step_count | default(3) %}
 {%- set p_as_bulk_clients_base = as_bulk_clients_base | default(8) %}
 {%- set p_as_reduce_factor = as_reduce_factor | default(3) %}
 {%- set p_ingest_percentage = ingest_percentage | default(100) %}

--- a/nyc_taxis/challenges/common/autoscale-schedule.json
+++ b/nyc_taxis/challenges/common/autoscale-schedule.json
@@ -30,14 +30,12 @@
 {%- set p_as_bulk_step_count = as_bulk_step_count | default(1) %}
 {%- set p_as_bulk_clients_base = as_bulk_clients_base | default(8) %}
 {%- set p_as_downscale_factor = as_downscale_factor | default(3) %}
-{%- set p_as_bulk_iterations = as_bulk_iterations | default(1) %}
 {%- set p_ingest_percentage = ingest_percentage | default(100) %}
 {%- for step in range(1, p_as_bulk_step_count + 1, 1) %},
     {%- if step % p_as_downscale_factor == 0 %}
         {%- set task_label = "base" %}
         {%- set bulk_clients = p_as_bulk_clients_base %}
         {%- set p_ingest_percentage = p_ingest_percentage * 0.5 %}
-        {%- set p_as_bulk_iterations = 1 %}
     {%- else %}
         {%- set task_label = "step" %}
         {%- set bulk_clients = p_as_bulk_clients_base * step %}

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -939,4 +939,12 @@
       "schedule": [
         {{ rally.collect(parts="common/update-aggs-only-schedule.json") }}
       ]
+    },
+    {
+      "name": "autoscale",
+      "description": "Bulk index with a varying number of clients",
+      "default": false,
+      "schedule": [
+        {{ rally.collect(parts="common/autoscale-schedule.json") }}
+      ]
     }


### PR DESCRIPTION
This commit adds a workload to exercise the performance and functionality of Serverless autoscaling using the nyc_taxis track. The challenge executes one or more iterations; i.e., the "step", starting with a "base" number of clients. There are three primary track parameters:

* `as_bulk_clients_base` (default: `8`): The base number of clients at the start of the benchmark.
* `as_bulk_step_count` (default: `3`): The number of times to execute bulk operations. Increasing the step increases the number of bulk clients for each iteration of the step.
* `as_reduce_factor` (default: `3`): An integer indicating how often to insert a reduced bulk operation into the loop. 

At the minimum, step and reduce should be equal to give the benchmark a chance to run at least one reduce iteration. For a heavier benchmark, configure the step count to 6, leaving the other parameters unchanged.
 