### PR TITLE
Adding invalidate-vector-store param to knn-recall operations

### DIFF
--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -189,6 +189,7 @@
     {
       "name": "knn-recall-10-100",
       "operation": {
+          "name": "knn-recall-10-100",
           "operation-type": "knn-recall",
           "param-source": "knn-recall-param-source",
           "k": 10,

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -187,7 +187,15 @@
       "iterations": 1000
     },
     {
-      "operation": "knn-recall-10-100"
+      "name": "knn-recall-10-100",
+      "operation": {
+          "operation-type": "knn-recall",
+          "param-source": "knn-recall-param-source",
+          "k": 10,
+          "num-candidates": 100,
+          "include-in-reporting": false,
+          "invalidate-vector-store": true
+      }
     },
     {
       "operation": "knn-recall-100-1000"

--- a/dense_vector/operations/default.json
+++ b/dense_vector/operations/default.json
@@ -23,8 +23,8 @@
   "name": "knn-recall-10-100",
   "operation-type": "knn-recall",
   "param-source": "knn-recall-param-source",
-  "k": 100,
-  "num-candidates": 1000,
+  "k": 10,
+  "num-candidates": 100,
   "include-in-reporting": false
 },
 {

--- a/dense_vector/operations/default.json
+++ b/dense_vector/operations/default.json
@@ -20,6 +20,14 @@
   "exact": true
 },
 {
+  "name": "knn-recall-10-100",
+  "operation-type": "knn-recall",
+  "param-source": "knn-recall-param-source",
+  "k": 100,
+  "num-candidates": 1000,
+  "include-in-reporting": false
+},
+{
   "name": "knn-recall-100-1000",
   "operation-type": "knn-recall",
   "param-source": "knn-recall-param-source",

--- a/dense_vector/operations/default.json
+++ b/dense_vector/operations/default.json
@@ -20,14 +20,6 @@
   "exact": true
 },
 {
-  "name": "knn-recall-10-100",
-  "operation-type": "knn-recall",
-  "param-source": "knn-recall-param-source",
-  "k": 10,
-  "num-candidates": 100,
-  "include-in-reporting": false
-},
-{
   "name": "knn-recall-100-1000",
   "operation-type": "knn-recall",
   "param-source": "knn-recall-param-source",

--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -178,7 +178,7 @@ class KnnRecallParamSource:
             "num_candidates": self._params.get("num-candidates", 100),
             "target_k": self._target_k,
             "knn_vector_store": KnnVectorStore.get_instance(self._queries_file, self._vector_field),
-            "invalidate_vector_store": self._params.get("invalidate-vector-store", False)
+            "invalidate_vector_store": self._params.get("invalidate-vector-store", False),
         }
 
 

--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -45,7 +45,6 @@ async def extract_exact_neighbors(
 
 
 class KnnVectorStore:
-
     @staticmethod
     def empty_store():
         return defaultdict(lambda: defaultdict(list))

--- a/dense_vector/track.py
+++ b/dense_vector/track.py
@@ -45,11 +45,16 @@ async def extract_exact_neighbors(
 
 
 class KnnVectorStore:
+
+    @staticmethod
+    def empty_store():
+        return defaultdict(lambda: defaultdict(list))
+
     def __init__(self, queries_file: str, vector_field: str):
         assert queries_file and vector_field
         self._query_vectors = load_query_vectors(queries_file)
         self._vector_field = vector_field
-        self._store = defaultdict(lambda: defaultdict(list))
+        self._store = KnnVectorStore.empty_store()
 
     async def get_neighbors_for_query(self, index: str, query_id: int, size: int, request_cache: bool, client) -> List[str]:
         try:
@@ -64,10 +69,14 @@ class KnnVectorStore:
             logger.exception(f"Failed to compute nearest neighbors for '{query_id}'. Returning empty results instead.", ex)
             return []
 
-    async def load_exact_neighbors(self, index: str, query_id: str, max_size: int, request_cache: bool, client):
+    async def load_exact_neighbors(self, index: str, query_id: int, max_size: int, request_cache: bool, client):
         if query_id not in self._query_vectors:
             raise ValueError(f"Unknown query with id: '{query_id}' provided")
         return await extract_exact_neighbors(self._query_vectors[query_id], index, max_size, self._vector_field, request_cache, client)
+
+    def invalidate_all(self):
+        logger.info("Invalidating all entries from knn-vector-store")
+        self._store = KnnVectorStore.empty_store()
 
     def get_query_vectors(self) -> Dict[int, List[float]]:
         if len(self._query_vectors) == 0:
@@ -169,6 +178,7 @@ class KnnRecallParamSource:
             "num_candidates": self._params.get("num-candidates", 100),
             "target_k": self._target_k,
             "knn_vector_store": KnnVectorStore.get_instance(self._queries_file, self._vector_field),
+            "invalidate_vector_store": self._params.get("invalidate-vector-store", False)
         }
 
 
@@ -187,6 +197,9 @@ class KnnRecallRunner:
         min_recall = k
 
         knn_vector_store: KnnVectorStore = params["knn_vector_store"]
+        invalidate_vector_store: bool = params["invalidate_vector_store"]
+        if invalidate_vector_store:
+            knn_vector_store.invalidate_all()
         for query_id, query_vector in knn_vector_store.get_query_vectors().items():
             knn_result = await es.search(
                 body={


### PR DESCRIPTION
In this PR we add a new param named `invalidate-vector-store` that resets the in-memory `KnnVectorStore` added [here](https://github.com/elastic/rally-tracks/pull/518). 

The reason for this is that in some cases it might be possible for two vectors to have the same cosine similarity score, so the final ranking depends on the internal doc id. However, as we have a `force-merge` operation in the schedule, which collapses all individual segments to 1 for each shard, these internal ids could change - which in turn might lead to the original results been "outdated".

We set the newly added param to `true` right after the `force-merge` operation takes place - and the ranking could be different.  