### PR TITLE
Add searches on multiple segments for dense vector

### DIFF
--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -83,6 +83,25 @@
       }
     },
     {
+      "name": "wait-until-merges-finish_after_update",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "_all",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": false
+      }
+    },
+    {
+      "name": "knn-search-100-1000_multiple_segments",
+      "operation": "knn-search-100-1000",
+      "warmup-iterations": 100,
+      "iterations": 1000
+    },
+    {
       "operation": {
         "operation-type": "force-merge",
         "mode" : "polling",

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -96,10 +96,24 @@
       }
     },
     {
+      "name": "knn-search-10-100_multiple_segments",
+      "operation": "knn-search-10-100",
+      "warmup-iterations": 100,
+      "iterations": 1000
+    },
+    {
       "name": "knn-search-100-1000_multiple_segments",
       "operation": "knn-search-100-1000",
       "warmup-iterations": 100,
       "iterations": 1000
+    },
+    {
+      "name": "knn-recall-10-100_multiple_segments",
+      "operation": "knn-recall-10-100"
+    },
+    {
+      "name": "knn-recall-100-1000_multiple_segments",
+      "operation": "knn-recall-100-1000"
     },
     {
       "operation": {


### PR DESCRIPTION
With introduction of concurrent search across multiple segments elastic/elasticsearch/pull/98204 there is a need to measure search across multiple segments before force merge.

This PR adds this operation.