### PR TITLE
Add force merge and refresh after indexing to wikipedia track

### DIFF
--- a/wikipedia/challenges/default.json
+++ b/wikipedia/challenges/default.json
@@ -26,6 +26,14 @@
       "operation": "refresh-after-index"
     },
     {
+      "name": "force-merge",
+      "operation": "force-merge"
+    },
+    {
+      "name": "refresh-after-force-merge",
+      "operation": "refresh-after-force-merge"
+    },
+    {
       "name": "wait-until-merges-finish-after-index",
       "operation": "wait-until-merges-finish-after-index"
     },

--- a/wikipedia/operations/default.json
+++ b/wikipedia/operations/default.json
@@ -35,6 +35,18 @@
   "include-in-reporting": false
 },
 {
+  "name": "force-merge",
+  "operation-type": "force-merge",
+  "request-timeout": 7200,
+  "include-in-reporting": false
+},
+{
+  "name": "refresh-after-force-merge",
+  "operation-type": "refresh",
+  "request-timeout": 1000,
+  "include-in-reporting": false
+},
+{
   "name": "wait-until-merges-finish-after-index",
   "operation-type": "index-stats",
   "index": "_all",


### PR DESCRIPTION
As per conversation with the Performance team, Rally tracks typically do a force merge and refresh step after indexing a large number of documents to help with the consistency of results. This PR adds these operations to the `wikipedia` track.

I used the [http_logs](https://github.com/elastic/rally-tracks/tree/master/http_logs) track for reference.