### PR TITLE
Unblock elastic/security for public serverless

### DIFF
--- a/elastic/security/README.md
+++ b/elastic/security/README.md
@@ -83,6 +83,7 @@ The following parameters are available:
 
 * `wait_for_status` (default: `green`) - The track creates Data Streams prior to indexing. All created Data Streams must at least reach this status before indexing commences. Reduce to `yellow` for clusters where green isn't possible e.g. single node.
 * `corpora_uri_base` (default: `https://rally-tracks.elastic.co`) - Specify the base location of the datasets used by this track.
+* `lifecycle` (default: unset to fall back on Serverless detection) - Specifies the lifecycle management feature to use for data streams. Use `ilm` for index lifecycle management or `dlm` for data lifecycle management. By default, `dlm` will be used for benchmarking Serverless Elasticsearch.
 
 ### Data Generation Parameters
 

--- a/elastic/security/tasks/index-setup.json
+++ b/elastic/security/tasks/index-setup.json
@@ -6,6 +6,7 @@
     "param-source": "add-track-path"
   }
 },
+{# non-serverless-project-settings-marker-start #}{%- if build_flavor != "serverless" -%}
 {
   "name": "insert-ilm",
   "tags": ["setup"],
@@ -14,6 +15,7 @@
     "param-source": "add-track-path"
   }
 },
+{%- endif -%}{# non-serverless-project-settings-marker-end #}
 {
   "name": "delete-all-datastreams",
   "tags": ["setup"],
@@ -47,8 +49,10 @@
     "param-source": "composable-template-source",
     "settings": {
       "index": {
+        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         "number_of_shards": {{ p_number_of_shards }},
         "number_of_replicas": {{ p_number_of_replicas }}
+        {%- endif -%}{# non-serverless-index-settings-marker-end #}
       }
     },
     "remove-routing-shards": true,

--- a/elastic/security/templates/component/track-data-stream-lifecycle.json
+++ b/elastic/security/templates/component/track-data-stream-lifecycle.json
@@ -1,0 +1,15 @@
+{
+  "template": {
+{% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+    "settings": {
+      "index": {
+        "lifecycle": {
+          "name": "security"
+        }
+      }
+    }
+{%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+    "lifecycle": {}
+{%- endif -%}
+  }
+}

--- a/elastic/security/templates/composable/security-auditbeat.json
+++ b/elastic/security/templates/composable/security-auditbeat.json
@@ -5,18 +5,17 @@
   "template" : {
     "settings" : {
       "index" : {
-        "lifecycle" : {
-          "name" : "security"
-        },
         "mapping" : {
           "total_fields" : {
             "limit" : "10000"
           }
         },
         "refresh_interval" : "5s",
+        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         "number_of_shards" : "{{ number_of_shards | default(1) }}",
         "number_of_replicas" : "{{ number_of_replicas | default(1) }}",
         "max_docvalue_fields_search" : "200",
+        {%- endif -%}{# non-serverless-index-settings-marker-end #}
         "query" : {
           "default_field" : [
             "tags",
@@ -8106,7 +8105,10 @@
       }
     }
   },
-  "composed_of" : ["track-custom-mappings"],
+  "composed_of" : [
+    "track-custom-mappings",
+    "track-data-stream-lifecycle"
+  ],
   "priority" : 150,
   "data_stream" : { }
 }

--- a/elastic/security/templates/composable/security-filebeat.json
+++ b/elastic/security/templates/composable/security-filebeat.json
@@ -5,18 +5,17 @@
   "template" : {
     "settings" : {
       "index" : {
-        "lifecycle" : {
-          "name" : "security"
-        },
         "mapping" : {
           "total_fields" : {
             "limit" : "10000"
           }
         },
         "refresh_interval" : "5s",
+        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         "number_of_shards" : "{{ number_of_shards | default(1) }}",
         "number_of_replicas" : "{{ number_of_replicas | default(1) }}",
         "max_docvalue_fields_search" : "200",
+        {%- endif -%}{# non-serverless-index-settings-marker-end #}
         "query" : {
           "default_field" : [
             "tags",
@@ -29071,7 +29070,10 @@
       }
     }
   },
-  "composed_of" : ["track-custom-mappings"],
+  "composed_of" : [
+    "track-custom-mappings",
+    "track-data-stream-lifecycle"
+  ],
   "priority" : 150,
   "data_stream" : { }
 }

--- a/elastic/security/templates/composable/security-metricbeat.json
+++ b/elastic/security/templates/composable/security-metricbeat.json
@@ -5,9 +5,6 @@
   "template" : {
     "settings" : {
       "index" : {
-        "lifecycle" : {
-          "name" : "security"
-        },
         "codec" : "best_compression",
         "mapping" : {
           "total_fields" : {
@@ -15,9 +12,11 @@
           }
         },
         "refresh_interval" : "5s",
+        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         "number_of_shards" : "{{ number_of_shards | default(1) }}",
         "number_of_replicas" : "{{ number_of_replicas | default(1) }}",
         "max_docvalue_fields_search" : "200",
+        {%- endif -%}{# non-serverless-index-settings-marker-end #}
         "query" : {
           "default_field" : [
             "tags",
@@ -29619,7 +29618,10 @@
       "date_detection" : false
     }
   },
-  "composed_of" : ["track-custom-mappings"],
+  "composed_of" : [
+    "track-custom-mappings",
+    "track-data-stream-lifecycle"
+  ],
   "priority" : 150,
   "data_stream" : { }
 }

--- a/elastic/security/templates/composable/security-packetbeat.json
+++ b/elastic/security/templates/composable/security-packetbeat.json
@@ -5,18 +5,17 @@
   "template" : {
     "settings" : {
       "index" : {
-        "lifecycle" : {
-          "name" : "security"
-        },
         "mapping" : {
           "total_fields" : {
             "limit" : "10000"
           }
         },
         "refresh_interval" : "5s",
+        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         "number_of_shards" : "{{ number_of_shards | default(1) }}",
         "number_of_replicas" : "{{ number_of_replicas | default(1) }}",
         "max_docvalue_fields_search" : "200",
+        {%- endif -%}{# non-serverless-index-settings-marker-end #}
         "query" : {
           "default_field" : [
             "tags",
@@ -8973,7 +8972,10 @@
       }
     }
   },
-  "composed_of" : ["track-custom-mappings"],
+  "composed_of" : [
+    "track-custom-mappings",
+    "track-data-stream-lifecycle"
+  ],
   "priority" : 150,
   "data_stream" : { }
 }

--- a/elastic/security/templates/composable/security-winlogbeat.json
+++ b/elastic/security/templates/composable/security-winlogbeat.json
@@ -5,18 +5,17 @@
   "template" : {
     "settings" : {
       "index" : {
-        "lifecycle" : {
-          "name" : "security"
-        },
         "mapping" : {
           "total_fields" : {
             "limit" : "10000"
           }
         },
         "refresh_interval" : "5s",
+        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         "number_of_shards" : "{{ number_of_shards | default(1) }}",
         "number_of_replicas" : "{{ number_of_replicas | default(1) }}",
         "max_docvalue_fields_search" : "200",
+        {%- endif -%}{# non-serverless-index-settings-marker-end #}
         "query" : {
           "default_field" : [
             "tags",
@@ -7317,7 +7316,10 @@
       }
     }
   },
-  "composed_of" : ["track-custom-mappings"],
+  "composed_of" : [
+    "track-custom-mappings",
+    "track-data-stream-lifecycle"
+  ],
   "priority" : 150,
   "data_stream" : { }
 }

--- a/elastic/security/templates/composable/track-empty-index-template.json
+++ b/elastic/security/templates/composable/track-empty-index-template.json
@@ -1,0 +1,8 @@
+{
+  "index_patterns" : [
+    "track-empty-index-template"
+  ],
+  "template" : {
+  },
+  "data_stream" : { }
+}

--- a/elastic/security/track.json
+++ b/elastic/security/track.json
@@ -97,6 +97,11 @@
       "template": "./templates/component/track-custom-mappings.json"
     },
     {
+      "name": "track-data-stream-lifecycle",
+      "template": "./templates/component/track-data-stream-lifecycle.json"
+    }
+    {# non-serverless-component-templates-marker-start #}{%- if build_flavor != "serverless" -%},
+    {
       "name": ".fleet_agent_id_verification-1",
       "template": "./templates/component/.fleet_agent_id_verification-1.json",
       "template-path": "component_template"
@@ -218,10 +223,18 @@
       "template": "./templates/component/logs-endpoint.events.registry@custom.json",
       "template-path": "component_template"
     }
+    {%- endif -%}{# non-serverless-component-templates-marker-end #}
   ],
   "composable-templates": [
+    {
+      "name": "track-empty-index-template",
+      "index-pattern": "track-empty-index-template",
+      "delete-matching-indices": false,
+      "template": "./templates/composable/track-empty-index-template.json"
+    }
 {% for integration in p_integration_ratios.keys() %}
-{% if integration == "logs-endpoint" %}
+  {% if integration == "logs-endpoint" and build_flavor != "serverless" %}
+    {{ "," if loop.first else "" }}
     {
         "name": "logs-endpoint.events.file",
         "index-pattern": "logs-endpoint.events.file-*",
@@ -264,14 +277,15 @@
         "template": "./templates/composable/logs-endpoint.events.security.json",
         "template-path": "index_template"
     }{{ ", " if not loop.last else "" }}
-{% else %}
+  {% elif integration != "logs-endpoint" %}
+    {{ "," if loop.first else "" }}
     {
       "name": "{{ integration }}",
       "index-pattern": "{{ integration + "-*" }}",
       "delete-matching-indices": false,
       "template": "{{ "./templates/composable/security-" + integration + ".json" }}"
     }{{ ", " if not loop.last else "" }}
-{% endif %}
+  {% endif %}
 {% endfor %}
   ],
   "corpora": [


### PR DESCRIPTION
Similar to https://github.com/elastic/rally-tracks/pull/465.

Remarks:
* Assumption: `elastic/security` will be run against serverless Security projects.
* With the above assumption `logs-endpoint` composable templates and all referenced objects are already included, so can by skipped entirely by Rally.
* The `track-empty-index-template` is a workaround for empty `composable-templates` array which is not accepted by Rally track schema. This can happen if the only integration type is `logs-enpoint`.
* ILM is not supported in serverless, so I'm adopting a solution from `elastic/logs` - `lifecycle` parameter and `track-data-stream-lifecycle` component template which either configures `security` ILM policy or sets a default/empty DLM policy.

Testing:
```
# logs-endpoint-params.json
{
  "query_warmup_time_period": "1",
  "query_time_period": "1",
  "workflow_time_interval": "1",
  "think_time_interval": "1",
  "integration_ratios": {
    "logs-endpoint": {
      "corpora": {
        "endpoint-events-file": 0.2,
        "endpoint-events-library": 0.1,
        "endpoint-events-network": 0.2,
        "endpoint-events-process": 0.3,
        "endpoint-events-registry": 0.1,
        "endpoint-events-security": 0.1
      }
    }
  }
}

TRACK=elastic/security

# logs-endpoint integration
esrally race --track-path=../rally-tracks/$TRACK --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --challenge="security-indexing" --test-mode --track-params=../<path>/logs-endpoint-params.json
esrally race --track-path=../rally-tracks/$TRACK --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --challenge="security-querying" --test-mode --track-params=../<path>/logs-endpoint-params.json --exclude-tasks="tag:setup"
esrally race --track-path=../rally-tracks/$TRACK --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --challenge="security-indexing-querying" --test-mode --track-params=../<path>/logs-endpoint-params.json

# integrations other than logs-endpoint
esrally race --track-path=../rally-tracks/$TRACK --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --challenge="security-indexing" --test-mode 
esrally race --track-path=../rally-tracks/$TRACK --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --challenge="security-querying" --test-mode --exclude-tasks="tag:setup"
esrally race --track-path=../rally-tracks/$TRACK --target-hosts=${ES_HOST}:443 --pipeline=benchmark-only --client-options="use_ssl:true,api_key:${ES_API_KEY}" --on-error=abort --challenge="security-indexing-querying" --test-mode --track-params="query_warmup_time_period:1,query_time_period:1,workflow_time_interval:1,think_time_interval:1"
```