### PR TITLE
Added LIMIT 0 versions of queries to ESQL tasks in elastic/logs and NYC Taxis

### DIFF
--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -56,6 +56,62 @@
       }
     },
     {
+      "operation": "esql_basic_count_group_0_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql","limit0"]
+    },
+    {
+      "operation": "esql_basic_count_group_1_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql","limit0"]
+    },
+    {
+      "operation": "esql_basic_count_group_2_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql","limit0"]
+    },
+    {
+      "operation": "esql_basic_count_group_3_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql","limit0"]
+    },
+    {
+      "operation": "esql_basic_count_group_4_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql","limit0"]
+    },
+    {
+      "operation": "esql_time_range_and_date_histogram_two_groups_pre_filter_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql","limit0"]
+    },
+    {
+      "operation": "esql_time_range_and_date_histogram_two_groups_post_filter_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql","limit0"]
+    },
+    {
+      "operation": "esql_dissect_duration_and_stats_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql","limit0"]
+    },
+    {
       "operation": "esql_basic_count_group_0",
       "clients": 1,
       "warmup-iterations": 10,
@@ -66,43 +122,50 @@
       "operation": "esql_basic_count_group_1",
       "clients": 1,
       "warmup-iterations": 10,
-      "iterations": 50
+      "iterations": 50,
+      "tags": ["esql"]
     },
     {
       "operation": "esql_basic_count_group_2",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 20
+      "iterations": 20,
+      "tags": ["esql"]
     },
     {
       "operation": "esql_basic_count_group_3",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 10
+      "iterations": 10,
+      "tags": ["esql"]
     },
     {
       "operation": "esql_basic_count_group_4",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 10
+      "iterations": 10,
+      "tags": ["esql"]
     },
     {
       "operation": "esql_time_range_and_date_histogram_two_groups_pre_filter",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 20
+      "iterations": 20,
+      "tags": ["esql"]
     },
     {
       "operation": "esql_time_range_and_date_histogram_two_groups_post_filter",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 20
+      "iterations": 20,
+      "tags": ["esql"]
     },
     {
       "operation": "esql_dissect_duration_and_stats",
       "clients": 1,
       "warmup-iterations": 5,
-      "iterations": 20
+      "iterations": 20,
+      "tags": ["esql"]
     }
   ]
 }

--- a/elastic/logs/operations/esql.json
+++ b/elastic/logs/operations/esql.json
@@ -44,4 +44,42 @@
       "description": "Based on observability queries for duration average",
       "operation-type": "esql",
       "query": "FROM logs-postgres* | DISSECT message \"duration: %{query_duration} ms\" | EVAL query_duration_num = TO_DOUBLE(query_duration) | STATS avg_duration = AVG(query_duration_num)"
+    },
+    {
+      "name": "esql_basic_count_group_1_limit_0",
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS count=count(*) BY agent.version | SORT count DESC | LIMIT 0"
+    },
+    {
+      "name": "esql_basic_count_group_2_limit_0",
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS count=count(*) BY agent.version, agent.type | SORT count DESC | LIMIT 0"
+    },
+    {
+      "name": "esql_basic_count_group_3_limit_0",
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS count=count(*) BY agent.version, agent.type, agent.hostname | SORT count DESC | LIMIT 0"
+    },
+    {
+      "name": "esql_basic_count_group_4_limit_0",
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS count=count(*) BY agent.version, agent.type, agent.hostname, agent.id | SORT count DESC | LIMIT 0"
+    },
+    {
+      "name": "esql_time_range_and_date_histogram_two_groups_pre_filter_limit_0",
+      "description": "Based on observability queries for average CPU over date histogram",
+      "operation-type": "esql",
+      "query": "FROM logs-* | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time AND http.response.body.bytes IS NOT NULL | EVAL bucket = DATE_TRUNC(1 hour, @timestamp) | STATS avg=AVG(http.response.body.bytes), min=MIN(http.response.body.bytes), max=MAX(http.response.body.bytes) BY data_stream.dataset, bucket | KEEP data_stream.dataset, bucket, min, avg, max | LIMIT 0"
+    },
+    {
+      "name": "esql_time_range_and_date_histogram_two_groups_post_filter_limit_0",
+      "description": "Based on observability queries for average CPU over date histogram",
+      "operation-type": "esql",
+      "query": "FROM logs-* | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | EVAL bucket = DATE_TRUNC(1 hour, @timestamp) | STATS avg=AVG(http.response.body.bytes), min=MIN(http.response.body.bytes), max=MAX(http.response.body.bytes) BY data_stream.dataset, bucket | WHERE min IS NOT NULL | KEEP data_stream.dataset, bucket, min, avg, max | LIMIT 0"
+    },
+    {
+      "name": "esql_dissect_duration_and_stats_limit_0",
+      "description": "Based on observability queries for duration average",
+      "operation-type": "esql",
+      "query": "FROM logs-postgres* | DISSECT message \"duration: %{query_duration} ms\" | EVAL query_duration_num = TO_DOUBLE(query_duration) | STATS avg_duration = AVG(query_duration_num) | LIMIT 0"
     }

--- a/elastic/logs/operations/esql.json
+++ b/elastic/logs/operations/esql.json
@@ -1,11 +1,7 @@
     {
       "name": "esql_basic_count_group_0",
-      "operation-type": "raw-request",
-      "method": "POST",
-      "path": "/_query",
-      "body": {
-        "query": "FROM logs-* | STATS count=count(*) | SORT count DESC | LIMIT 20"
-      }
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS count=count(*) | SORT count DESC | LIMIT 20"
     },
     {
       "name": "esql_basic_count_group_1",
@@ -44,6 +40,11 @@
       "description": "Based on observability queries for duration average",
       "operation-type": "esql",
       "query": "FROM logs-postgres* | DISSECT message \"duration: %{query_duration} ms\" | EVAL query_duration_num = TO_DOUBLE(query_duration) | STATS avg_duration = AVG(query_duration_num)"
+    },
+    {
+      "name": "esql_basic_count_group_0_limit_0",
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS count=count(*) | SORT count DESC | LIMIT 0"
     },
     {
       "name": "esql_basic_count_group_1_limit_0",

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -1194,6 +1194,188 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
+        },
+        {
+          "operation": "avg_passenger_count_esql_limit_0",
+          "tags": ["limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_passenger_count_filtered_esql_limit_0",
+          "tags": ["limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_tip_percent_esql_limit_0",
+          "tags": ["limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_amount_group_by_integer_esql_limit_0",
+          "tags": ["limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "avg_amount_group_by_keyword_esql_limit_0",
+          "tags": ["limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "multi_terms-keyword_esql_limit_0",
+          "tags": ["limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "sort_by_ts_esql_limit_0",
+          "tags": ["limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "date_histogram_calendar_interval_esql_limit_0",
+          "tags": ["limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "date_histogram_fixed_interval_esql_limit_0",
+          "tags": ["limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "date_histogram_fixed_interval_with_metrics_esql_limit_0",
+          "tags": ["limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_enrich_control_limit_0",
+          "tags": ["enrich", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_enrich_1_limit_0",
+          "tags": ["enrich", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_enrich_2_limit_0",
+          "tags": ["enrich", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_enrich_3_limit_0",
+          "tags": ["enrich", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_enrich_4_limit_0",
+          "tags": ["enrich", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_enrich_rates_fares_limit_0",
+          "tags": ["enrich", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_enrich_payments_limit_0",
+          "tags": ["enrich", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_enrich_payments_fares_limit_0",
+          "tags": ["enrich", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_stats_enrich_control_limit_0",
+          "tags": ["enrich", "stats", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_stats_enrich_1_limit_0",
+          "tags": ["enrich", "stats", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_stats_enrich_2_limit_0",
+          "tags": ["enrich", "stats", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_stats_enrich_3_limit_0",
+          "tags": ["enrich", "stats", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_stats_enrich_4_limit_0",
+          "tags": ["enrich", "stats", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_stats_enrich_rates_fares_limit_0",
+          "tags": ["enrich", "stats", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_stats_enrich_payments_limit_0",
+          "tags": ["enrich", "stats", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_stats_enrich_payments_fares_limit_0",
+          "tags": ["enrich", "stats", "limit0"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
         }
       ]
     },

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -959,13 +959,13 @@
     {
       "name": "avg_passenger_count_esql_shard_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | stats avg(passenger_count)",
+      "query" : "FROM nyc_taxis | stats avg(passenger_count)",
       "body": { "pragma": { "data_partitioning": "shard" } }
     },
     {
       "name": "avg_passenger_count_esql_doc_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | stats avg(passenger_count)",
+      "query" : "FROM nyc_taxis | stats avg(passenger_count)",
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
@@ -1002,13 +1002,13 @@
     {
       "name": "avg_tip_percent_esql_shard_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | where fare_amount > 0 | eval tip_percent = tip_amount / fare_amount | stats avg(tip_percent)",
+      "query" : "FROM nyc_taxis | where fare_amount > 0 | eval tip_percent = tip_amount / fare_amount | stats avg(tip_percent)",
       "body": { "pragma": { "data_partitioning": "shard" } }
     },
     {
       "name": "avg_tip_percent_esql_doc_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | where fare_amount > 0 | eval tip_percent = tip_amount / fare_amount | stats avg(tip_percent)",
+      "query" : "FROM nyc_taxis | where fare_amount > 0 | eval tip_percent = tip_amount / fare_amount | stats avg(tip_percent)",
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
@@ -1040,13 +1040,13 @@
     {
       "name": "avg_amount_group_by_integer_esql_shard_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count",
+      "query" : "FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count",
       "body": { "pragma": { "data_partitioning": "shard" } }
     },
     {
       "name": "avg_amount_group_by_integer_esql_doc_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count",
+      "query" : "FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count",
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
@@ -1078,13 +1078,13 @@
     {
       "name": "avg_amount_group_by_keyword_esql_shard_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id",
+      "query" : "FROM nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id",
       "body": { "pragma": { "data_partitioning": "shard" } }
     },
     {
       "name": "avg_amount_group_by_keyword_esql_doc_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id",
+      "query" : "FROM nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id",
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
@@ -1123,13 +1123,13 @@
     {
       "name": "avg_passenger_count_filtered_esql_shard_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | where total_amount > 60 and rate_code_id==\"2\"| stats avg(passenger_count)",
+      "query" : "FROM nyc_taxis | where total_amount > 60 and rate_code_id==\"2\"| stats avg(passenger_count)",
       "body": { "pragma": { "data_partitioning": "shard" } }
     },
     {
       "name": "avg_passenger_count_filtered_esql_doc_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | where total_amount > 60 and rate_code_id==\"2\"| stats avg(passenger_count)",
+      "query" : "FROM nyc_taxis | where total_amount > 60 and rate_code_id==\"2\"| stats avg(passenger_count)",
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
@@ -1148,37 +1148,37 @@
     {
       "name": "sort_by_ts_esql_shard_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance| limit 1000",
+      "query" : "FROM nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance | LIMIT 1000",
       "body": { "pragma": { "data_partitioning": "shard" } }
     },
     {
       "name": "sort_by_ts_esql_doc_partitioning",
       "operation-type": "esql",
-      "query" : "from nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance| limit 1000",
+      "query" : "FROM nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance | LIMIT 1000",
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
       "name": "date_histogram_calendar_interval_esql_shard_partitioning",
       "operation-type": "esql",
-      "query": "from nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 week, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 week, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
       "body": { "pragma": { "data_partitioning": "shard" } }
     },
     {
       "name": "date_histogram_calendar_interval_esql_doc_partitioning",
       "operation-type": "esql",
-      "query": "from nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 week, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 week, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
       "name": "date_histogram_fixed_interval_esql_shard_partitioning",
       "operation-type": "esql",
-      "query": "from nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
       "body": { "pragma": { "data_partitioning": "shard" } }
     },
     {
       "name": "date_histogram_fixed_interval_esql_doc_partitioning",
       "operation-type": "esql",
-      "query": "from nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
@@ -1230,13 +1230,13 @@
     {
       "name": "date_histogram_fixed_interval_with_metrics_esql_shard_partitioning",
       "operation-type": "esql",
-      "query": "from nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats min_total_amount = min(total_amount), max_total_amount = max(total_amount), avg_total_amount = avg(total_amount), avg_trip_distance = avg(trip_distance) by dropoffs_over_time | sort dropoffs_over_time",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats min_total_amount = min(total_amount), max_total_amount = max(total_amount), avg_total_amount = avg(total_amount), avg_trip_distance = avg(trip_distance) by dropoffs_over_time | sort dropoffs_over_time",
       "body": { "pragma": { "data_partitioning": "shard" } }
     },
     {
       "name": "date_histogram_fixed_interval_with_metrics_esql_doc_partitioning",
       "operation-type": "esql",
-      "query": "from nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats min_total_amount = min(total_amount), max_total_amount = max(total_amount), avg_total_amount = avg(total_amount), avg_trip_distance = avg(trip_distance) by dropoffs_over_time | sort dropoffs_over_time",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats min_total_amount = min(total_amount), max_total_amount = max(total_amount), avg_total_amount = avg(total_amount), avg_trip_distance = avg(trip_distance) by dropoffs_over_time | sort dropoffs_over_time",
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
@@ -1269,13 +1269,13 @@
     {
       "name": "multi_terms-keyword_esql_shard_partitioning",
       "operation-type": "esql",
-      "query": "from nyc_taxis | where dropoff_datetime < \"2015-02-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | stats c = count(dropoff_datetime) by trip_type, payment_type, vendor_id",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-02-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | stats c = count(dropoff_datetime) by trip_type, payment_type, vendor_id",
       "body": { "pragma": { "data_partitioning": "shard" } }
     },
     {
       "name": "multi_terms-keyword_esql_doc_partitioning",
       "operation-type": "esql",
-      "query": "from nyc_taxis | where dropoff_datetime < \"2015-02-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | stats c = count(dropoff_datetime) by trip_type, payment_type, vendor_id",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-02-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | stats c = count(dropoff_datetime) by trip_type, payment_type, vendor_id",
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
@@ -1357,4 +1357,134 @@
       "name": "esql_stats_enrich_payments_fares",
       "operation-type": "esql",
       "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_payment_types_fares ON payment_type WITH payment_type_name=name, payment_type_fare=fare | STATS count=count(*), avg_fare=avg(fare_amount), avg_fare=avg(fare_amount) BY payment_type_name"
+    },
+    {
+      "name": "avg_passenger_count_esql_limit_0",
+      "operation-type": "esql",
+      "query" : "FROM nyc_taxis | stats avg(passenger_count) | LIMIT 0"
+    },
+    {
+      "name": "avg_tip_percent_esql_limit_0",
+      "operation-type": "esql",
+      "query" : "FROM nyc_taxis | where fare_amount > 0 | eval tip_percent = tip_amount / fare_amount | stats avg(tip_percent) | LIMIT 0"
+    },
+    {
+      "name": "avg_amount_group_by_integer_esql_limit_0",
+      "operation-type": "esql",
+      "query" : "FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count | LIMIT 0"
+    },
+    {
+      "name": "avg_amount_group_by_keyword_esql_limit_0",
+      "operation-type": "esql",
+      "query" : "FROM nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id | LIMIT 0"
+    },
+    {
+      "name": "avg_passenger_count_filtered_esql_limit_0",
+      "operation-type": "esql",
+      "query" : "FROM nyc_taxis | where total_amount > 60 and rate_code_id==\"2\"| stats avg(passenger_count) | LIMIT 0"
+    },
+    {
+      "name": "sort_by_ts_esql_limit_0",
+      "operation-type": "esql",
+      "query" : "FROM nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance | LIMIT 0"
+    },
+    {
+      "name": "date_histogram_calendar_interval_esql_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 week, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time | LIMIT 0"
+    },
+    {
+      "name": "date_histogram_fixed_interval_esql_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time | LIMIT 0"
+    },
+    {
+      "name": "date_histogram_fixed_interval_with_metrics_esql_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats min_total_amount = min(total_amount), max_total_amount = max(total_amount), avg_total_amount = avg(total_amount), avg_trip_distance = avg(trip_distance) by dropoffs_over_time | sort dropoffs_over_time | LIMIT 0"
+    },
+    {
+      "name": "multi_terms-keyword_esql_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-02-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | stats c = count(dropoff_datetime) by trip_type, payment_type, vendor_id | LIMIT 0"
+    },
+    {
+      "name": "esql_enrich_control_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id | LIMIT 0"
+    },
+    {
+      "name": "esql_enrich_1_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | LIMIT 0"
+    },
+    {
+      "name": "esql_enrich_2_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | LIMIT 0"
+    },
+    {
+      "name": "esql_enrich_3_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | ENRICH nyc_vendors ON vendor_id WITH vendor_name=name | LIMIT 0"
+    },
+    {
+      "name": "esql_enrich_4_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | ENRICH nyc_vendors ON vendor_id WITH vendor_name=name | ENRICH nyc_trip_types ON trip_type WITH trip_type_name=name | LIMIT 0"
+    },
+    {
+      "name": "esql_enrich_rates_fares_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id | ENRICH nyc_rate_codes_fares ON rate_code_id WITH rate_code_name=name, rate_code_fare=fare | LIMIT 0"
+    },
+    {
+      "name": "esql_enrich_payments_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | LIMIT 0"
+    },
+    {
+      "name": "esql_enrich_payments_fares_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id | ENRICH nyc_payment_types_fares ON payment_type WITH payment_type_name=name, payment_type_fare=fare | LIMIT 0"
+    },
+    {
+      "name": "esql_stats_enrich_control_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_id | LIMIT 0"
+    },
+    {
+      "name": "esql_stats_enrich_1_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name | LIMIT 0"
+    },
+    {
+      "name": "esql_stats_enrich_2_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name, payment_type_name | LIMIT 0"
+    },
+    {
+      "name": "esql_stats_enrich_3_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | ENRICH nyc_vendors ON vendor_id WITH vendor_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name, payment_type_name, vendor_name | LIMIT 0"
+    },
+    {
+      "name": "esql_stats_enrich_4_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_rate_codes ON rate_code_id WITH rate_code_name=name | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | ENRICH nyc_vendors ON vendor_id WITH vendor_name=name | ENRICH nyc_trip_types ON trip_type WITH trip_type_name=name | STATS count=count(*), avg_fare=avg(fare_amount) BY rate_code_name, payment_type_name, vendor_name, trip_type_name | LIMIT 0"
+    },
+    {
+      "name": "esql_stats_enrich_rates_fares_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_rate_codes_fares ON rate_code_id WITH rate_code_name=name, rate_code_fare=fare | STATS count=count(*), avg_fare=avg(fare_amount), avg_rate_code_fare=avg(rate_code_fare) BY rate_code_name | LIMIT 0"
+    },
+    {
+      "name": "esql_stats_enrich_payments_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_payment_types ON payment_type WITH payment_type_name=name | STATS count=count(*), avg_fare=avg(fare_amount), avg_fare=avg(fare_amount) BY payment_type_name | LIMIT 0"
+    },
+    {
+      "name": "esql_stats_enrich_payments_fares_limit_0",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | KEEP rate_code_id, payment_type, trip_type, vendor_id, fare_amount | LIMIT 100000 | ENRICH nyc_payment_types_fares ON payment_type WITH payment_type_name=name, payment_type_fare=fare | STATS count=count(*), avg_fare=avg(fare_amount), avg_fare=avg(fare_amount) BY payment_type_name | LIMIT 0"
     }


### PR DESCRIPTION
These should run extremely fast and should measure only query parsing/planning, not runtime.