### PR TITLE
Update hatch configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling<=1.18.0", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project.optional-dependencies]
 develop = [
-    "hatch==1.3.1",
-    "hatchling==1.6.0",
+    "hatch==1.7.0",
+    "hatchling==1.18.0",
     "black==23.3.0",
     "isort==5.12.0",
     "pre-commit==3.3.3",
@@ -26,6 +26,7 @@ requires-python = ">=3.8"
 
 [tool.hatch.build.targets.sdist]
 exclude = [
+  "/.buildkite",
   "/.github",
   "/.ci",
 ]


### PR DESCRIPTION
Updates hatch version and limits hatchling version to 1.18.0 as a workaround for https://github.com/pypa/hatch/issues/1113.