### PR TITLE
Reduce Wikipedia default bulk size

### DIFF
--- a/wikipedia/operations/default.json
+++ b/wikipedia/operations/default.json
@@ -20,13 +20,13 @@
 {
   "name": "initial-documents-indexing",
   "operation-type": "bulk",
-  "bulk-size": {{ initial_indexing_bulk_size | default(500) | int }},
+  "bulk-size": {{ initial_indexing_bulk_size | default(250) | int }},
   "ingest-percentage": {{ initial_indexing_ingest_percentage | default(100) | int }}
 },
 {
   "name": "parallel-documents-indexing",
   "operation-type": "bulk",
-  "bulk-size": {{ parallel_indexing_bulk_size | default(500) }}
+  "bulk-size": {{ parallel_indexing_bulk_size | default(250) }}
 },
 {
   "name": "refresh-after-index",


### PR DESCRIPTION
As we've discussed, the Wikipedia track has been running into stability issues depending on the configuration, and one of the findings has highlighted that the default bulk size is a little too large and [can exceed Elasticsearch's default `http.max_content_length` value of `100mb`](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#http-settings).

This commit reduces the default bulk size by half.

Relates https://github.com/elastic/rally/pull/1805

cc @elastic/es-perf for awareness