### PR TITLE
Update elastic/logs query challenge ESQL operations

### DIFF
--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -59,50 +59,43 @@
       "operation": "esql_basic_count_group_1",
       "clients": 1,
       "warmup-iterations": 10,
-      "iterations": 50,
-      "tags": ["esql"]
+      "iterations": 50
     },
     {
       "operation": "esql_basic_count_group_2",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 20,
-      "tags": ["esql"]
+      "iterations": 20
     },
     {
       "operation": "esql_basic_count_group_3",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 10,
-      "tags": ["esql"]
+      "iterations": 10
     },
     {
       "operation": "esql_basic_count_group_4",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 10,
-      "tags": ["esql"]
+      "iterations": 10
     },
     {
       "operation": "esql_time_range_and_date_histogram_two_groups_pre_filter",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 20,
-      "tags": ["esql"]
+      "iterations": 20
     },
     {
       "operation": "esql_time_range_and_date_histogram_two_groups_post_filter",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 20,
-      "tags": ["esql"]
+      "iterations": 20
     },
     {
       "operation": "esql_dissect_duration_and_stats",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 20,
-      "tags": ["esql"]
+      "iterations": 20
     }
   ]
 }

--- a/elastic/logs/operations/esql.json
+++ b/elastic/logs/operations/esql.json
@@ -1,66 +1,38 @@
     {
       "name": "esql_basic_count_group_1",
-      "operation-type": "raw-request",
-      "method": "POST",
-      "path": "/_query",
-      "body": {
-        "query": "FROM logs-* | STATS count=count(*) BY agent.version | SORT count DESC | LIMIT 20"
-      }
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS count=count(*) BY agent.version | SORT count DESC | LIMIT 20"
     },
     {
       "name": "esql_basic_count_group_2",
-      "operation-type": "raw-request",
-      "method": "POST",
-      "path": "/_query",
-      "body": {
-        "query": "FROM logs-* | STATS count=count(*) BY agent.version, agent.type | SORT count DESC | LIMIT 20"
-      }
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS count=count(*) BY agent.version, agent.type | SORT count DESC | LIMIT 20"
     },
     {
       "name": "esql_basic_count_group_3",
-      "operation-type": "raw-request",
-      "method": "POST",
-      "path": "/_query",
-      "body": {
-        "query": "FROM logs-* | STATS count=count(*) BY agent.version, agent.type, agent.hostname | SORT count DESC | LIMIT 20"
-      }
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS count=count(*) BY agent.version, agent.type, agent.hostname | SORT count DESC | LIMIT 20"
     },
     {
       "name": "esql_basic_count_group_4",
-      "operation-type": "raw-request",
-      "method": "POST",
-      "path": "/_query",
-      "body": {
-        "query": "FROM logs-* | STATS count=count(*) BY agent.version, agent.type, agent.hostname, agent.id | SORT count DESC | LIMIT 20"
-      }
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS count=count(*) BY agent.version, agent.type, agent.hostname, agent.id | SORT count DESC | LIMIT 20"
     },
     {
       "name": "esql_time_range_and_date_histogram_two_groups_pre_filter",
       "description": "Based on observability queries for average CPU over date histogram",
-      "operation-type": "raw-request",
-      "method": "POST",
-      "path": "/_query",
-      "body": {
-        "query": "FROM logs-* | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-01\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-02\") | WHERE @timestamp >= start_time AND @timestamp <= end_time AND http.response.body.bytes IS NOT NULL | EVAL bucket = DATE_TRUNC(1 hour, @timestamp) | STATS avg=AVG(http.response.body.bytes), min=MIN(http.response.body.bytes), max=MAX(http.response.body.bytes) BY data_stream.dataset, bucket | KEEP data_stream.dataset, bucket, min, avg, max"
-      }
+      "operation-type": "esql",
+      "query": "FROM logs-* | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-01\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-02\") | WHERE @timestamp >= start_time AND @timestamp <= end_time AND http.response.body.bytes IS NOT NULL | EVAL bucket = DATE_TRUNC(1 hour, @timestamp) | STATS avg=AVG(http.response.body.bytes), min=MIN(http.response.body.bytes), max=MAX(http.response.body.bytes) BY data_stream.dataset, bucket | KEEP data_stream.dataset, bucket, min, avg, max"
     },
     {
       "name": "esql_time_range_and_date_histogram_two_groups_post_filter",
       "description": "Based on observability queries for average CPU over date histogram",
-      "operation-type": "raw-request",
-      "method": "POST",
-      "path": "/_query",
-      "body": {
-        "query": "FROM logs-* | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-01\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-02\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | EVAL bucket = DATE_TRUNC(1 hour, @timestamp) | STATS avg=AVG(http.response.body.bytes), min=MIN(http.response.body.bytes), max=MAX(http.response.body.bytes) BY data_stream.dataset, bucket | WHERE min IS NOT NULL | KEEP data_stream.dataset, bucket, min, avg, max"
-      }
+      "operation-type": "esql",
+      "query": "FROM logs-* | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-01\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-02\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | EVAL bucket = DATE_TRUNC(1 hour, @timestamp) | STATS avg=AVG(http.response.body.bytes), min=MIN(http.response.body.bytes), max=MAX(http.response.body.bytes) BY data_stream.dataset, bucket | WHERE min IS NOT NULL | KEEP data_stream.dataset, bucket, min, avg, max"
     },
     {
       "name": "esql_dissect_duration_and_stats",
       "description": "Based on observability queries for duration average",
-      "operation-type": "raw-request",
-      "method": "POST",
-      "path": "/_query",
-      "body": {
-        "query": "FROM logs-postgres* | DISSECT message \"duration: %{query_duration} ms\" | EVAL query_duration_num = TO_DOUBLE(query_duration) | STATS avg_duration = AVG(query_duration_num)"
-      }
+      "operation-type": "esql",
+      "query": "FROM logs-postgres* | DISSECT message \"duration: %{query_duration} ms\" | EVAL query_duration_num = TO_DOUBLE(query_duration) | STATS avg_duration = AVG(query_duration_num)"
     }

--- a/elastic/logs/operations/esql.json
+++ b/elastic/logs/operations/esql.json
@@ -22,13 +22,13 @@
       "name": "esql_time_range_and_date_histogram_two_groups_pre_filter",
       "description": "Based on observability queries for average CPU over date histogram",
       "operation-type": "esql",
-      "query": "FROM logs-* | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-01\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-02\") | WHERE @timestamp >= start_time AND @timestamp <= end_time AND http.response.body.bytes IS NOT NULL | EVAL bucket = DATE_TRUNC(1 hour, @timestamp) | STATS avg=AVG(http.response.body.bytes), min=MIN(http.response.body.bytes), max=MAX(http.response.body.bytes) BY data_stream.dataset, bucket | KEEP data_stream.dataset, bucket, min, avg, max"
+      "query": "FROM logs-* | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time AND http.response.body.bytes IS NOT NULL | EVAL bucket = DATE_TRUNC(1 hour, @timestamp) | STATS avg=AVG(http.response.body.bytes), min=MIN(http.response.body.bytes), max=MAX(http.response.body.bytes) BY data_stream.dataset, bucket | KEEP data_stream.dataset, bucket, min, avg, max"
     },
     {
       "name": "esql_time_range_and_date_histogram_two_groups_post_filter",
       "description": "Based on observability queries for average CPU over date histogram",
       "operation-type": "esql",
-      "query": "FROM logs-* | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-01\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"2020-01-02\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | EVAL bucket = DATE_TRUNC(1 hour, @timestamp) | STATS avg=AVG(http.response.body.bytes), min=MIN(http.response.body.bytes), max=MAX(http.response.body.bytes) BY data_stream.dataset, bucket | WHERE min IS NOT NULL | KEEP data_stream.dataset, bucket, min, avg, max"
+      "query": "FROM logs-* | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | EVAL bucket = DATE_TRUNC(1 hour, @timestamp) | STATS avg=AVG(http.response.body.bytes), min=MIN(http.response.body.bytes), max=MAX(http.response.body.bytes) BY data_stream.dataset, bucket | WHERE min IS NOT NULL | KEEP data_stream.dataset, bucket, min, avg, max"
     },
     {
       "name": "esql_dissect_duration_and_stats",


### PR DESCRIPTION
Updates the ESQL operations to use the new [ESQL runner](https://github.com/elastic/rally/pull/1791), and templates two of the queries (`esql_time_range_and_date_histogram_two_groups_pre_filter` and `esql_time_range_and_date_histogram_two_groups_post_filter`) to use the `bulk_start_date` and `bulk_end_dates` track parameters.