### PR TITLE
Unblock vector tracks for public serverless

### DIFF
--- a/cohere_vector/README.md
+++ b/cohere_vector/README.md
@@ -49,3 +49,5 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - index_settings {default: {}}
  - number_of_shards (default : 1)
  - number_of_replicas (default: 0)
+ - post_ingest_sleep (default: false): Whether to pause after ingest and prior to subsequent operations.
+ - post_ingest_sleep_duration (default: 30): Sleep duration in seconds.

--- a/cohere_vector/challenges/default.json
+++ b/cohere_vector/challenges/default.json
@@ -43,6 +43,15 @@
         "include-in-reporting": false
       }
     },
+    {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+    {
+      "name": "post-ingest-sleep",
+      "operation": {
+        "operation-type": "sleep",
+        "duration": {{ post_ingest_sleep_duration|default(30) }}
+      }
+    },
+    {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
     {
       "name": "standalone-search-knn-10-100-single-client",
       "operation": "knn-search-10-100",

--- a/cohere_vector/index-vectors-only-mapping.json
+++ b/cohere_vector/index-vectors-only-mapping.json
@@ -1,10 +1,12 @@
 {
   "settings": {
-  {% if preload_pagecache %}
+    {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem"],
-  {% endif %}
+      {% endif %}
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {
     "dynamic": false,

--- a/cohere_vector/index-vectors-with-text-mapping.json
+++ b/cohere_vector/index-vectors-with-text-mapping.json
@@ -1,10 +1,12 @@
 {
   "settings": {
-  {% if preload_pagecache %}
+    {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem"],
-  {% endif %}
+      {% endif %}
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {
     "properties": {

--- a/dense_vector/README.md
+++ b/dense_vector/README.md
@@ -29,5 +29,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 1): Number of clients that issue bulk indexing requests.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
-* `max_num_segments`: The number of segments to target when doing a force merge (default: 1)
+* `max_num_segments` (default: 1): The number of segments to target when doing a force merge.
 * `number_of_replicas` (default: 0)
+* `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
+* `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -54,6 +54,15 @@
         "include-in-reporting": false
       }
     },
+    {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+    {
+      "name": "post-ingest-sleep-after-index",
+      "operation": {
+        "operation-type": "sleep",
+        "duration": {{ post_ingest_sleep_duration|default(30) }}
+      }
+    },
+    {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
     {
       "parallel": {
         "warmup-time-period": 10,
@@ -95,6 +104,15 @@
         "include-in-reporting": false
       }
     },
+    {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+    {
+      "name": "post-ingest-sleep-after-update",
+      "operation": {
+        "operation-type": "sleep",
+        "duration": {{ post_ingest_sleep_duration|default(30) }}
+      }
+    },
+    {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
     {
       "name": "knn-search-10-100_multiple_segments",
       "operation": "knn-search-10-100",
@@ -141,6 +159,15 @@
         "include-in-reporting": false
       }
     },
+    {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+    {
+      "name": "post-ingest-sleep",
+      "operation": {
+        "operation-type": "sleep",
+        "duration": {{ post_ingest_sleep_duration|default(30) }}
+      }
+    },
+    {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
     {
       "name": "knn-search-10-100",
       "operation": "knn-search-10-100",

--- a/dense_vector/index.json
+++ b/dense_vector/index.json
@@ -1,8 +1,10 @@
 {
   "settings": {
     "index": {
+      {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       "number_of_shards": 2,
       "number_of_replicas": {{number_of_replicas | default(0)}}
+      {%- endif -%}{# non-serverless-index-settings-marker-end #}
     }
   },
   "mappings": {

--- a/so_vector/challenges/default.json
+++ b/so_vector/challenges/default.json
@@ -109,7 +109,7 @@
       "warmup-iterations": 100,
       "iterations": 100,
       "clients": 1
-    },
+    }{# non-serverless-after-force-merge-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%},
     {
       "operation": {
         "operation-type": "force-merge",
@@ -157,5 +157,6 @@
       "iterations": 100,
       "clients": 1
     }
+    {%- endif -%}{# non-serverless-after-force-merge-marker-end #}
   ]
 }

--- a/so_vector/index.json
+++ b/so_vector/index.json
@@ -1,7 +1,9 @@
 {
   "settings": {
+    {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     "index.number_of_shards": {{number_of_shards | default(2)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {
     "_source": {


### PR DESCRIPTION
Similar to https://github.com/elastic/rally-tracks/pull/465.

Remarks:
* In `so_vector` an optional post-ingest pause is not introduced because original schedule in `index-and-search` challange executes search immediately after index/refresh. However, the second part of the schedule repeats all the searches after force merge to a single segment which is not available to public users. This part of the schedule gets skipped entirely.
* In `dense_vector` the pause is introduced _multiple_ times.