### PR TITLE
ESQL: Reduce iteration count for long running queries

### DIFF
--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -188,22 +188,22 @@
     {
       "operation": "search_basic_count_group_2",
       "clients": 1,
-      "warmup-iterations": 10,
-      "iterations": 50,
+      "warmup-iterations": 2,
+      "iterations": 5,
       "tags": ["esql", "count", "search"]
     },
     {
       "operation": "search_basic_count_group_3",
       "clients": 1,
-      "warmup-iterations": 10,
-      "iterations": 50,
+      "warmup-iterations": 1,
+      "iterations": 3,
       "tags": ["esql", "count", "search"]
     },
     {
       "operation": "search_basic_count_group_4",
       "clients": 1,
-      "warmup-iterations": 10,
-      "iterations": 50,
+      "warmup-iterations": 1,
+      "iterations": 3,
       "tags": ["esql", "count", "search"]
     },
     {


### PR DESCRIPTION
We only need a rough measure of these very long running queries. Currently the benchmarks are taking way too long.