### PR TITLE
elastic/logs: Determine lifecycle automatically

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -218,7 +218,7 @@ The following parameters are available:
 * `start_date` (default: `2020-01-01` ) - The start date of the data. The `end_date` minus this value will determine the time range assigned to the data and also directly impact the total volume indexed. Must be less than the `end_date`.
 * `end_date` (default: `2020-01-02` ) - The end date of the data. This value minus the `start_date` will determine the time range assigned to the data and also directly impact the total volume indexed. Must be greater than the `start_date`.
 * `corpora_uri_base` (default: `https://rally-tracks.elastic.co`) - Specify the base location of the datasets used by this track.
-* `lifecycle` (default: `ilm`) - Specifies the lifecycle management feature to use for data streams. Use `ilm` for index lifecycle management or `dlm` for data lifecycle management. `dlm` is required for benchmarking Serverless Elasticsearch.
+* `lifecycle` (default: unset to fall back on Serverless detection) - Specifies the lifecycle management feature to use for data streams. Use `ilm` for index lifecycle management or `dlm` for data lifecycle management. By default, `dlm` will be used for benchmarking Serverless Elasticsearch.
 
 ### Data Download Parameters
 

--- a/elastic/logs/tasks/index-setup.json
+++ b/elastic/logs/tasks/index-setup.json
@@ -8,7 +8,7 @@
   }
 },
 {%- endif %}
-{%- if not lifecycle or lifecycle == "ilm" %}
+{%- if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
 {
   "name": "insert-ilm",
   "tags": ["setup"],

--- a/elastic/logs/templates/component/track-data-stream-lifecycle.json
+++ b/elastic/logs/templates/component/track-data-stream-lifecycle.json
@@ -1,6 +1,6 @@
 {
   "template": {
-{% if not lifecycle or lifecycle == "ilm" -%}
+{% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
     "settings": {
       "index": {
         "lifecycle": {
@@ -8,7 +8,7 @@
         }
       }
     }
-{%- elif lifecycle == "dlm" -%}
+{%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
     "lifecycle": {}
 {%- endif -%}
   }

--- a/elastic/logs/templates/composable/auditbeat-frozen.json
+++ b/elastic/logs/templates/composable/auditbeat-frozen.json
@@ -3,7 +3,7 @@
     "auditbeatfrozen-*"
   ],
   "template": {
-  {% if not lifecycle or lifecycle == "ilm" -%}
+  {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
     "settings": {
       "index": {
         "lifecycle": {
@@ -11,7 +11,7 @@
         }
       }
     }
-  {%- elif lifecycle == "dlm" -%}
+  {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
     "lifecycle": {}
   {%- endif -%}
   },

--- a/elastic/logs/templates/composable/auditbeat-quantitative.json
+++ b/elastic/logs/templates/composable/auditbeat-quantitative.json
@@ -3,7 +3,7 @@
     "auditbeatquantitative-*"
   ],
   "template": {
-  {% if not lifecycle or lifecycle == "ilm" -%}
+  {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
     "settings": {
       "index": {
         "lifecycle": {
@@ -11,7 +11,7 @@
         }
       }
     }
-  {%- elif lifecycle == "dlm" -%}
+  {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
     "lifecycle": {}
   {%- endif -%}
   },

--- a/elastic/logs/templates/composable/auditbeat.json
+++ b/elastic/logs/templates/composable/auditbeat.json
@@ -3,7 +3,7 @@
     "auditbeat-*"
   ],
   "template": {
-  {% if not lifecycle or lifecycle == "ilm" -%}
+  {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
     "settings": {
       "index": {
         "lifecycle": {
@@ -11,7 +11,7 @@
         }
       }
     }
-  {%- elif lifecycle == "dlm" -%}
+  {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
     "lifecycle": {}
   {%- endif -%}
   },


### PR DESCRIPTION
Now that Rally 2.9.0 is out, we can take advantage of the `build_flavor` track parameter to decide whether to use ILM or DLM. I have not tested this however. @b-deam @inqueue Since you recently touched those benchmarks, do you know what is the best way to test this? After all, the auditbeat settings were incorrect for a while and it took us some time to notice.