### PR TITLE
Unblock elastic/logs for public serverless

### DIFF
--- a/elastic/logs/challenges/logging-indexing.json
+++ b/elastic/logs/challenges/logging-indexing.json
@@ -20,7 +20,8 @@
       "schedule": "timestamp-throttler",
       "max-delay-secs": 1
       {% endif %}
-    },
+    }
+    {# non-serverless-index-statistics-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%},
     {
       "name": "compression-stats",
       "operation": {
@@ -28,5 +29,6 @@
         "param-source": "create-datastream-source"
       }
     }
+    {%- endif -%}{# non-serverless-index-statistics-marker-end #}
   ]
 }

--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -21,7 +21,8 @@
         },
         "clients": {{ p_bulk_indexing_clients }},
         "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
-      },
+      }
+      {# non-serverless-index-statistics-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%},
       {
         "name": "compression-stats",
         "operation": {
@@ -29,6 +30,7 @@
           "param-source": "create-datastream-source"
         }
       },
+      {%- endif -%}{# non-serverless-index-statistics-marker-end #}
     {% endif %}
     {
       "name": "logging-queries",

--- a/elastic/logs/tasks/index-setup.json
+++ b/elastic/logs/tasks/index-setup.json
@@ -76,8 +76,10 @@
       "template" : {
         "settings": {
           "index" : {
+            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
             "number_of_replicas" : "{{ number_of_replicas | default('1')}}",
             "number_of_shards" : "{{ number_of_shards | default('1')}}"
+            {%- endif -%}{# non-serverless-index-settings-marker-end #}
           }
         },
         "mappings" : {

--- a/elastic/logs/templates/component/auditbeat-mappings.json
+++ b/elastic/logs/templates/component/auditbeat-mappings.json
@@ -5610,8 +5610,10 @@
             "limit": 10000
           }
         },
+        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         "max_docvalue_fields_search": 200,
         "number_of_shards": 1,
+        {%- endif -%}{# non-serverless-index-settings-marker-end #}
         "query": {
           "default_field": [
             "message",

--- a/elastic/logs/templates/component/logs-apache.access@custom.json
+++ b/elastic/logs/templates/component/logs-apache.access@custom.json
@@ -1,13 +1,6 @@
 {
   "template": {
     "settings": {
-      "index": {
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-        {%- if refresh_interval %},
-        "refresh_interval": "{{ refresh_interval }}"
-        {%- endif %}
-      }
     }
   },
   "_meta": {

--- a/elastic/logs/templates/component/logs-apache.error@custom.json
+++ b/elastic/logs/templates/component/logs-apache.error@custom.json
@@ -1,13 +1,6 @@
 {
   "template": {
     "settings": {
-      "index": {
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-        {%- if refresh_interval %},
-        "refresh_interval": "{{ refresh_interval }}"
-        {%- endif %}
-      }
     }
   },
   "_meta": {

--- a/elastic/logs/templates/component/logs-kafka.log@custom.json
+++ b/elastic/logs/templates/component/logs-kafka.log@custom.json
@@ -1,13 +1,6 @@
 {
   "template": {
     "settings": {
-      "index": {
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-        {%- if refresh_interval %},
-        "refresh_interval": "{{ refresh_interval }}"
-        {%- endif %}
-      }
     }
   },
   "_meta": {

--- a/elastic/logs/templates/component/logs-mysql.error@custom.json
+++ b/elastic/logs/templates/component/logs-mysql.error@custom.json
@@ -1,13 +1,6 @@
 {
   "template": {
     "settings": {
-      "index": {
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-        {%- if refresh_interval %},
-        "refresh_interval": "{{ refresh_interval }}"
-        {%- endif %}
-      }
     }
   },
   "_meta": {

--- a/elastic/logs/templates/component/logs-mysql.slowlog@custom.json
+++ b/elastic/logs/templates/component/logs-mysql.slowlog@custom.json
@@ -1,13 +1,6 @@
 {
   "template": {
     "settings": {
-      "index": {
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-        {%- if refresh_interval %},
-        "refresh_interval": "{{ refresh_interval }}"
-        {%- endif %}
-      }
     }
   },
   "_meta": {

--- a/elastic/logs/templates/component/logs-nginx.access@custom.json
+++ b/elastic/logs/templates/component/logs-nginx.access@custom.json
@@ -1,13 +1,6 @@
 {
     "template" : {
       "settings": {
-        "index": {
-          "number_of_shards": "{{ number_of_shards | default(1) }}",
-          "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-          {%- if refresh_interval %},
-          "refresh_interval": "{{ refresh_interval }}"
-          {%- endif %}
-        }
       }
     },
     "_meta" : {

--- a/elastic/logs/templates/component/logs-nginx.error@custom.json
+++ b/elastic/logs/templates/component/logs-nginx.error@custom.json
@@ -1,13 +1,6 @@
 {
   "template": {
     "settings": {
-      "index": {
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-        {%- if refresh_interval %},
-        "refresh_interval": "{{ refresh_interval }}"
-        {%- endif %}
-      }
     }
   },
   "_meta": {

--- a/elastic/logs/templates/component/logs-postgresql.log@custom.json
+++ b/elastic/logs/templates/component/logs-postgresql.log@custom.json
@@ -1,13 +1,6 @@
 {
   "template": {
     "settings": {
-      "index": {
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-        {%- if refresh_interval %},
-        "refresh_interval": "{{ refresh_interval }}"
-        {%- endif %}
-      }
     }
   },
   "_meta": {

--- a/elastic/logs/templates/component/logs-redis.log@custom.json
+++ b/elastic/logs/templates/component/logs-redis.log@custom.json
@@ -1,13 +1,6 @@
 {
   "template": {
     "settings": {
-      "index": {
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-        {%- if refresh_interval %},
-        "refresh_interval": "{{ refresh_interval }}"
-        {%- endif %}
-      }
     }
   },
   "_meta": {

--- a/elastic/logs/templates/component/logs-redis.slowlog@custom.json
+++ b/elastic/logs/templates/component/logs-redis.slowlog@custom.json
@@ -1,13 +1,6 @@
 {
   "template": {
     "settings": {
-      "index": {
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-        {%- if refresh_interval %},
-        "refresh_interval": "{{ refresh_interval }}"
-        {%- endif %}
-      }
     }
   },
   "_meta": {

--- a/elastic/logs/templates/component/logs-system.auth@custom.json
+++ b/elastic/logs/templates/component/logs-system.auth@custom.json
@@ -1,13 +1,6 @@
 {
   "template": {
     "settings": {
-      "index": {
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-        {%- if refresh_interval %},
-        "refresh_interval": "{{ refresh_interval }}"
-        {%- endif %}
-      }
     }
   },
   "_meta": {

--- a/elastic/logs/templates/component/logs-system.syslog@custom.json
+++ b/elastic/logs/templates/component/logs-system.syslog@custom.json
@@ -1,13 +1,6 @@
 {
   "template": {
     "settings": {
-      "index": {
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
-        {%- if refresh_interval %},
-        "refresh_interval": "{{ refresh_interval }}"
-        {%- endif %}
-      }
     }
   },
   "_meta": {

--- a/elastic/logs/templates/component/track-custom-shared-settings.json
+++ b/elastic/logs/templates/component/track-custom-shared-settings.json
@@ -1,0 +1,15 @@
+{
+  "template": {
+    "settings": {
+      "index": {
+        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+        "number_of_shards": "{{ number_of_shards | default(1) }}",
+        "number_of_replicas": "{{ number_of_replicas | default(1) }}"{%- if refresh_interval -%},{%- endif -%}
+        {%- endif -%}{# non-serverless-index-settings-marker-end #}
+        {% if refresh_interval -%}
+        "refresh_interval": "{{ refresh_interval }}"
+        {%- endif %}
+      }
+    }
+  }
+}

--- a/elastic/logs/templates/composable/logs-apache.access.json
+++ b/elastic/logs/templates/composable/logs-apache.access.json
@@ -520,6 +520,7 @@
     "logs-apache.access@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/templates/composable/logs-apache.error.json
+++ b/elastic/logs/templates/composable/logs-apache.error.json
@@ -476,6 +476,7 @@
     "logs-apache.error@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -11,9 +11,11 @@
             "limit": "10000"
           }
         },
-        "refresh_interval": "5s",
+        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+        "number_of_routing_shards": "30",
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}",
+        {%- endif -%}{# non-serverless-index-settings-marker-end #}
         "query": {
           "default_field": [
             "message"
@@ -22,7 +24,7 @@
         {%- if disable_pipelines is not true %}
         "default_pipeline": "logs-k8-app",
         {%- endif %}
-        "number_of_routing_shards": "30"
+        "refresh_interval": "5s"
       }
     },
     "mappings": {

--- a/elastic/logs/templates/composable/logs-kafka.log.json
+++ b/elastic/logs/templates/composable/logs-kafka.log.json
@@ -286,6 +286,7 @@
     "logs-kafka.log@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/templates/composable/logs-mysql.error.json
+++ b/elastic/logs/templates/composable/logs-mysql.error.json
@@ -304,6 +304,7 @@
     "logs-mysql.error@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/templates/composable/logs-mysql.slowlog.json
+++ b/elastic/logs/templates/composable/logs-mysql.slowlog.json
@@ -449,6 +449,7 @@
     "logs-mysql.slowlog@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/templates/composable/logs-nginx.access.json
+++ b/elastic/logs/templates/composable/logs-nginx.access.json
@@ -460,6 +460,7 @@
     "logs-nginx.access@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/templates/composable/logs-nginx.error.json
+++ b/elastic/logs/templates/composable/logs-nginx.error.json
@@ -295,6 +295,7 @@
     "logs-nginx.error@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/templates/composable/logs-postgresql.log.json
+++ b/elastic/logs/templates/composable/logs-postgresql.log.json
@@ -406,6 +406,7 @@
     "logs-postgresql.log@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/templates/composable/logs-redis.log.json
+++ b/elastic/logs/templates/composable/logs-redis.log.json
@@ -277,6 +277,7 @@
     "logs-redis.log@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/templates/composable/logs-redis.slowlog.json
+++ b/elastic/logs/templates/composable/logs-redis.slowlog.json
@@ -258,6 +258,7 @@
     "logs-redis.slowlog@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/templates/composable/logs-system.auth.json
+++ b/elastic/logs/templates/composable/logs-system.auth.json
@@ -472,6 +472,7 @@
     "logs-system.auth@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/templates/composable/logs-system.syslog.json
+++ b/elastic/logs/templates/composable/logs-system.syslog.json
@@ -296,6 +296,7 @@
     "logs-system.syslog@custom",
     ".fleet_component_template-1",
     "track-custom-mappings",
+    "track-custom-shared-settings",
     "track-data-stream-lifecycle"
   ],
   "priority": 200,

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -293,12 +293,16 @@
         "template": "./templates/component/track-custom-mappings.json"
     },
     {
+        "name": "track-custom-shared-settings",
+        "template": "./templates/component/track-custom-shared-settings.json"
+    },
+    {
         "name": "auditbeat-mappings",
         "template": "./templates/component/auditbeat-mappings.json"
     },
     {
-      "name": "track-data-stream-lifecycle",
-      "template": "./templates/component/track-data-stream-lifecycle.json"
+        "name": "track-data-stream-lifecycle",
+        "template": "./templates/component/track-data-stream-lifecycle.json"
     }
   ],
   "composable-templates": [


### PR DESCRIPTION
Similar to https://github.com/elastic/rally-tracks/pull/465.

Remarks:
* unblocking limited to `logging-indexing`, `logging-querying` and `logging-indexing-querying` challenges which are applicable to serverless today,
* shared custom index settings moved to a dedicated component template (`track-custom-shared-settings`) to avoid repetition, this makes `@custom` templates empty, but these are kept as placeholders for any future changes,
* there is no explicit force merge step in `elastic/logs` so optional post-ingest sleep was not introduced,
* `compression-statistics` custom runner had to be excluded at the track level as it is based on index stats.

Tests:
```
TRACK=elastic/logs
esrally race --track-path=../rally-tracks/$TRACK --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --challenge="logging-indexing" --test-mode --track-params="start_date:2021-01-01T00-00-00Z,end_date:2021-01-01T00-10-00Z"
esrally race --track-path=../rally-tracks/$TRACK --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --challenge="logging-indexing" --test-mode --track-params="start_date:2021-01-01T00-00-00Z,end_date:2021-01-01T00-10-00Z,refresh_interval:17s"
esrally race --track-path=../rally-tracks/$TRACK --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --challenge="logging-querying" --test-mode --exclude-tasks="tag:setup" --track-params="query_warmup_time_period:1,query_time_period:1,workflow_time_interval:1,think_time_interval:1"
esrally race --track-path=../rally-tracks/$TRACK --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --challenge="logging-indexing-querying" --test-mode --track-params="start_date:2021-01-01T00-00-00Z,end_date:2021-01-01T00-10-00Z,query_warmup_time_period:1,query_time_period:1,workflow_time_interval:1,think_time_interval:1"
```