### PR TITLE
Esql bring back stats enrich

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -1111,6 +1111,55 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
+        },
+        {
+          "operation": "esql_stats_enrich_1",
+          "tags": ["enrich","stats"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 5
+        },
+        {
+          "operation": "esql_stats_enrich_2",
+          "tags": ["enrich","stats"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 5
+        },
+        {
+          "operation": "esql_stats_enrich_3",
+          "tags": ["enrich","stats"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 5
+        },
+        {
+          "operation": "esql_stats_enrich_4",
+          "tags": ["enrich","stats"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 5
+        },
+        {
+          "operation": "esql_stats_enrich_rates_fares",
+          "tags": ["enrich","stats"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 5
+        },
+        {
+          "operation": "esql_stats_enrich_payments",
+          "tags": ["enrich","stats"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 5
+        },
+        {
+          "operation": "esql_stats_enrich_payments_fares",
+          "tags": ["enrich","stats"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 5
         }
       ]
     },

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -1116,50 +1116,50 @@
           "operation": "esql_stats_enrich_1",
           "tags": ["enrich","stats"],
           "clients": 1,
-          "warmup-iterations": 2,
-          "iterations": 5
+          "warmup-iterations": 10,
+          "iterations": 50
         },
         {
           "operation": "esql_stats_enrich_2",
           "tags": ["enrich","stats"],
           "clients": 1,
-          "warmup-iterations": 2,
-          "iterations": 5
+          "warmup-iterations": 10,
+          "iterations": 50
         },
         {
           "operation": "esql_stats_enrich_3",
           "tags": ["enrich","stats"],
           "clients": 1,
-          "warmup-iterations": 2,
-          "iterations": 5
+          "warmup-iterations": 10,
+          "iterations": 50
         },
         {
           "operation": "esql_stats_enrich_4",
           "tags": ["enrich","stats"],
           "clients": 1,
-          "warmup-iterations": 2,
-          "iterations": 5
+          "warmup-iterations": 10,
+          "iterations": 50
         },
         {
           "operation": "esql_stats_enrich_rates_fares",
           "tags": ["enrich","stats"],
           "clients": 1,
-          "warmup-iterations": 2,
-          "iterations": 5
+          "warmup-iterations": 10,
+          "iterations": 50
         },
         {
           "operation": "esql_stats_enrich_payments",
           "tags": ["enrich","stats"],
           "clients": 1,
-          "warmup-iterations": 2,
-          "iterations": 5
+          "warmup-iterations": 10,
+          "iterations": 50
         },
         {
           "operation": "esql_stats_enrich_payments_fares",
           "tags": ["enrich","stats"],
           "clients": 1,
-          "warmup-iterations": 2,
-          "iterations": 5
+          "warmup-iterations": 10,
+          "iterations": 50
         }
       ]
     },

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -1321,40 +1321,40 @@
     {
       "name": "esql_stats_enrich_control",
       "operation-type": "esql",
-      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_id"
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_id"
     },
     {
       "name": "esql_stats_enrich_1",
       "operation-type": "esql",
-      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name"
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name"
     },
     {
       "name": "esql_stats_enrich_2",
       "operation-type": "esql",
-      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name, payment_type_name"
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name, payment_type_name"
     },
     {
       "name": "esql_stats_enrich_3",
       "operation-type": "esql",
-      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | ENRICH nyc_vendors ON vendor_id WITH vendor_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name, payment_type_name, vendor_name"
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | ENRICH nyc_vendors ON vendor_id WITH vendor_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name, payment_type_name, vendor_name"
     },
     {
       "name": "esql_stats_enrich_4",
       "operation-type": "esql",
-      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | ENRICH nyc_vendors ON vendor_id WITH vendor_name=name | ENRICH nyc_trip_types ON trip_type WITH trip_type_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name, payment_type_name, vendor_name, trip_type_name"
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | ENRICH nyc_vendors ON vendor_id WITH vendor_name=name | ENRICH nyc_trip_types ON trip_type WITH trip_type_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name, payment_type_name, vendor_name, trip_type_name"
     },
     {
       "name": "esql_stats_enrich_rates_fares",
       "operation-type": "esql",
-      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | ENRICH nyc_rate_codes_fares ON rate_code_id WITH rate_code_name=name, rate_code_fare=fare | STATS count=count(*), avg_fare=avg(fare_amount), avg_rate_code_fare=avg(rate_code_fare) BY rate_code_name"
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_rate_codes_fares ON rate_code_id WITH rate_code_name=name, rate_code_fare=fare | STATS count=count(*), avg_fare=avg(fare_amount), avg_rate_code_fare=avg(rate_code_fare) BY rate_code_name"
     },
     {
       "name": "esql_stats_enrich_payments",
       "operation-type": "esql",
-      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | STATS count=count(*), avg_fare=avg(fare_amount), avg_fare=avg(fare_amount) BY payment_type_name"
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | STATS count=count(*), avg_fare=avg(fare_amount), avg_fare=avg(fare_amount) BY payment_type_name"
     },
     {
       "name": "esql_stats_enrich_payments_fares",
       "operation-type": "esql",
-      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | ENRICH nyc_payment_types_fares ON payment_type WITH payment_type_name=name, payment_type_fare=fare | STATS count=count(*), avg_fare=avg(fare_amount), avg_fare=avg(fare_amount) BY payment_type_name"
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_payment_types_fares ON payment_type WITH payment_type_name=name, payment_type_fare=fare | STATS count=count(*), avg_fare=avg(fare_amount), avg_fare=avg(fare_amount) BY payment_type_name"
     }


### PR DESCRIPTION
Our first attempt to add STATS..BY an ENRICH field caused timeouts and required an urgent removal of these benchmarks on Friday. Now by using the same LIMIT 100000 we used in the non-stats queries, we get much better performance, better even than the normal STATS queries.