### PR TITLE
Add IT serverless Buildkite pipeline

### DIFF
--- a/.buildkite/it/serverless-pipeline.yml
+++ b/.buildkite/it/serverless-pipeline.yml
@@ -1,0 +1,6 @@
+agents:
+  image: "docker.elastic.co/ci-agent-images/es-perf/buildkite-agent-python"
+
+steps:
+  - label: "Run IT Serverless Test"
+    command: echo "TODO"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,14 +22,15 @@ spec:
   lifecycle: production
   dependsOn: 
     - "resource:rally-tracks-it"
+    - "resource:rally-tracks-it-serverless"
 
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
 ---
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: rally-tracks-it
-  description: Run tests
+  description: Run Rally Tracks integration tests
   links:
     - title: Pipeline
       url: https://buildkite.com/elastic/rally-tracks-it
@@ -47,6 +48,40 @@ spec:
     spec:
       pipeline_file: .buildkite/it/pipeline.yml
       repository: elastic/rally-tracks
+      teams:
+        es-perf: {}
+        everyone:
+          access_level: READ_ONLY
+
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: rally-tracks-it-serverless
+  description: Run Rally Tracks integration tests for serverless
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/rally-tracks-it-serverless
+
+spec:
+  type: buildkite-pipeline
+  owner: group:es-perf
+  system: buildkite
+
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: Rally Tracks - IT Serverless
+    spec:
+      pipeline_file: .buildkite/it/serverless-pipeline.yml
+      repository: elastic/rally-tracks
+      schedules:
+        Daily:
+          branch: master
+          cronline: "0 14 * * *"
+          message: periodic it serverless
       teams:
         es-perf: {}
         everyone:


### PR DESCRIPTION
Starting point for Buildkite pipeline for Rally tracks IT tests in serverless.