### PR TITLE
ESQL: Bring back two queries after ESQL bugfix

### DIFF
--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -147,6 +147,20 @@
       "tags": ["esql"]
     },
     {
+      "operation": "esql_time_range_and_date_histogram_two_groups_pre_filter",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 20,
+      "tags": ["esql"]
+    },
+    {
+      "operation": "esql_time_range_and_date_histogram_two_groups_post_filter",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 20,
+      "tags": ["esql"]
+    },
+    {
       "operation": "esql_dissect_duration_and_stats",
       "clients": 1,
       "warmup-iterations": 5,


### PR DESCRIPTION
Revert "Remove two troublesome queries (#499)"
This reverts commit a1cf09881d0a97c19c9aa284f86ab2453d49fd15.

After Elasticsearch merged https://github.com/elastic/elasticsearch/pull/101496, these two queries should work again. I tested locally using an elasticsearch installed using `esrally` and it worked, so current builds have this fixed.