### PR TITLE
autoscaling: remove index settings for serverless

### DIFF
--- a/nyc_taxis/challenges/common/autoscale-schedule.json
+++ b/nyc_taxis/challenges/common/autoscale-schedule.json
@@ -10,8 +10,7 @@
     "operation-type": "create-index",
     "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
       "index.store.type": "{{store_type | default('fs')}}",
-      "index.codec": "best_compression",
-      "index.refresh_interval": "30s"
+      "index.codec": "best_compression"
     }{%- endif %}
   }
 },

--- a/nyc_taxis/challenges/common/autoscale-schedule.json
+++ b/nyc_taxis/challenges/common/autoscale-schedule.json
@@ -11,8 +11,7 @@
     "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
       "index.store.type": "{{store_type | default('fs')}}",
       "index.codec": "best_compression",
-      "index.refresh_interval": "30s",
-      "index.translog.flush_threshold_size": "4g"
+      "index.refresh_interval": "30s"
     }{%- endif %}
   }
 },


### PR DESCRIPTION
Remove the refresh interval and translog flush threshold size to allow them to use the Elasticsearch Serverless defaults.