### PR TITLE
Increase timeout from 60m to 90m so that transforms can finish in time

### DIFF
--- a/so/challenges/default.json
+++ b/so/challenges/default.json
@@ -135,8 +135,8 @@
           "operation": {
             "operation-type": "wait-for-transform",
             "transform-id": "transform-group-by-user",
-            "transform-timeout": 3600,
-            "timeout": "60m"
+            "transform-timeout": 5400,
+            "timeout": "90m"
           }
         },
         {
@@ -163,8 +163,8 @@
           "operation": {
             "operation-type": "wait-for-transform",
             "transform-id": "transform-group-by-hour",
-            "transform-timeout": 3600,
-            "timeout": "60m"
+            "transform-timeout": 5400,
+            "timeout": "90m"
           }
         }
       ]


### PR DESCRIPTION
After recent changes in search (most probably https://github.com/elastic/elasticsearch/pull/101230), the transform benchmark in rally slowed down, to the point of exceeding the timeout.
This PR increases the timeout from 60m to 90m in order to let the transforms finish and allow further performance investigations.
