### PR TITLE
Avoid ZeroDivisionError in compression stats

### DIFF
--- a/elastic/shared/runners/datastream.py
+++ b/elastic/shared/runners/datastream.py
@@ -155,8 +155,9 @@ async def compression_stats(es, params):
             "index_size": ds_index_size,
             "reserved_size": reserved_size,
             "doc_size": ds_doc_size,
-            "json_to_index_ratio": ds_index_size / ds_doc_size,
-            "avg_doc_size": ds_doc_size / total_count,
+            # Avoid ZeroDivisionError in the event of a search failure
+            "json_to_index_ratio": ds_index_size / ds_doc_size if ds_doc_size > 0 else 0,
+            "avg_doc_size": ds_doc_size / total_count if total_count > 0 else 0,
         }
         if total_count == message_count:
             response = await es.search(
@@ -170,9 +171,10 @@ async def compression_stats(es, params):
             )
             ds_msg_size = response["aggregations"]["total_msg_size"]["value"]
             data_stream_stats["message_size"] = ds_msg_size
-            data_stream_stats["avg_message_size"] = ds_msg_size / total_count
-            data_stream_stats["raw_to_json_ratio"] = ds_doc_size / ds_msg_size
-            data_stream_stats["raw_to_index_ratio"] = ds_index_size / ds_msg_size
+            # Avoid ZeroDivisionError in the event of a search failure
+            data_stream_stats["avg_message_size"] = ds_msg_size / total_count if total_count > 0 else 0
+            data_stream_stats["raw_to_json_ratio"] = ds_doc_size / ds_msg_size if ds_msg_size > 0 else 0
+            data_stream_stats["raw_to_index_ratio"] = ds_index_size / ds_msg_size if ds_msg_size > 0 else 0
             complete_message_stats = True
         else:
             logger = logging.getLogger(__name__)


### PR DESCRIPTION
___resubmission of https://github.com/elastic/rally-tracks/pull/527___

This commit addresses https://github.com/elastic/rally-tracks/issues/523 which is triggered by an Elasticsearch bug when performing search operations against data streams with a synthetic source. The key here is to gracefully deal with cases in compression stats where division by 0 has the potential to occur. It happens because Elasticsearch returns partial results to the search client by default and we pick up the `0.0` value from `total_doc_size`; e.g.:

```diff
{
  "took": 25063,
  "timed_out": false,
  "_shards": {
    "total": 3,
    "successful": 2,
    "skipped": 0,
    "failed": 1,
    "failures": [
      {
        "shard": 2,
        "index": ".ds-logs-apache.access-default-2023.11.29-000001",
        "node": "W4zynXr3R6S1iZOtFieOdg",
        "reason": {
          "type": "index_out_of_bounds_exception",
          "reason": "index_out_of_bounds_exception: null",
          "suppressed": [
            {
              "type": "illegal_state_exception",
              "reason": "Failed to close the XContentBuilder",
              "caused_by": {
                "type": "i_o_exception",
                "reason": "Unclosed object or array found"
              }
            }
          ]
        }
      }
    ]
  },
  "hits": {
    "total": {
      "value": 10000,
      "relation": "gte"
    },
    "max_score": null,
    "hits": []
  },
  "aggregations": {
    "total_doc_size": {
-      "value": 0.0
    }
  }
}
```