### PR TITLE
Unblock tsdb tracks for public serverless

### DIFF
--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -187,6 +187,8 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `codec` (default: default): The codec to use compressing the index. `default` uses more space and less cpu. `best_compression` uses less space and more cpu.
 * `ingest_mode` (default: index) Should be `data_stream` to benchmark ingesting into a tsdb data stream.
 * `corpus` (default: full) Should be `split16` to use a corpus split in 16 to be used with 16 indexing clients and index mostly in @timestamp order.
+* `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
+* `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
 
 ### License
 

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -3,6 +3,7 @@
       "description": "Indexes the whole document corpus.",
       "default": true,
       "schedule": [
+        {# non-serverless-cluster-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         {
           "name":"increase-max_buckets_setting",
           "tags": ["setup"],
@@ -18,6 +19,7 @@
             "include-in-reporting": false
           }
         },
+        {%- endif -%}{# non-serverless-cluster-settings-marker-end #}
         {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
         {
           "name": "create-all-templates",
@@ -97,6 +99,15 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
+        {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+        {
+          "name": "post-ingest-sleep",
+          "operation": {
+            "operation-type": "sleep",
+            "duration": {{ post_ingest_sleep_duration|default(30) }}
+          }
+        },
+        {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
           "operation": "default",
           "warmup-iterations": 50,
@@ -210,6 +221,15 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
+        {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+        {
+          "name": "post-ingest-sleep",
+          "operation": {
+            "operation-type": "sleep",
+            "duration": {{ post_ingest_sleep_duration|default(30) }}
+          }
+        },
+        {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
           "name": "block-source-index-writes",
           "operation": {

--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -7,12 +7,14 @@
   "template": {
     "settings": {
       "index": {
+        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         "number_of_shards": {{number_of_shards | default(1)}},
         "number_of_replicas": {{number_of_replicas | default(0)}},
+        "requests.cache.enable": false,
+        {%- endif -%}{# non-serverless-index-settings-marker-end #}
         {% if refresh_interval %}
         "refresh_interval": "{{refresh_interval}}",
         {% endif %}
-        "mapping.total_fields.limit": 10000,
         "codec": "{{codec | default('default')}}",
         "mode": "{{index_mode | default('time_series')}}",
         {% if index_mode | default('time_series') is equalto 'time_series' %}
@@ -29,7 +31,7 @@
           "end_time": "2021-05-01T00:00:00.000Z"
         },
         {% endif %}
-        "requests.cache.enable": false
+        "mapping.total_fields.limit": 10000
       }
     },
     "mappings": {

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -4,9 +4,11 @@
 {
   "settings": {
     "index": {
+      {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       "number_of_shards": {{number_of_shards | default(1)}},
       "number_of_replicas": {{number_of_replicas | default(0)}},
-      "mapping.total_fields.limit": 10000,
+      "requests.cache.enable": false,
+      {%- endif -%}{# non-serverless-index-settings-marker-end #}
       "codec": "{{codec | default('default')}}",
       "mode": "{{index_mode | default('time_series')}}",
       {% if refresh_interval %}
@@ -26,7 +28,7 @@
         "end_time": "9999-01-01T00:00:00.000Z"
       },
       {% endif %}
-      "requests.cache.enable": false
+      "mapping.total_fields.limit": 10000
     }
   },
   "mappings": {

--- a/tsdb_k8s_queries/README.md
+++ b/tsdb_k8s_queries/README.md
@@ -91,3 +91,5 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `number_of_replicas` (default: 0)
 * `number_of_shards` (default: 1)
+* `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
+* `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.

--- a/tsdb_k8s_queries/challenges/default.json
+++ b/tsdb_k8s_queries/challenges/default.json
@@ -84,6 +84,15 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
+        {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+        {
+          "name": "post-ingest-sleep",
+          "operation": {
+            "operation-type": "sleep",
+            "duration": {{ post_ingest_sleep_duration|default(30) }}
+          }
+        },
+        {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {% for name, info in time_intervals.items() %}
         {
           "parallel": {

--- a/tsdb_k8s_queries/container-template.json
+++ b/tsdb_k8s_queries/container-template.json
@@ -8,12 +8,12 @@
     "template": {
       "settings": {
         "index": {
+          {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
           "number_of_shards": {{number_of_shards | default(1)}},
           "number_of_replicas": {{number_of_replicas | default(0)}},
-          "lifecycle": {
-            "name": "metrics"
-          },
-          "codec": "best_compression",
+          "requests.cache.enable": false,
+          {%- endif -%}{# non-serverless-index-settings-marker-end #}
+          {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" -%}
           "routing": {
             "allocation": {
               "include": {
@@ -21,6 +21,16 @@
               }
             }
           },
+          "search": {
+            "idle": {
+              "after": "1s"
+            }
+          },
+          "lifecycle": {
+            "name": "metrics"
+          },
+          {%- endif -%}{# non-serverless-index-settings-marker-end #}
+          "codec": "best_compression",
           "mapping": {
             "total_fields": {
               "limit": "10000"
@@ -86,12 +96,6 @@
           "time_series": {
             "start_time": "2000-01-01T00:00:00Z",
             "end_time": "2099-12-31T23:59:59Z"
-          },
-          "requests.cache.enable": false,
-          "search": {
-            "idle": {
-              "after": "1s"
-            }
           }
         }
       },

--- a/tsdb_k8s_queries/pod-template.json
+++ b/tsdb_k8s_queries/pod-template.json
@@ -8,12 +8,12 @@
     "template": {
       "settings": {
         "index": {
+          {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
           "number_of_shards": {{number_of_shards | default(1)}},
           "number_of_replicas": {{number_of_replicas | default(0)}},
-          "lifecycle": {
-            "name": "metrics"
-          },
-          "codec": "best_compression",
+          "requests.cache.enable": false,
+          {%- endif -%}{# non-serverless-index-settings-marker-end #}
+          {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" -%}
           "routing": {
             "allocation": {
               "include": {
@@ -21,6 +21,16 @@
               }
             }
           },
+          "search": {
+            "idle": {
+              "after": "1s"
+            }
+          },
+          "lifecycle": {
+            "name": "metrics"
+          },
+          {%- endif -%}{# non-serverless-index-settings-marker-end #}
+          "codec": "best_compression",
           "mapping": {
             "total_fields": {
               "limit": "10000"
@@ -84,12 +94,6 @@
           "time_series": {
             "start_time": "2000-01-01T00:00:00Z",
             "end_time": "2099-12-31T23:59:59Z"
-          },
-          "requests.cache.enable": false,
-          "search": {
-            "idle": {
-              "after": "1s"
-            }
           }
         }
       },


### PR DESCRIPTION
Similar to https://github.com/elastic/rally-tracks/pull/465.

Remarks:
* `downsample` challenge in `tsdb` track doesn't work because downsample operations get skipped by Rally (downsampling not available for public use yet, see [here](https://github.com/elastic/elasticsearch/blob/ecd13e3f118d34e151081cd1e3d432a609295dad/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/RestDownsampleAction.java#L25)),
* in `tsdb_k8s_queries` track index settings fall into 2 categories: the ones not available in serverless at all (e.g. `lifecycle.name`), and the ones that are available through operator only (e.g. `number_of_shards`).