### PR TITLE
Remove ESQL shard partitioning, and re-introduce segment partitioning

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -904,7 +904,7 @@
           "iterations": 50
         },
         {
-          "operation": "avg_passenger_count_esql_shard_partitioning",
+          "operation": "avg_passenger_count_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
@@ -922,7 +922,7 @@
           "iterations": 50
         },
         {
-          "operation": "avg_passenger_count_filtered_esql_shard_partitioning",
+          "operation": "avg_passenger_count_filtered_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
@@ -940,7 +940,7 @@
           "iterations": 50
         },
         {
-          "operation": "avg_tip_percent_esql_shard_partitioning",
+          "operation": "avg_tip_percent_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
@@ -958,7 +958,7 @@
           "iterations": 50
         },
         {
-          "operation": "avg_amount_group_by_integer_esql_shard_partitioning",
+          "operation": "avg_amount_group_by_integer_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
@@ -976,7 +976,7 @@
           "iterations": 50
         },
         {
-          "operation": "avg_amount_group_by_keyword_esql_shard_partitioning",
+          "operation": "avg_amount_group_by_keyword_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
@@ -994,7 +994,7 @@
           "iterations": 50
         },
         {
-          "operation": "count_group_by_keyword_esql_shard_partitioning",
+          "operation": "count_group_by_keyword_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
@@ -1018,7 +1018,7 @@
           "iterations": 50
         },
         {
-          "operation": "multi_terms-keyword_esql_shard_partitioning",
+          "operation": "multi_terms-keyword_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
@@ -1036,7 +1036,7 @@
           "iterations": 50
         },
         {
-          "operation": "sort_by_ts_esql_shard_partitioning",
+          "operation": "sort_by_ts_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
@@ -1054,7 +1054,7 @@
           "iterations": 50
         },
         {
-          "operation": "date_histogram_calendar_interval_esql_shard_partitioning",
+          "operation": "date_histogram_calendar_interval_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
@@ -1072,7 +1072,7 @@
           "iterations": 50
         },        
         {
-          "operation": "date_histogram_fixed_interval_esql_shard_partitioning",
+          "operation": "date_histogram_fixed_interval_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
@@ -1090,7 +1090,7 @@
           "iterations": 50
         },
         {
-          "operation": "date_histogram_fixed_interval_with_metrics_esql_shard_partitioning",
+          "operation": "date_histogram_fixed_interval_with_metrics_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -957,10 +957,10 @@
       }
     },
     {
-      "name": "avg_passenger_count_esql_shard_partitioning",
+      "name": "avg_passenger_count_esql_segment_partitioning",
       "operation-type": "esql",
       "query" : "FROM nyc_taxis | stats avg(passenger_count)",
-      "body": { "pragma": { "data_partitioning": "shard" } }
+      "body": { "pragma": { "data_partitioning": "segment" } }
     },
     {
       "name": "avg_passenger_count_esql_doc_partitioning",
@@ -1000,10 +1000,10 @@
       }
     },
     {
-      "name": "avg_tip_percent_esql_shard_partitioning",
+      "name": "avg_tip_percent_esql_segment_partitioning",
       "operation-type": "esql",
       "query" : "FROM nyc_taxis | where fare_amount > 0 | eval tip_percent = tip_amount / fare_amount | stats avg(tip_percent)",
-      "body": { "pragma": { "data_partitioning": "shard" } }
+      "body": { "pragma": { "data_partitioning": "segment" } }
     },
     {
       "name": "avg_tip_percent_esql_doc_partitioning",
@@ -1038,10 +1038,10 @@
       }
     },
     {
-      "name": "avg_amount_group_by_integer_esql_shard_partitioning",
+      "name": "avg_amount_group_by_integer_esql_segment_partitioning",
       "operation-type": "esql",
       "query" : "FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count",
-      "body": { "pragma": { "data_partitioning": "shard" } }
+      "body": { "pragma": { "data_partitioning": "segment" } }
     },
     {
       "name": "avg_amount_group_by_integer_esql_doc_partitioning",
@@ -1076,10 +1076,10 @@
       }
     },
     {
-      "name": "avg_amount_group_by_keyword_esql_shard_partitioning",
+      "name": "avg_amount_group_by_keyword_esql_segment_partitioning",
       "operation-type": "esql",
       "query" : "FROM nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id",
-      "body": { "pragma": { "data_partitioning": "shard" } }
+      "body": { "pragma": { "data_partitioning": "segment" } }
     },
     {
       "name": "avg_amount_group_by_keyword_esql_doc_partitioning",
@@ -1104,10 +1104,10 @@
       }
     },
     {
-      "name": "count_group_by_keyword_esql_shard_partitioning",
+      "name": "count_group_by_keyword_esql_segment_partitioning",
       "operation-type": "esql",
       "query" : "FROM nyc_taxis | stats count=count(*) by rate_code_id | sort count desc",
-      "body": { "pragma": { "data_partitioning": "shard" } }
+      "body": { "pragma": { "data_partitioning": "segment" } }
     },
     {
       "name": "count_group_by_keyword_esql_doc_partitioning",
@@ -1149,10 +1149,10 @@
       }
     },
     {
-      "name": "avg_passenger_count_filtered_esql_shard_partitioning",
+      "name": "avg_passenger_count_filtered_esql_segment_partitioning",
       "operation-type": "esql",
       "query" : "FROM nyc_taxis | where total_amount > 60 and rate_code_id==\"2\"| stats avg(passenger_count)",
-      "body": { "pragma": { "data_partitioning": "shard" } }
+      "body": { "pragma": { "data_partitioning": "segment" } }
     },
     {
       "name": "avg_passenger_count_filtered_esql_doc_partitioning",
@@ -1174,10 +1174,10 @@
       }
     },
     {
-      "name": "sort_by_ts_esql_shard_partitioning",
+      "name": "sort_by_ts_esql_segment_partitioning",
       "operation-type": "esql",
       "query" : "FROM nyc_taxis | sort pickup_datetime desc | project pickup_datetime, dropoff_datetime, trip_distance | LIMIT 1000",
-      "body": { "pragma": { "data_partitioning": "shard" } }
+      "body": { "pragma": { "data_partitioning": "segment" } }
     },
     {
       "name": "sort_by_ts_esql_doc_partitioning",
@@ -1186,10 +1186,10 @@
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
-      "name": "date_histogram_calendar_interval_esql_shard_partitioning",
+      "name": "date_histogram_calendar_interval_esql_segment_partitioning",
       "operation-type": "esql",
       "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 week, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
-      "body": { "pragma": { "data_partitioning": "shard" } }
+      "body": { "pragma": { "data_partitioning": "segment" } }
     },
     {
       "name": "date_histogram_calendar_interval_esql_doc_partitioning",
@@ -1198,10 +1198,10 @@
       "body": { "pragma": { "data_partitioning": "doc" } }
     },
     {
-      "name": "date_histogram_fixed_interval_esql_shard_partitioning",
+      "name": "date_histogram_fixed_interval_esql_segment_partitioning",
       "operation-type": "esql",
       "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
-      "body": { "pragma": { "data_partitioning": "shard" } }
+      "body": { "pragma": { "data_partitioning": "segment" } }
     },
     {
       "name": "date_histogram_fixed_interval_esql_doc_partitioning",
@@ -1256,10 +1256,10 @@
       }
     },
     {
-      "name": "date_histogram_fixed_interval_with_metrics_esql_shard_partitioning",
+      "name": "date_histogram_fixed_interval_with_metrics_esql_segment_partitioning",
       "operation-type": "esql",
       "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(10 days, dropoff_datetime) | stats min_total_amount = min(total_amount), max_total_amount = max(total_amount), avg_total_amount = avg(total_amount), avg_trip_distance = avg(trip_distance) by dropoffs_over_time | sort dropoffs_over_time",
-      "body": { "pragma": { "data_partitioning": "shard" } }
+      "body": { "pragma": { "data_partitioning": "segment" } }
     },
     {
       "name": "date_histogram_fixed_interval_with_metrics_esql_doc_partitioning",
@@ -1295,10 +1295,10 @@
       }
     },
     {
-      "name": "multi_terms-keyword_esql_shard_partitioning",
+      "name": "multi_terms-keyword_esql_segment_partitioning",
       "operation-type": "esql",
       "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-02-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | stats c = count(dropoff_datetime) by trip_type, payment_type, vendor_id",
-      "body": { "pragma": { "data_partitioning": "shard" } }
+      "body": { "pragma": { "data_partitioning": "segment" } }
     },
     {
       "name": "multi_terms-keyword_esql_doc_partitioning",


### PR DESCRIPTION
Shard partitioning was considered worst case, therefor interesting to compare to best case (doc) and _search. However, we now are more interesting in the default behaviour (segment) since it is more apples-for-apples comparison to _search.