### PR TITLE
k8s_metrics/fast-refresh-index-with-search: parameter adjustments

### DIFF
--- a/k8s_metrics/README.md
+++ b/k8s_metrics/README.md
@@ -11,6 +11,7 @@ K8s Metrics is a track intended for benchmarking refresh on Elasticsearch using 
 | `fast_refresh_bulk_size` | `15` | The bulk batch size of the fast refresh index. |
 | `fast_refresh_clients` | `1` | The number of bulk indexing clients for fast refresh indexing. |
 | `fast_refresh_indexing_throughput` | `2.7` | The throughput, in operations per second, for fast refresh indexing. |
+| `fast_refresh_search_throughput` | `1` | The throughput, in operations per second, for fast refresh search. |
 | `ingest_percentage` | `100` | The percentage of the document corpus to index. |
 | `manual_refresh_clients` | `1` | The number of clients to use for manual refresh operations. |
 | `manual_refresh_interval` | `15` | The interval, in seconds, for issuing manual refresh requests. |
@@ -96,3 +97,4 @@ Index a small Kibana corpus to a system index with fast refresh enabled, and sim
 * `fast_refresh_bulk_size` (default: `15`)
 * `fast_refresh_clients` (default: `1`)
 * `fast_refresh_indexing_throughput` (default: `2.7`)
+* `fast_refresh_search_throughput` (default: `1`)

--- a/k8s_metrics/challenges/default.json
+++ b/k8s_metrics/challenges/default.json
@@ -427,7 +427,7 @@
             },
             "warmup-time-period": 5,
             "time-period": 99999,
-            "target-interval": 5
+            "target-throughput": 1
           }
         ]
       }

--- a/k8s_metrics/challenges/default.json
+++ b/k8s_metrics/challenges/default.json
@@ -427,7 +427,7 @@
             },
             "warmup-time-period": 5,
             "time-period": 99999,
-            "target-throughput": 1
+            "target-throughput": {{fast_refresh_search_throughput | default(1)}}
           }
         ]
       }

--- a/k8s_metrics/challenges/default.json
+++ b/k8s_metrics/challenges/default.json
@@ -425,7 +425,7 @@
                 }
               ]
             },
-            "warmup-time-period": 60,
+            "warmup-time-period": 5,
             "time-period": 99999,
             "target-interval": 5
           }


### PR DESCRIPTION
This commit adjusts the search warmup and target throughput parameters for the k8s_metrics `fast-refresh-index-with-search` challenge to correct an issue where all search operations were finished within the warmup period. It also adds and documents a parameter for adjusting the search throughput.