### PR TITLE
Adjust geonames, geopoint, nyc_taxis and so_vector tracks for serverless benchmarks

### DIFF
--- a/geonames/README.md
+++ b/geonames/README.md
@@ -51,6 +51,9 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 * `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
+* `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
+* `include_force_merge` (default: true for non-serverless clusters, false for serverless clusters): Whether to include force merge operation.
+* `include_target_throughput` (default: true for non-serverless clusters, false for serverless clusters): Whether to apply target throughput.
 
 ### License
 

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -47,7 +47,6 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
-        {% endif %}
         {
           "name": "wait-until-merges-finish",
           "operation": {
@@ -61,6 +60,7 @@
             "include-in-reporting": false
           }
         },
+        {% endif %}
         {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
         {
           "name": "post-ingest-sleep",

--- a/geonames/challenges/default.json
+++ b/geonames/challenges/default.json
@@ -34,6 +34,7 @@
           "name": "refresh-after-index",
           "operation": "refresh"
         },
+        {% if p_include_force_merge %}
         {
           "operation": {
             "operation-type": "force-merge",
@@ -46,6 +47,7 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
+        {% endif %}
         {
           "name": "wait-until-merges-finish",
           "operation": {
@@ -71,8 +73,9 @@
         {
           "operation": "index-stats",
           "warmup-iterations": 500,
-          "iterations": 1000,
+          "iterations": 1000{% if p_include_target_throughput %},
           "target-throughput": 90
+          {%- endif %}
         },
         {
           "operation": "node-stats",
@@ -82,166 +85,193 @@
         {
           "operation": "default",
           "warmup-iterations": 500,
-          "iterations": 1000,
+          "iterations": 1000{% if p_include_target_throughput %},
           "target-throughput": 50
+          {%- endif %}
         },
         {
           "operation": "term",
           "warmup-iterations": 500,
-          "iterations": 1000,
+          "iterations": 1000{% if p_include_target_throughput %},
           "target-throughput": 100
+          {%- endif %}
         },
         {
           "operation": "phrase",
           "warmup-iterations": 500,
-          "iterations": 1000,
+          "iterations": 1000{% if p_include_target_throughput %},
           "target-throughput": 110
+          {%- endif %}
         },
         {
           "operation": "country_agg_uncached",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 3
+          {%- endif %}
         },
         {
           "operation": "country_agg_cached",
           "warmup-iterations": 1000,
-          "iterations": 1000,
+          "iterations": 1000{% if p_include_target_throughput %},
           "target-throughput": 100
+          {%- endif %}
         },
         {
           "operation": "scroll",
           "warmup-iterations": 200,
           "iterations": 100,
-          "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages",
+          "#COMMENT": "Throughput is considered per request. So we issue one scroll request per second which will retrieve 25 pages"{% if p_include_target_throughput %},
           "target-throughput": 0.8
+          {%- endif %}
         },
         {
           "operation": "expression",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.5
+          {%- endif %}
         },
         {
           "operation": "painless_static",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.1
+          {%- endif %}
         },
         {
           "operation": "painless_dynamic",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.4
+          {%- endif %}
         },
         {
           "operation": "decay_geo_gauss_function_score",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1
+          {%- endif %}
         },
         {
           "operation": "decay_geo_gauss_script_score",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1
+          {%- endif %}
         },
         {
           "operation": "field_value_function_score",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.5
+          {%- endif %}
         },
         {
           "operation": "field_value_script_score",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.5
+          {%- endif %}
         },
         {
           "operation": "large_terms",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.1
+          {%- endif %}
         },
         {
           "operation": "large_filtered_terms",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.1
+          {%- endif %}
         },
         {
           "operation": "large_prohibited_terms",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.1
+          {%- endif %}
         },
         {
           "operation": "desc_sort_population",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.5
+          {%- endif %}
         },
         {
           "operation": "desc_sort_population_can_match_shortcut",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.5
+          {%- endif %}
         },
         {
           "operation": "desc_sort_population_no_can_match_shortcut",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.5
+          {%- endif %}
         },
 
         {
           "operation": "asc_sort_population",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.5
+          {%- endif %}
         },
         {
           "operation": "asc_sort_with_after_population",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.5
+          {%- endif %}
         },
         {
           "operation": "desc_sort_geonameid",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 6
+          {%- endif %}
         },
         {
           "operation": "desc_sort_with_after_geonameid",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 6
+          {%- endif %}
         },
         {
           "operation": "asc_sort_geonameid",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 6
+          {%- endif %}
         },
         {
           "operation": "asc_sort_with_after_geonameid",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 6
+          {%- endif %}
         },
         {
           "operation": "sort_country_code_can_match_shortcut",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.5
+          {%- endif %}
         },
         {
           "operation": "sort_country_code_no_can_match_shortcut",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 1.5
+          {%- endif %}
         }
       ]
     },
@@ -275,7 +305,8 @@
           "warmup-time-period": 120,
           "clients": {{bulk_indexing_clients | default(8)}},
           "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
-        },
+        }
+        {% if p_include_force_merge %},
         {
           "operation": {
             "operation-type": "force-merge",
@@ -297,6 +328,7 @@
             "include-in-reporting": false
           }
         }
+        {% endif %}
       ]
     },
     {
@@ -335,7 +367,8 @@
           "warmup-time-period": 45,
           "clients": {{bulk_indexing_clients | default(8)}},
           "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
-        },
+        }
+        {% if p_include_force_merge %},
         {
           "operation": {
             "operation-type": "force-merge",
@@ -357,6 +390,7 @@
             "include-in-reporting": false
           }
         }
+        {% endif %}
       ]
     },
     {
@@ -389,6 +423,7 @@
           "warmup-time-period": 120,
           "clients": {{bulk_indexing_clients | default(8)}}
         },
+        {% if p_include_force_merge %}
         {
           "operation": {
             "operation-type": "force-merge",
@@ -410,6 +445,7 @@
             "include-in-reporting": false
           }
         },
+        {% endif %}
         {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
         {
           "name": "post-ingest-sleep",
@@ -422,26 +458,30 @@
         {
           "operation": "significant_text_selective",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 2
+          {%- endif %}
         },
         {
           "operation": "significant_text_sampled_selective",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 20
+          {%- endif %}
         },
         {
           "operation": "significant_text_unselective",
           "warmup-iterations": 50,
-          "iterations": 20,
+          "iterations": 20{% if p_include_target_throughput %},
           "target-throughput": 0.04
+          {%- endif %}
         },
         {
           "operation": "significant_text_sampled_unselective",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 6
+          {%- endif %}
         }
       ]
     }

--- a/geonames/index.json
+++ b/geonames/index.json
@@ -1,9 +1,11 @@
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
     "index.store.type": "{{store_type | default('fs')}}",
+      {% endif %}
     "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/geonames/index.json
+++ b/geonames/index.json
@@ -1,3 +1,5 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}

--- a/geonames/track.json
+++ b/geonames/track.json
@@ -1,4 +1,9 @@
 {% import "rally.helpers" as rally with context %}
+
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+{% set p_include_force_merge = (include_force_merge | default(build_flavor != "serverless")) %}
+{% set p_include_target_throughput = (include_target_throughput | default(build_flavor != "serverless")) %}
+
 {
   "version": 2,
   "description": "POIs from Geonames",

--- a/geonames/track.json
+++ b/geonames/track.json
@@ -1,6 +1,5 @@
 {% import "rally.helpers" as rally with context %}
 
-{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 {% set p_include_force_merge = (include_force_merge | default(build_flavor != "serverless")) %}
 {% set p_include_target_throughput = (include_target_throughput | default(build_flavor != "serverless")) %}
 

--- a/geopoint/README.md
+++ b/geopoint/README.md
@@ -33,6 +33,9 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 * `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
+* `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
+* `include_force_merge` (default: true for non-serverless clusters, false for serverless clusters): Whether to include force merge operation.
+* `include_target_throughput` (default: true for non-serverless clusters, false for serverless clusters): Whether to apply target throughput.
 
 ### License
 

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -164,8 +164,8 @@
         {
         "name": "refresh-after-index",
         "operation": "refresh"
-        },
-        {% if p_include_force_merge %}
+        }
+        {% if p_include_force_merge %},
         {
           "operation": {
             "operation-type": "force-merge",
@@ -234,8 +234,8 @@
         {
         "name": "refresh-after-index",
         "operation": "refresh"
-        },
-        {% if p_include_force_merge %}
+        }
+        {% if p_include_force_merge %},
         {
           "operation": {
             "operation-type": "force-merge",

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -34,6 +34,7 @@
           "name": "refresh-after-index",
           "operation": "refresh"
         },
+        {% if p_include_force_merge %}
         {
           "operation": {
             "operation-type": "force-merge",
@@ -46,6 +47,7 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
+        {% endif %}
         {
           "name": "wait-until-merges-finish",
           "operation": {
@@ -71,26 +73,30 @@
         {
           "operation": "polygon",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 2
+          {%- endif %}
         },
         {
           "operation": "bbox",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 2
+          {%- endif %}
         },
         {
           "operation": "distance",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 5
+          {%- endif %}
         },
         {
           "operation": "distanceRange",
           "warmup-iterations": 200,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 0.5
+          {%- endif %}
         },
         {
           "operation": "geoGrid_geohash",
@@ -159,6 +165,7 @@
         "name": "refresh-after-index",
         "operation": "refresh"
         },
+        {% if p_include_force_merge %}
         {
           "operation": {
             "operation-type": "force-merge",
@@ -171,6 +178,7 @@
         "name": "refresh-after-force-merge",
         "operation": "refresh"
         },
+        {% endif %}
         {
           "name": "wait-until-merges-finish",
           "operation": {
@@ -227,6 +235,7 @@
         "name": "refresh-after-index",
         "operation": "refresh"
         },
+        {% if p_include_force_merge %}
         {
           "operation": {
             "operation-type": "force-merge",
@@ -239,6 +248,7 @@
         "name": "refresh-after-force-merge",
         "operation": "refresh"
         },
+        {% endif %}
         {
           "name": "wait-until-merges-finish",
           "operation": {

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -47,7 +47,6 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
-        {% endif %}
         {
           "name": "wait-until-merges-finish",
           "operation": {
@@ -61,6 +60,7 @@
             "include-in-reporting": false
           }
         },
+        {% endif %}
         {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
         {
           "name": "post-ingest-sleep",
@@ -178,7 +178,6 @@
         "name": "refresh-after-force-merge",
         "operation": "refresh"
         },
-        {% endif %}
         {
           "name": "wait-until-merges-finish",
           "operation": {
@@ -192,6 +191,7 @@
             "include-in-reporting": false
           }
         }
+        {% endif %}
       ]
     },
     {
@@ -248,7 +248,6 @@
         "name": "refresh-after-force-merge",
         "operation": "refresh"
         },
-        {% endif %}
         {
           "name": "wait-until-merges-finish",
           "operation": {
@@ -262,5 +261,6 @@
             "include-in-reporting": false
           }
         }
+        {% endif %}
       ]
     }

--- a/geopoint/index.json
+++ b/geopoint/index.json
@@ -1,8 +1,10 @@
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
     "index.number_of_shards": {{number_of_shards | default(5)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
+      {% endif %}
     "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/geopoint/index.json
+++ b/geopoint/index.json
@@ -1,3 +1,5 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}

--- a/geopoint/track.json
+++ b/geopoint/track.json
@@ -1,6 +1,5 @@
 {% import "rally.helpers" as rally with context %}
 
-{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 {% set p_include_force_merge = (include_force_merge | default(build_flavor != "serverless")) %}
 {% set p_include_target_throughput = (include_target_throughput | default(build_flavor != "serverless")) %}
 

--- a/geopoint/track.json
+++ b/geopoint/track.json
@@ -1,5 +1,9 @@
 {% import "rally.helpers" as rally with context %}
 
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+{% set p_include_force_merge = (include_force_merge | default(build_flavor != "serverless")) %}
+{% set p_include_target_throughput = (include_target_throughput | default(build_flavor != "serverless")) %}
+
 {
   "version": 2,
   "description": "Point coordinates from PlanetOSM",

--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -74,6 +74,9 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `detailed_results` (default: `false`): Adds additional [metadata](https://esrally.readthedocs.io/en/latest/track.html?highlight=detailed-results#meta-data) to challenges using the track `update` operation. Be aware using this option can add client side overhead due to the deserialization of API responses.
 * `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
+* `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
+* `include_force_merge` (default: true for non-serverless clusters, false for serverless clusters): Whether to include force merge operation.
+* `include_target_throughput` (default: true for non-serverless clusters, false for serverless clusters): Whether to apply target throughput.
 
 ### License
 

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -339,19 +339,6 @@
             "retry-until-success": true
           }
         },
-        {% if disable_serverless_autoscaler|default(false) and serverless_operator %}
-        {
-          "name": "disable-serverless-autoscaler",
-          "operation": {
-            "operation-type": "put-settings",
-            "body": {
-              "persistent": {
-                "serverless.autoscaling.enabled": false
-              }
-            }
-          }
-        },
-        {% endif %}
         {
           "operation": "update",
           "warmup-time-period": 1200,

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -12,7 +12,9 @@
             "index": "nyc_taxis",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+                {% if p_include_non_serverless_index_settings %}
               "index.translog.flush_threshold_size": "4g",
+                {% endif %}
               {%- endif -%}{# non-serverless-index-settings-marker-end #}
               "index.codec": "best_compression",
               "index.refresh_interval": "30s"
@@ -41,6 +43,7 @@
           "name": "refresh-after-index",
           "operation": "refresh"
         },
+        {% if p_include_force_merge %}
         {
           "operation": {
             "operation-type": "force-merge",
@@ -54,6 +57,7 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
+        {% endif %}
         {
           "operation": "wait-until-merges-finish"
         },
@@ -72,17 +76,20 @@
           "warmup-iterations": 50,
           "iterations": 100
         },
+        {% if p_include_target_throughput %}
         {
           "operation": "default",
           "warmup-iterations": 50,
           "iterations": 100,
           "target-throughput": 3
         },
+        {% endif %}
         {
           "operation": "default_1k",
           "warmup-iterations": 50,
-          "iterations": 100,
+          "iterations": 100{% if p_include_target_throughput %},
           "target-throughput": 3
+          {%- endif %}
         },
         {
           "operation": "range",
@@ -119,7 +126,9 @@
             "index": "nyc_taxis",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+                {% if p_include_non_serverless_index_settings %}
               "index.translog.flush_threshold_size": "4g",
+                {% endif %}
               {%- endif -%}{# non-serverless-index-settings-marker-end #}
               "index.codec": "best_compression",
               "index.refresh_interval": "30s"
@@ -148,6 +157,7 @@
           "name": "refresh-after-index",
           "operation": "refresh"
         },
+        {% if p_include_force_merge %}
         {
           "operation": {
             "operation-type": "force-merge",
@@ -161,6 +171,7 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
+        {% endif %}
         {
           "operation": "wait-until-merges-finish"
         }
@@ -179,7 +190,9 @@
             "index": "nyc_taxis",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+                {% if p_include_non_serverless_index_settings %}
               "index.translog.flush_threshold_size": "4g",
+                {% endif %}
               {%- endif -%}{# non-serverless-index-settings-marker-end #}
               "index.codec": "best_compression",
               "index.refresh_interval": "30s",
@@ -210,6 +223,7 @@
           "name": "refresh-after-index",
           "operation": "refresh"
         },
+        {% if p_include_force_merge %}
         {
           "operation": {
             "operation-type": "force-merge",
@@ -223,6 +237,7 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
+        {% endif %}
         {
           "operation": "wait-until-merges-finish"
         }
@@ -241,9 +256,11 @@
             "index": "nyc_taxis",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+                {% if p_include_non_serverless_index_settings %}
               "index.number_of_shards": {{number_of_shards | default(1)}},
               "index.number_of_replicas": {{number_of_replicas | default(0)}},
               "index.store.type": "{{store_type | default('fs')}}"
+                {% endif %}
               {%- endif -%}{# non-serverless-index-settings-marker-end #}
             }{%- endif %}
           }
@@ -270,6 +287,7 @@
           "name": "refresh-after-index",
           "operation": "refresh"
         },
+        {% if p_include_force_merge %}
         {
           "operation": {
             "operation-type": "force-merge",
@@ -283,6 +301,7 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
+        {% endif %}
         {
           "operation": "wait-until-merges-finish"
         }
@@ -301,7 +320,9 @@
             "index": "nyc_taxis",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+                {% if p_include_non_serverless_index_settings %}
               "index.store.type": "{{store_type | default('fs')}}"
+                {% endif %}
               {%- endif -%}{# non-serverless-index-settings-marker-end #}
             }{%- endif %}
           }
@@ -341,7 +362,9 @@
             "index": "nyc_taxis",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+                {% if p_include_non_serverless_index_settings %}
               "index.translog.flush_threshold_size": "4g",
+                {% endif %}
               {%- endif -%}{# non-serverless-index-settings-marker-end #}
               "index.codec": "best_compression",
               "index.refresh_interval": "30s"
@@ -537,6 +560,7 @@
           "name": "refresh-after-index",
           "operation": "refresh"
         },
+        {% if p_include_force_merge %}
         {
           "operation": {
             "operation-type": "force-merge",
@@ -550,6 +574,7 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
+        {% endif %}
         {
           "operation": "wait-until-merges-finish"
         },
@@ -599,7 +624,9 @@
             "index": "nyc_taxis",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+                {% if p_include_non_serverless_index_settings %}
               "index.translog.flush_threshold_size": "4g",
+                {% endif %}
               {%- endif -%}{# non-serverless-index-settings-marker-end #}
               "index.codec": "best_compression",
               "index.refresh_interval": "30s"
@@ -762,7 +789,9 @@
             "operation-type": "create-index",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
               {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+                {% if p_include_non_serverless_index_settings %}
               "index.translog.flush_threshold_size": "4g",
+                {% endif %}
               {%- endif -%}{# non-serverless-index-settings-marker-end #}
               "index.codec": "best_compression",
               "index.refresh_interval": "30s"

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -156,8 +156,8 @@
         {
           "name": "refresh-after-index",
           "operation": "refresh"
-        },
-        {% if p_include_force_merge %}
+        }
+        {% if p_include_force_merge %},
         {
           "operation": {
             "operation-type": "force-merge",
@@ -222,8 +222,8 @@
         {
           "name": "refresh-after-index",
           "operation": "refresh"
-        },
-        {% if p_include_force_merge %}
+        }
+        {% if p_include_force_merge %},
         {
           "operation": {
             "operation-type": "force-merge",
@@ -286,8 +286,8 @@
         {
           "name": "refresh-after-index",
           "operation": "refresh"
-        },
-        {% if p_include_force_merge %}
+        }
+        {% if p_include_force_merge %},
         {
           "operation": {
             "operation-type": "force-merge",
@@ -339,6 +339,19 @@
             "retry-until-success": true
           }
         },
+        {% if disable_serverless_autoscaler|default(false) and serverless_operator %}
+        {
+          "name": "disable-serverless-autoscaler",
+          "operation": {
+            "operation-type": "put-settings",
+            "body": {
+              "persistent": {
+                "serverless.autoscaling.enabled": false
+              }
+            }
+          }
+        },
+        {% endif %}
         {
           "operation": "update",
           "warmup-time-period": 1200,

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -57,10 +57,10 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
-        {% endif %}
         {
           "operation": "wait-until-merges-finish"
         },
+        {% endif %}
         {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
         {
           "name": "post-ingest-sleep",
@@ -171,10 +171,10 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
-        {% endif %}
         {
           "operation": "wait-until-merges-finish"
         }
+        {% endif %}
       ]
     },
     {
@@ -237,10 +237,10 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
-        {% endif %}
         {
           "operation": "wait-until-merges-finish"
         }
+        {% endif %}
       ]
     },
     {
@@ -301,10 +301,10 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
-        {% endif %}
         {
           "operation": "wait-until-merges-finish"
         }
+        {% endif %}
       ]
     },
     {
@@ -574,10 +574,10 @@
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
-        {% endif %}
         {
           "operation": "wait-until-merges-finish"
         },
+        {% endif %}
         {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
         {
           "name": "post-ingest-sleep",

--- a/nyc_taxis/index-payment-types.json
+++ b/nyc_taxis/index-payment-types.json
@@ -1,8 +1,10 @@
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0
+      {% endif %}
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {

--- a/nyc_taxis/index-payment-types.json
+++ b/nyc_taxis/index-payment-types.json
@@ -1,3 +1,5 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}

--- a/nyc_taxis/index-rate-codes.json
+++ b/nyc_taxis/index-rate-codes.json
@@ -1,8 +1,10 @@
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0
+      {% endif %}
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {

--- a/nyc_taxis/index-rate-codes.json
+++ b/nyc_taxis/index-rate-codes.json
@@ -1,3 +1,5 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}

--- a/nyc_taxis/index-trip-types.json
+++ b/nyc_taxis/index-trip-types.json
@@ -1,8 +1,10 @@
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0
+      {% endif %}
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {

--- a/nyc_taxis/index-trip-types.json
+++ b/nyc_taxis/index-trip-types.json
@@ -1,3 +1,5 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}

--- a/nyc_taxis/index-vendors.json
+++ b/nyc_taxis/index-vendors.json
@@ -1,8 +1,10 @@
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
     "index.number_of_shards": 1,
     "index.number_of_replicas": 0
+      {% endif %}
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {

--- a/nyc_taxis/index-vendors.json
+++ b/nyc_taxis/index-vendors.json
@@ -1,3 +1,5 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -1,8 +1,10 @@
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}},
+      {% endif %}
     "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/nyc_taxis/index.json
+++ b/nyc_taxis/index.json
@@ -1,3 +1,5 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}

--- a/nyc_taxis/track.json
+++ b/nyc_taxis/track.json
@@ -1,5 +1,9 @@
 {% import "rally.helpers" as rally with context %}
 
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+{% set p_include_force_merge = (include_force_merge | default(build_flavor != "serverless")) %}
+{% set p_include_target_throughput = (include_target_throughput | default(build_flavor != "serverless")) %}
+
 {
   "version": 2,
   "description": "Taxi rides in New York in 2015",

--- a/so_vector/README.md
+++ b/so_vector/README.md
@@ -66,6 +66,8 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `bulk_indexing_clients` (default: 1)
 * `ingest_percentage` (default: 100)
 * `max_num_segments` (default: 1)
+* `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
+* `include_force_merge` (default: true for non-serverless clusters, false for serverless clusters): Whether to include force merge operation.
 
 ### License
 We use the same license for the data as the original data: [CC-SA-4.0](http://creativecommons.org/licenses/by-sa/4.0/).

--- a/so_vector/challenges/default.json
+++ b/so_vector/challenges/default.json
@@ -109,7 +109,10 @@
       "warmup-iterations": 100,
       "iterations": 100,
       "clients": 1
-    }{# non-serverless-after-force-merge-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%},
+    }
+    {# non-serverless-after-force-merge-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_force_merge %}
+    ,
     {
       "operation": {
         "operation-type": "force-merge",
@@ -157,6 +160,7 @@
       "iterations": 100,
       "clients": 1
     }
+      {% endif %}
     {%- endif -%}{# non-serverless-after-force-merge-marker-end #}
   ]
 }

--- a/so_vector/index.json
+++ b/so_vector/index.json
@@ -1,8 +1,12 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
     "index.number_of_shards": {{number_of_shards | default(2)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
+      {% endif %}
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {

--- a/so_vector/track.json
+++ b/so_vector/track.json
@@ -1,6 +1,5 @@
 {% import "rally.helpers" as rally with context %}
 
-{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 {% set p_include_force_merge = (include_force_merge | default(build_flavor != "serverless")) %}
 
 {

--- a/so_vector/track.json
+++ b/so_vector/track.json
@@ -1,4 +1,8 @@
 {% import "rally.helpers" as rally with context %}
+
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+{% set p_include_force_merge = (include_force_merge | default(build_flavor != "serverless")) %}
+
 {
   "version": 2,
   "description": "Benchmark for vector search with StackOverflow data",


### PR DESCRIPTION
This changes the behaviour of tracks when used with serverless operator privileges to reflect public user defaults.

To provide an override mechanism to change the new defaults the following new parameters are introduced:
* `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings. Useful only when running with operator privileges.
* `include_force_merge` (default: true for non-serverless clusters, false for serverless clusters): Whether to include force merge operation. Useful only when running with operator privileges.
* `include_target_throughput` (default: true for non-serverless clusters, false for serverless clusters): Whether to apply target throughput.

Before this PR gets merged, configuration of existing serverless benchmarks needs to be adjusted.