### PR TITLE
Removed duplicate tasks after two PRs merged

### DIFF
--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -161,20 +161,6 @@
       "tags": ["esql", "date_histogram"]
     },
     {
-      "operation": "esql_time_range_and_date_histogram_two_groups_pre_filter",
-      "clients": 1,
-      "warmup-iterations": 5,
-      "iterations": 20,
-      "tags": ["esql"]
-    },
-    {
-      "operation": "esql_time_range_and_date_histogram_two_groups_post_filter",
-      "clients": 1,
-      "warmup-iterations": 5,
-      "iterations": 20,
-      "tags": ["esql"]
-    },
-    {
       "operation": "esql_dissect_duration_and_stats",
       "clients": 1,
       "warmup-iterations": 5,


### PR DESCRIPTION
Merging two PR's that included related content, resulted in duplicate tasks in the schedule. This removes the duplication.

The two PR's that should have conflicted, but did not are:

* https://github.com/elastic/rally-tracks/pull/506
* https://github.com/elastic/rally-tracks/pull/496
