### PR TITLE
Unblock percolator, so, and sql tracks for public serverless

### DIFF
--- a/percolator/README.md
+++ b/percolator/README.md
@@ -30,6 +30,8 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
+* `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
 
 ### License
 

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -59,6 +59,15 @@
             "include-in-reporting": false
           }
         },
+        {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+        {
+          "name": "post-ingest-sleep",
+          "operation": {
+            "operation-type": "sleep",
+            "duration": {{ post_ingest_sleep_duration|default(30) }}
+          }
+        },
+        {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
           "operation": "percolator_with_content_president_bush",
           "warmup-iterations": 100,

--- a/percolator/index.json
+++ b/percolator/index.json
@@ -1,9 +1,11 @@
 {
   "settings": {
+    {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
     "index.queries.cache.enabled": false,
     "index.requests.cache.enable": false
+    {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {
     "_source": {

--- a/so/README.md
+++ b/so/README.md
@@ -52,6 +52,8 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
+* `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
+* `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
 
 ### License
 

--- a/so/challenges/default.json
+++ b/so/challenges/default.json
@@ -102,6 +102,15 @@
             "include-in-reporting": false
           }
         },
+        {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+        {
+          "name": "post-ingest-sleep",
+          "operation": {
+            "operation-type": "sleep",
+            "duration": {{ post_ingest_sleep_duration|default(30) }}
+          }
+        },
+        {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
           "name": "delete-transform-group-by-user",
           "operation": {
@@ -211,6 +220,15 @@
             "include-in-reporting": false
           }
         },
+        {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+        {
+          "name": "post-ingest-sleep",
+          "operation": {
+            "operation-type": "sleep",
+            "duration": {{ post_ingest_sleep_duration|default(30) }}
+          }
+        },
+        {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
           "operation": "frequent_items_all_100",
           "warmup-iterations": 3,

--- a/so/index.json
+++ b/so/index.json
@@ -1,8 +1,10 @@
 {
   "settings": {
+    {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
     "index.requests.cache.enable": false
+    {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {
     "dynamic": "strict",

--- a/so/operations/default.json
+++ b/so/operations/default.json
@@ -138,6 +138,7 @@
     {
       "name": "frequent_items_all_100",
       "operation-type": "search",
+      "index": "so",
       "body": {
         "query": {
           "bool": {
@@ -182,6 +183,7 @@
     {
       "name": "frequent_items_python_10",
       "operation-type": "search",
+      "index": "so",
       "body": {
         "query": {
           "bool": {
@@ -232,6 +234,7 @@
     {
       "name": "frequent_items_java_1000",
       "operation-type": "search",
+      "index": "so",
       "body": {
         "query": {
           "bool": {

--- a/sql/README.md
+++ b/sql/README.md
@@ -12,6 +12,8 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `max_num_segments` (default: 1)
 * `query_percentage` (default: 100): Factor applied to the number of warmup-iterations and iterations for queries. Useful to run quick experiments but watch out for effects due to the shorter warmup period!
+* `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
+* `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
 
 ## Testing
 

--- a/sql/index.json
+++ b/sql/index.json
@@ -1,9 +1,11 @@
 {
   "settings": {
+    {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
     "index.queries.cache.enabled": false,
     "index.requests.cache.enable": false
+    {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {
     "dynamic": "strict",

--- a/sql/track.json
+++ b/sql/track.json
@@ -173,6 +173,15 @@
           },
           "tags": ["setup"]
         },
+        {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+        {
+          "name": "post-ingest-sleep",
+          "operation": {
+            "operation-type": "sleep",
+            "duration": {{ post_ingest_sleep_duration|default(30) }}
+          }
+        },
+        {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
           "operation": {
             "name": "increase-max-open-scoll-context",


### PR DESCRIPTION
Similar to https://github.com/elastic/rally-tracks/pull/465.

Remarks:
* I've added specific index selection in operations used by `so` frequent items challenge. That was required to avoid errors in serverless project which never comes empty, i.e. includes indices other than the indices added by the challenge.
* The `so` frequent items requires `post_ingest_sleep_duration` high enough for refresh to occur. The default refresh interval is 15s in serverless, the default post ingest sleep duration is 30s, so defaults work.
* The `sql` track does not support test mode, so I've tested with the following track params (based on https://github.com/elastic/rally-tracks/tree/master/sql#testing):
```
--track-params="ingest_percentage:1,query_percentage:2,post_ingest_sleep:true"
```