### PR TITLE
ESQL: Load 500 rows

### DIFF
--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -164,6 +164,12 @@
           "iterations": 100
         }
         {% endif %}
+        ,{
+          "operation": "esql-fetch-500",
+          "warmup-iterations": 50,
+          "clients": {{ search_clients | default(1) | int }},
+          "iterations": 100
+        }
       ]
     },
     {

--- a/tsdb/operations/default.json
+++ b/tsdb/operations/default.json
@@ -322,4 +322,14 @@
       }
     }
   }
+},
+{
+  "name": "esql-fetch-500",
+  "description": "Grab 500 documents",
+  "operation-type": "esql",
+  {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
+  "query": "FROM k8s | LIMIT 500"
+  {%- else %}
+  "query": "FROM tsdb | LIMIT 500"
+  {% endif %}
 }


### PR DESCRIPTION
This adds a test that *just* loads 500 rows with ESQL. Against an index with *thousands* of fields. Those thousands of fields are pretty expensive for ESQL to load, much more expensive than _search. Because ESQL doesn't have any "just load the _source" style optimizations.