### PR TITLE
Adding KnnVectorStore to dense_vector track for supporting knn-recall operations

### DIFF
--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -1,64 +1,108 @@
+import functools
 import json
 import logging
 import os
+import re
+
 from collections import defaultdict
-from functools import lru_cache
-
-
+from esrally.track import loader
+from esrally.track.track import Task, Parallel
 logger = logging.getLogger(__name__)
+
+
+def load_query_vectors(queries_file):
+    if not (os.path.exists(queries_file) and os.path.isfile(queries_file)):
+        raise ValueError(f"Provided queries file %s does not exist or is not a file" % queries_file)
+    query_vectors: dict[str, list[float]]
+    with open(queries_file, 'r') as f:
+        logger.info(f"Reading query vectors from '{queries_file}'")
+        lines = f.readlines()
+        query_vectors = {_index: json.loads(vector) for _index, vector in enumerate(lines)}
+        logger.info(f"Finished reading query vectors from '{queries_file}'")
+    return query_vectors
 
 
 class KnnVectorStore:
 
-    def __init__(self, _query_vectors: dict[str, list[float]], _exact_neighbors: dict[str, list[str]]):
-        self._query_vectors: dict[str, list[float]] = _query_vectors
-        self._exact_neighbors: dict[str, list[str]] = _exact_neighbors
+    def __init__(self, queries_file: str):
+        self._query_vectors = load_query_vectors(queries_file)
+        self._store = defaultdict(lambda: defaultdict(list))
+
+    async def get_neighbors_for_query(self, index: str, query_id: str, max_size: int, client) -> list[str]:
+        try:
+            logger.debug(f"Fetching exact neighbors for {query_id} from in-memory store")
+            if not (index in self._store and query_id in self._store[index]):
+                logger.debug(f"Query vector with id {query_id} not cached - computing neighbors")
+                self._store[index][query_id] = await self.load_exact_neighbors(index, query_id, max_size, client)
+                logger.debug(f"Finished computing exact neighbors for {query_id} - it's now cached!")
+            return self._store[index][query_id]
+        except Exception as ex:
+            return []
+
+    async def load_exact_neighbors(self, index: str, query_id: str, max_size: int, client):
+        if query_id not in self._query_vectors:
+            raise ValueError(f"Unknown query with id: '{query_id}' provided")
+        return await self.extract_exact_neighbors(self._query_vectors[query_id], index, max_size, client)
 
     def get_query_vectors(self) -> dict[str, list[float]]:
         return self._query_vectors
 
-    def get_neighbors_for_query(self, query_id: str) -> list[str]:
-        if query_id not in self._exact_neighbors:
-            raise ValueError(f"query_id not found in the precomputed list")
-        return self._exact_neighbors[query_id]
-
     @classmethod
-    @lru_cache(maxsize=1)
-    async def from_queries_files(cls, queries_file: str, index: str, max_size: int, client) -> "KnnVectorStore":
-        if not (os.path.exists(queries_file) and os.path.isfile(queries_file)):
-            raise ValueError(f"Provided queries file %s does not exist or is not a file" % queries_file)
-        query_vectors: dict[str, list[float]]
-        with open(queries_file, 'r') as f:
-            logger.info(f"Start computing exact neighbors for %s" % queries_file)
-            lines = f.readlines()
-            query_vectors = {_index: json.loads(vector) for _index, vector in enumerate(lines)}
-            exact_neighbors = await KnnVectorStore.extract_exact_neighbors(query_vectors, index, max_size, client)
-            logger.info(f"Done computing exact neighbors")
-            return KnnVectorStore(query_vectors, exact_neighbors)
+    @functools.lru_cache(maxsize=1)
+    def get_instance(cls, queries_file: str):
+        return KnnVectorStore(queries_file)
 
     @staticmethod
-    async def extract_exact_neighbors(query_vectors: dict[str, list[float]], index: str, max_size: int, client) -> dict[str, list[str]]:
-        exact_neighbors: dict[str, list[str]] = defaultdict(list)
-        for query_id, query_vector in query_vectors.items():
-            script_query = await client.search(
-                body={
-                    "query": {
-                        "script_score": {
-                            "query": {"match_all": {}},
-                            "script": {
-                                "source": "cosineSimilarity(params.query, 'vector') + 1.0",
-                                "params": {"query": query_vector},
-                            },
-                        }
-                    },
-                    "_source": False,
+    async def extract_exact_neighbors(query_vector: list[float], index: str, max_size: int, client) -> list[str]:
+        script_query = await client.search(
+            body={
+                "query": {
+                    "script_score": {
+                        "query": {"match_all": {}},
+                        "script": {
+                            "source": "cosineSimilarity(params.query, 'vector') + 1.0",
+                            "params": {"query": query_vector},
+                        },
+                    }
                 },
-                index=index,
-                size=max_size,
-            )
-            neighbors = [hit["_id"] for hit in script_query["hits"]["hits"]]
-            exact_neighbors[query_id] = neighbors
-        return exact_neighbors
+                "_source": False,
+            },
+            index=index,
+            size=max_size,
+        )
+        return [hit["_id"] for hit in script_query["hits"]["hits"]]
+
+
+class KnnRecallProcessor:
+
+    KNN_RECALL_OPERATION_PATTERN = re.compile(r"knn-recall-(\d+)-(\d+)")
+
+    def on_after_load_track(self, t):
+        max_k = 0
+        tasks_to_update = []
+        for challenge in t.challenges:
+            for task in challenge.schedule:
+                if isinstance(task, Task):
+                    task_matched = self.KNN_RECALL_OPERATION_PATTERN.search(task.operation.name)
+                    if task_matched:
+                        tasks_to_update.append(task)
+                        matched_k_parameter = task_matched.group(1)
+                        max_k = max(max_k, int(matched_k_parameter))
+                elif isinstance(task, Parallel):
+                    for nested_task in task.tasks:
+                        task_matched = self.KNN_RECALL_OPERATION_PATTERN.search(nested_task.operation.name)
+                        if task_matched:
+                            tasks_to_update.append(nested_task)
+                            matched_k_parameter = task_matched.group(1)
+                            max_k = max(max_k, int(matched_k_parameter))
+            for task in tasks_to_update:
+                task.operation.params.update({"max_k": max_k})
+
+    def on_prepare_track(self, track, data_root_dir):
+        return []
+
+    def __repr__(self, *args, **kwargs):
+        return "knn-recall-processor"
 
 
 class KnnParamSource:
@@ -133,7 +177,8 @@ class KnnRecallParamSource:
         self._params = params
         self._queries = []
         self.infinite = True
-        self._queries_file = "queries.json"
+        cwd = os.path.dirname(__file__)
+        self._queries_file = os.path.join(cwd, "queries.json")
 
     def partition(self, partition_index, total_partitions):
         return self
@@ -145,6 +190,7 @@ class KnnRecallParamSource:
             "size": self._params.get("k", 10),
             "num_candidates": self._params.get("num-candidates", 100),
             "queries_file": self._queries_file,
+            "max_k": self._params.get("max_k", 33)
         }
 
 
@@ -153,33 +199,35 @@ class KnnRecallParamSource:
 # the accuracy of the knn query.
 class KnnRecallRunner:
     async def __call__(self, es, params):
-        knn_vector_store: KnnVectorStore = await KnnVectorStore.from_queries_files(
-            params["queries_files"],
-            params["index"],
-            params["size"],
-            es
-        )
+        k = params["size"]
+        num_candidates = params["num_candidates"]
+        index = params["index"]
+        request_cache = params["cache"]
+        queries_file = params["queries_file"]
+        max_k = max(params["max_k"], k)
         recall_total = 0
         exact_total = 0
-        min_recall = params["size"]
+        min_recall = k
 
+        knn_vector_store: KnnVectorStore = KnnVectorStore.get_instance(queries_file)
         for query_id, query_vector in knn_vector_store.get_query_vectors().items():
             knn_result = await es.search(
                 body={
                     "knn": {
                         "field": "vector",
                         "query_vector": query_vector,
-                        "k": params["size"],
-                        "num_candidates": params["num_candidates"],
+                        "k": k,
+                        "num_candidates": num_candidates,
                     },
                     "_source": False,
                 },
-                index=params["index"],
-                request_cache=params["cache"],
-                size=params["size"],
+                index=index,
+                request_cache=request_cache,
+                size=k,
             )
             knn_hits = [hit["_id"] for hit in knn_result["hits"]["hits"]]
-            script_hits = knn_vector_store.get_neighbors_for_query(query_id)
+            script_hits = await knn_vector_store.get_neighbors_for_query(index, query_id, max_k, es)
+            script_hits = script_hits[:k]
             current_recall = len(set(knn_hits).intersection(set(script_hits)))
             recall_total += current_recall
             exact_total += len(script_hits)
@@ -189,8 +237,8 @@ class KnnRecallRunner:
             {
                 "avg_recall": recall_total / exact_total,
                 "min_recall": min_recall,
-                "k": params["size"],
-                "num_candidates": params["num_candidates"],
+                "k": k,
+                "num_candidates": num_candidates,
             }
             if exact_total > 0
             else None
@@ -204,3 +252,10 @@ def register(registry):
     registry.register_param_source("knn-param-source", KnnParamSource)
     registry.register_param_source("knn-recall-param-source", KnnRecallParamSource)
     registry.register_runner("knn-recall", KnnRecallRunner(), async_runner=True)
+    registry.register_track_processor(KnnRecallProcessor())
+    # TODO change this based on https://github.com/elastic/rally/issues/1257
+    try:
+        registry.register_track_processor(loader.DefaultTrackPreparator())
+    except TypeError as e:
+        if e == "__init__() missing 1 required positional argument: 'cfg'":
+            pass

--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -1,5 +1,64 @@
 import json
+import logging
 import os
+from collections import defaultdict
+from functools import lru_cache
+
+
+logger = logging.getLogger(__name__)
+
+
+class KnnVectorStore:
+
+    def __init__(self, _query_vectors: dict[str, list[float]], _exact_neighbors: dict[str, list[str]]):
+        self._query_vectors: dict[str, list[float]] = _query_vectors
+        self._exact_neighbors: dict[str, list[str]] = _exact_neighbors
+
+    def get_query_vectors(self) -> dict[str, list[float]]:
+        return self._query_vectors
+
+    def get_neighbors_for_query(self, query_id: str) -> list[str]:
+        if query_id not in self._exact_neighbors:
+            raise ValueError(f"query_id not found in the precomputed list")
+        return self._exact_neighbors[query_id]
+
+    @classmethod
+    @lru_cache(maxsize=1)
+    async def from_queries_files(cls, queries_file: str, index: str, max_size: int, client) -> "KnnVectorStore":
+        if not (os.path.exists(queries_file) and os.path.isfile(queries_file)):
+            raise ValueError(f"Provided queries file %s does not exist or is not a file" % queries_file)
+        query_vectors: dict[str, list[float]]
+        with open(queries_file, 'r') as f:
+            logger.info(f"Start computing exact neighbors for %s" % queries_file)
+            lines = f.readlines()
+            query_vectors = {_index: json.loads(vector) for _index, vector in enumerate(lines)}
+            exact_neighbors = await KnnVectorStore.extract_exact_neighbors(query_vectors, index, max_size, client)
+            logger.info(f"Done computing exact neighbors")
+            return KnnVectorStore(query_vectors, exact_neighbors)
+
+    @staticmethod
+    async def extract_exact_neighbors(query_vectors: dict[str, list[float]], index: str, max_size: int, client) -> dict[str, list[str]]:
+        exact_neighbors: dict[str, list[str]] = defaultdict(list)
+        for query_id, query_vector in query_vectors.items():
+            script_query = await client.search(
+                body={
+                    "query": {
+                        "script_score": {
+                            "query": {"match_all": {}},
+                            "script": {
+                                "source": "cosineSimilarity(params.query, 'vector') + 1.0",
+                                "params": {"query": query_vector},
+                            },
+                        }
+                    },
+                    "_source": False,
+                },
+                index=index,
+                size=max_size,
+            )
+            neighbors = [hit["_id"] for hit in script_query["hits"]["hits"]]
+            exact_neighbors[query_id] = neighbors
+        return exact_neighbors
 
 
 class KnnParamSource:
@@ -74,12 +133,7 @@ class KnnRecallParamSource:
         self._params = params
         self._queries = []
         self.infinite = True
-
-        cwd = os.path.dirname(__file__)
-        with open(os.path.join(cwd, "queries.json"), "r") as file:
-            # TODO take a random set of 20 queries instead
-            for line in file:
-                self._queries.append(json.loads(line))
+        self._queries_file = "queries.json"
 
     def partition(self, partition_index, total_partitions):
         return self
@@ -90,7 +144,7 @@ class KnnRecallParamSource:
             "cache": self._params.get("cache", False),
             "size": self._params.get("k", 10),
             "num_candidates": self._params.get("num-candidates", 100),
-            "queries": self._queries,
+            "queries_file": self._queries_file,
         }
 
 
@@ -99,16 +153,22 @@ class KnnRecallParamSource:
 # the accuracy of the knn query.
 class KnnRecallRunner:
     async def __call__(self, es, params):
+        knn_vector_store: KnnVectorStore = await KnnVectorStore.from_queries_files(
+            params["queries_files"],
+            params["index"],
+            params["size"],
+            es
+        )
         recall_total = 0
         exact_total = 0
         min_recall = params["size"]
 
-        for query in params["queries"]:
+        for query_id, query_vector in knn_vector_store.get_query_vectors().items():
             knn_result = await es.search(
                 body={
                     "knn": {
                         "field": "vector",
-                        "query_vector": query,
+                        "query_vector": query_vector,
                         "k": params["size"],
                         "num_candidates": params["num_candidates"],
                     },
@@ -118,26 +178,9 @@ class KnnRecallRunner:
                 request_cache=params["cache"],
                 size=params["size"],
             )
-            script_result = await es.search(
-                body={
-                    "query": {
-                        "script_score": {
-                            "query": {"match_all": {}},
-                            "script": {
-                                "source": "cosineSimilarity(params.query, 'vector') + 1.0",
-                                "params": {"query": query},
-                            },
-                        }
-                    },
-                    "_source": False,
-                },
-                index=params["index"],
-                request_cache=params["cache"],
-                size=params["size"],
-            )
-            knn_hits = {hit["_id"] for hit in knn_result["hits"]["hits"]}
-            script_hits = {hit["_id"] for hit in script_result["hits"]["hits"]}
-            current_recall = len(knn_hits.intersection(script_hits))
+            knn_hits = [hit["_id"] for hit in knn_result["hits"]["hits"]]
+            script_hits = knn_vector_store.get_neighbors_for_query(query_id)
+            current_recall = len(set(knn_hits).intersection(set(script_hits)))
             recall_total += current_recall
             exact_total += len(script_hits)
             min_recall = min(min_recall, current_recall)

--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -50,6 +50,7 @@ class KnnVectorStore:
     @classmethod
     @functools.lru_cache(maxsize=1)
     def get_instance(cls, queries_file: str):
+        logger.info("Initializing KnnVectorStore")
         return KnnVectorStore(queries_file)
 
     @staticmethod
@@ -190,7 +191,7 @@ class KnnRecallParamSource:
             "size": self._params.get("k", 10),
             "num_candidates": self._params.get("num-candidates", 100),
             "queries_file": self._queries_file,
-            "max_k": self._params.get("max_k", 33)
+            "max_k": self._params.get("max_k", 42)
         }
 
 

--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -178,7 +178,6 @@ class KnnRecallParamSource:
         self._index_name = params.get("index", default_index)
         self._cache = params.get("cache", False)
         self._params = params
-        self._queries = []
         self.infinite = True
         cwd = os.path.dirname(__file__)
         self._queries_file = os.path.join(cwd, "queries.json")

--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -7,18 +7,19 @@ import re
 from collections import defaultdict
 from esrally.track import loader
 from esrally.track.track import Task, Parallel
+
 logger = logging.getLogger(__name__)
 
 
 def load_query_vectors(queries_file):
     if not (os.path.exists(queries_file) and os.path.isfile(queries_file)):
-        raise ValueError(f"Provided queries file %s does not exist or is not a file" % queries_file)
+        raise ValueError(f"Provided queries file '{queries_file}' does not exist or is not a file")
     query_vectors: dict[str, list[float]]
     with open(queries_file, 'r') as f:
-        logger.info(f"Reading query vectors from '{queries_file}'")
+        logger.debug(f"Reading query vectors from '{queries_file}'")
         lines = f.readlines()
         query_vectors = {_index: json.loads(vector) for _index, vector in enumerate(lines)}
-        logger.info(f"Finished reading query vectors from '{queries_file}'")
+        logger.debug(f"Finished reading query vectors from '{queries_file}'")
     return query_vectors
 
 
@@ -57,6 +58,7 @@ class KnnVectorStore:
                 logger.debug(f"Finished computing exact neighbors for {query_id} - it's now cached!")
             return self._store[index][query_id]
         except Exception as ex:
+            logger.error(f"Failed to compute nearest neighbors for '{query_id}'. Returning empty results instead.", ex)
             return []
 
     async def load_exact_neighbors(self, index: str, query_id: str, max_size: int, client):


### PR DESCRIPTION
In this PR we add support for a `KnnVectorStore` to be shared across all `knn-recall-*` operations in the same thespian actor. As the true exact neighbors of all `knn-recall` operations are the same, it would be beneficial to compute them only once and then re-use them for later runs - instead of re-computing them every time when the index itself remains stale. 

So the idea here is to add a `KnnRecallProcessor` to identify the max `k` for the said track from all defined operations, so that we can later use this `k` to fetch the needed true exact neighbors and cover for all cases. Then, each runner would consult this vector store to:
* pick up the query vectors to use
* fetch the true `k` (where `k <= max_k`) nearest neighbors and
* compute overlap between result lists and report recall. 

A couple of notes:
* The `KnnVectorStore` is initialized by the first runner on each Actor (currently we only have 1 client for the `dense_vector` track so effectively only 1 actor). We could move this if needed to the `KnnRecallParamSource`
* The results are loaded lazily whenever requested. This means that we don't do prefetching & the first runner will take a substantial performance hit compared to the rest of the `knn-recall-*` runners. However as (i) this was already what was happening and (ii) we do not care about performance metrics in recall tasks, I believe that it's safe to define it through that.  This could also be beneficial in cases where we might apply sampling and/or randomization on a per-operation level, as we wouldn't have to unnecessary compute true nearest neighbors for every vector in the file.