### PR TITLE
Support DLM/ILM conditional for auditbeat templates

### DIFF
--- a/elastic/logs/templates/composable/auditbeat-frozen.json
+++ b/elastic/logs/templates/composable/auditbeat-frozen.json
@@ -3,9 +3,17 @@
     "auditbeatfrozen-*"
   ],
   "template": {
+  {% if not lifecycle or lifecycle == "ilm" -%}
     "settings": {
-      "index.lifecycle.name": "auditbeat-frozen"
+      "index": {
+        "lifecycle": {
+          "name": "auditbeat-frozen"
+        }
+      }
     }
+  {%- elif lifecycle == "dlm" -%}
+    "lifecycle": {}
+  {%- endif -%}
   },
   "composed_of" : ["auditbeat-mappings"],
   "priority": 1,

--- a/elastic/logs/templates/composable/auditbeat-quantitative.json
+++ b/elastic/logs/templates/composable/auditbeat-quantitative.json
@@ -3,9 +3,17 @@
     "auditbeatquantitative-*"
   ],
   "template": {
+  {% if not lifecycle or lifecycle == "ilm" -%}
     "settings": {
-      "index.lifecycle.name": "auditbeat-quantitative"
+      "index": {
+        "lifecycle": {
+          "name": "auditbeat-quantitative"
+        }
+      }
     }
+  {%- elif lifecycle == "dlm" -%}
+    "lifecycle": {}
+  {%- endif -%}
   },
   "composed_of" : ["auditbeat-mappings"],
   "priority": 1,

--- a/elastic/logs/templates/composable/auditbeat.json
+++ b/elastic/logs/templates/composable/auditbeat.json
@@ -3,9 +3,17 @@
     "auditbeat-*"
   ],
   "template": {
+  {% if not lifecycle or lifecycle == "ilm" -%}
     "settings": {
-      "index.lifecycle.name": "auditbeat"
+      "index": {
+        "lifecycle": {
+          "name": "auditbeat"
+        }
+      }
     }
+  {%- elif lifecycle == "dlm" -%}
+    "lifecycle": {}
+  {%- endif -%}
   },
   "composed_of" : ["auditbeat-mappings"],
   "priority": 1,


### PR DESCRIPTION
https://github.com/elastic/rally-tracks/pull/406 introduced DLM support for the `elastic/logs` track, but the auditbeat templates still have ILM policies defined, which will fail when ran against serverless Elasticsearch.