### PR TITLE
Fix typing in wikipedia track

### DIFF
--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -4,7 +4,7 @@ import random
 import re
 from os import getcwd
 from os.path import dirname
-from typing import Iterator
+from typing import Iterator, List
 
 from esrally.track.params import ParamSource
 
@@ -16,7 +16,7 @@ SEARCH_APPLICATION_ROOT_ENDPOINT: str = "/_application/search_application"
 QUERY_CLEAN_REXEXP = regexp = re.compile("[^0-9a-zA-Z]+")
 
 
-def query_samples(k: int, random_seed: int = None) -> list[str]:
+def query_samples(k: int, random_seed: int = None) -> List[str]:
     with open(QUERIES_FILENAME) as queries_file:
         csv_reader = csv.reader(queries_file)
         next(csv_reader)


### PR DESCRIPTION
https://github.com/elastic/rally-tracks/pull/458 modified `query_samples()` to return `list` instead of `Iterator`. This typing syntax is unavailable in Python 3.8 which we still support in Rally. This is breaking Rally integration tests, specifically `rally list tracks`.

```
2023-10-02 09:37:14,580 -not-actor-/PID:98993 esrally.utils.modules ERROR Could not load component [wikipedia]
Traceback (most recent call last):
  File "/Users/grzegorz/src/rally/esrally/utils/modules.py", line 106, in load
    root_module = self._load_component(component_name, module_dirs)
  File "/Users/grzegorz/src/rally/esrally/utils/modules.py", line 65, in _load_component
    m = importlib.import_module(p)
  File "/Users/grzegorz/.pyenv/versions/3.8.16/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/grzegorz/.rally/benchmarks/tracks/default/wikipedia/track.py", line 19, in <module>
    def query_samples(k: int, random_seed: int = None) -> list[str]:
TypeError: 'type' object is not subscriptable
```