### PR TITLE
Unblock k8s_metrics for public serverless

### DIFF
--- a/k8s_metrics/challenges/default.json
+++ b/k8s_metrics/challenges/default.json
@@ -81,14 +81,14 @@
     {
       "name": "create-track-component-templates",
       "operation": {
-        "operation-type": "create-component-template",
-        "template": "metrics-kubernetes.pod-template"
+        "operation-type": "create-component-template"
       }
     },
     {
       "name": "create-track-composable-templates",
       "operation": {
-        "operation-type": "create-composable-template"
+        "operation-type": "create-composable-template",
+        "template": "metrics-kubernetes.pod-template"
       }
     },
     {

--- a/k8s_metrics/templates/metrics-kubernetes.pod@custom.json
+++ b/k8s_metrics/templates/metrics-kubernetes.pod@custom.json
@@ -5,8 +5,10 @@
       "lifecycle": {},
       "settings": {
         "index": {
+          {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
           "number_of_shards": {{number_of_shards | default(1)}},
           "number_of_replicas": {{number_of_replicas | default(1)}},
+          {%- endif -%}{# non-serverless-index-settings-marker-end #}
           {%- if refresh_interval %}
           "refresh_interval": "{{refresh_interval}}",
           {%- endif %}

--- a/k8s_metrics/templates/metrics-kubernetes.pod@package.json
+++ b/k8s_metrics/templates/metrics-kubernetes.pod@package.json
@@ -5,8 +5,6 @@
       "lifecycle": {},
       "settings": {
         "index": {
-          "number_of_shards": 1,
-          "number_of_replicas": 1,
           "codec": "best_compression",
           "mapping": {
             "total_fields": {


### PR DESCRIPTION
Similar to https://github.com/elastic/rally-tracks/pull/465.

Remarks:
* not introducing post-ingest pause as this track does not include post-ingest search,
* fixed `append-no-conflicts-metrics-index-with-intermittent-refresh` challenge (`template` property in `create-component-template` instead of `crate-composable-template`),
* fast refresh challenges are not fixable for public use as they refer a system index.