### PR TITLE
Running node-stats query unthrottled

### DIFF
--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -68,8 +68,7 @@
         {
           "operation": "node-stats",
           "warmup-iterations": 100,
-          "iterations": 1000,
-          "target-throughput": 90
+          "iterations": 1000
         },
         {
           "operation": "default",


### PR DESCRIPTION
Removed target-throughput for node-stats to make it more platform agnostic
Relates to https://github.com/elastic/rally-tracks/pull/266