### PR TITLE
Update elastic/logs README.md

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -256,7 +256,7 @@ The following parameters are available:
 * `random_seed` (default: 13) - Integer used to determine the order of query execution. The interval between workflow executions, as well as the actions within them, is based on an exponentially distributed random variable. Seeding this process ensures execution is deterministic across different executions.
 * `query_min_date` (default: `2020-01-01`) - Minimum datetime to execute queries over (such as yyyy-MM-dd or yyyy-MM-ddThh:mm:ss.zzzZ). Affects ranges and date_histograms.  Must be less than `query_max_date` (or `query_max_date_start`).
 * `query_max_date` (default: `2020-01-02`) - Maximum datetime to execute queries over (such as yyyy-MM-dd or yyyy-MM-ddThh:mm:ss.zzzZ). Affects ranges and date_histograms. Cannot be configured when `query_max_date_start` is also defined.
-* `query_clients` (default: 1) - for the `logging-indexing-querying` challenge, this allows the number of clients per workflow to be adjusted.
+* `search_clients` (default: 1) - for the `logging-indexing-querying` challenge, this allows the number of clients per workflow to be adjusted.
 * `query_max_date_start` (optional) - Maximum datetime to execute queries over, at the beginning of a query workflow task. Increments with the time elapsed as the benchmark executes. Cannot be configured when `query_max_date` is also defined.
 * `query_average_interval` (optional) - Average time interval for queries to use. If unset, we use the durations and intervals set in the original action definitions.
 * `query_request_params` (optional) - A map of query parameters that will be used with any querying.


### PR DESCRIPTION
While experimenting with this track locally and also looking at the track definition, I think the "query_clients" parameter isn't used anywhere, but was probably renamed to "search_clients". See https://github.com/elastic/rally-tracks/blob/64eefc1451a5922c94421620ecec2f2eeb32a0fc/elastic/logs/track.json#L10 for reference for example.
Maybe you can check if I'm right or wrong with this and correct if necessary.