### PR TITLE
Added es|ql queries to tsdb k8s query track.

### DIFF
--- a/tsdb_k8s_queries/challenges/default.json
+++ b/tsdb_k8s_queries/challenges/default.json
@@ -130,6 +130,28 @@
         {% for name, info in time_intervals.items() %}
         {
           "parallel": {
+            "completed-by": "esql_cpu_usage_per_pod_{{name}}",
+            "clients": 2,
+            "tasks": [
+              {
+                "name": "esql_touch-pod-1-{{name}}",
+                "operation": "touch-pod-index",
+                "clients": {{touch_bulk_indexing_clients}}
+              },
+              {
+                "operation": "esql_cpu_usage_per_pod_{{name}}",
+                "warmup-iterations": {{search_warmup_iterations}},
+                "iterations": {{search_iterations}},
+                "target-interval": {{target_interval}},
+                "clients": 1
+              }
+            ]
+          }
+        },
+        {%- endfor %}
+        {% for name, info in time_intervals.items() %}
+        {
+          "parallel": {
             "completed-by": "memory_usage_per_pod_{{name}}",
             "clients": 2,
             "tasks": [
@@ -140,6 +162,28 @@
               },
               {
                 "operation": "memory_usage_per_pod_{{name}}",
+                "warmup-iterations": {{search_warmup_iterations}},
+                "iterations": {{search_iterations}},
+                "target-interval": {{target_interval}},
+                "clients": 1
+              }
+            ]
+          }
+        },
+        {%- endfor %}
+        {% for name, info in time_intervals.items() %}
+        {
+          "parallel": {
+            "completed-by": "esql_memory_usage_per_pod_{{name}}",
+            "clients": 2,
+            "tasks": [
+              {
+                "name": "esql_touch-pod-2-{{name}}",
+                "operation": "touch-pod-index",
+                "clients": {{touch_bulk_indexing_clients}}
+              },
+              {
+                "operation": "esql_memory_usage_per_pod_{{name}}",
                 "warmup-iterations": {{search_warmup_iterations}},
                 "iterations": {{search_iterations}},
                 "target-interval": {{target_interval}},
@@ -218,6 +262,28 @@
         {% for name, info in time_intervals.items() %}
         {
           "parallel": {
+            "completed-by": "esql_average_container_cpu_{{name}}",
+            "clients": 2,
+            "tasks": [
+              {
+                "name": "esql_touch-container-1-{{name}}",
+                "operation": "touch-container-index",
+                "clients": {{touch_bulk_indexing_clients}}
+              },
+              {
+                "operation": "esql_average_container_cpu_{{name}}",
+                "warmup-iterations": {{search_warmup_iterations}},
+                "iterations": {{search_iterations}},
+                "target-interval": {{target_interval}},
+                "clients": 1
+              }
+            ]
+          }
+        },
+        {%- endfor %}
+        {% for name, info in time_intervals.items() %}
+        {
+          "parallel": {
             "completed-by": "average_container_memory_usage_{{name}}",
             "clients": 2,
             "tasks": [
@@ -228,6 +294,28 @@
               },
               {
                 "operation": "average_container_memory_usage_{{name}}",
+                "warmup-iterations": {{search_warmup_iterations}},
+                "iterations": {{search_iterations}},
+                "target-interval": {{target_interval}},
+                "clients": 1
+              }
+            ]
+          }
+        },
+        {%- endfor %}
+        {% for name, info in time_intervals.items() %}
+        {
+          "parallel": {
+            "completed-by": "esql_average_container_memory_usage_{{name}}",
+            "clients": 2,
+            "tasks": [
+              {
+                "name": "esql_touch-container-2-{{name}}",
+                "operation": "touch-container-index",
+                "clients": {{touch_bulk_indexing_clients}}
+              },
+              {
+                "operation": "esql_average_container_memory_usage_{{name}}",
                 "warmup-iterations": {{search_warmup_iterations}},
                 "iterations": {{search_iterations}},
                 "target-interval": {{target_interval}},
@@ -262,6 +350,28 @@
         {% for name, info in time_intervals.items() %}
         {
           "parallel": {
+            "completed-by": "esql_cpu_usage_per_container_{{name}}",
+            "clients": 2,
+            "tasks": [
+              {
+                "name": "esql_touch-container-3-{{name}}",
+                "operation": "touch-container-index",
+                "clients": {{touch_bulk_indexing_clients}}
+              },
+              {
+                "operation": "esql_cpu_usage_per_container_{{name}}",
+                "warmup-iterations": {{search_warmup_iterations}},
+                "iterations": {{search_iterations}},
+                "target-interval": {{target_interval}},
+                "clients": 1
+              }
+            ]
+          }
+        },
+        {%- endfor %}
+        {% for name, info in time_intervals.items() %}
+        {
+          "parallel": {
             "completed-by": "memory_usage_per_container_{{name}}",
             "clients": 2,
             "tasks": [
@@ -284,6 +394,28 @@
         {% for name, info in time_intervals.items() %}
         {
           "parallel": {
+            "completed-by": "esql_memory_usage_per_container_{{name}}",
+            "clients": 2,
+            "tasks": [
+              {
+                "name": "esql_touch-container-4-{{name}}",
+                "operation": "touch-container-index",
+                "clients": {{touch_bulk_indexing_clients}}
+              },
+              {
+                "operation": "esql_memory_usage_per_container_{{name}}",
+                "warmup-iterations": {{search_warmup_iterations}},
+                "iterations": {{search_iterations}},
+                "target-interval": {{target_interval}},
+                "clients": 1
+              }
+            ]
+          }
+        },
+        {%- endfor %}
+        {% for name, info in time_intervals.items() %}
+        {
+          "parallel": {
             "completed-by": "unique_deployment_count_{{name}}",
             "clients": 2,
             "tasks": [
@@ -294,6 +426,50 @@
               },
               {
                 "operation": "unique_deployment_count_{{name}}",
+                "warmup-iterations": {{search_warmup_iterations}},
+                "iterations": {{search_iterations}},
+                "target-interval": {{target_interval}},
+                "clients": 1
+              }
+            ]
+          }
+        },
+        {%- endfor %}
+        {% for name, info in time_intervals.items() %}
+        {
+          "parallel": {
+            "completed-by": "esql_unique_deployment_count_{{name}}",
+            "clients": 2,
+            "tasks": [
+              {
+                "name": "eslq_touch-pod-5-{{name}}",
+                "operation": "touch-pod-index",
+                "clients": {{touch_bulk_indexing_clients}}
+              },
+              {
+                "operation": "esql_unique_deployment_count_{{name}}",
+                "warmup-iterations": {{search_warmup_iterations}},
+                "iterations": {{search_iterations}},
+                "target-interval": {{target_interval}},
+                "clients": 1
+              }
+            ]
+          }
+        },
+        {%- endfor %}
+        {% for name, info in time_intervals.items() %}
+        {
+          "parallel": {
+            "completed-by": "esql_percentile_cpu_usage_per_container_{{name}}",
+            "clients": 2,
+            "tasks": [
+              {
+                "name": "esql_touch-container-5-{{name}}",
+                "operation": "touch-container-index",
+                "clients": {{touch_bulk_indexing_clients}}
+              },
+              {
+                "operation": "esql_percentile_cpu_usage_per_container_{{name}}",
                 "warmup-iterations": {{search_warmup_iterations}},
                 "iterations": {{search_iterations}},
                 "target-interval": {{target_interval}},

--- a/tsdb_k8s_queries/operations/default.json
+++ b/tsdb_k8s_queries/operations/default.json
@@ -109,6 +109,14 @@
 {%- endfor %}
 {% for name, info in time_intervals.items() %}
 {
+  "name": "esql_cpu_usage_per_pod_{{name}}",
+  "operation-type": "esql",
+  "detailed-results": {{detailed_results | default("false")}},
+  "query": "FROM k8s-* | eval by_interval = date_trunc({{ info[2] }}, @timestamp), start_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ info[1] }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ end_time }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | STATS avg(kubernetes.pod.cpu.usage.limit.pct) BY kubernetes.pod.name, by_interval | LIMIT 10000"
+},
+{%- endfor %}
+{% for name, info in time_intervals.items() %}
+{
   "name": "memory_usage_per_pod_{{name}}",
   "data-stream": "k8s-*",
   "operation-type": "search",
@@ -198,6 +206,14 @@
       }
     }
   }  
+},
+{%- endfor %}
+{% for name, info in time_intervals.items() %}
+{
+  "name": "esql_memory_usage_per_pod_{{name}}",
+  "operation-type": "esql",
+  "detailed-results": {{detailed_results | default("false")}},
+  "query": "FROM k8s-* | eval by_interval = date_trunc({{ info[2] }}, @timestamp), start_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ info[1] }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ end_time }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | STATS avg(kubernetes.pod.memory.usage.node.pct) BY kubernetes.pod.name, by_interval | LIMIT 10000"
 },
 {%- endfor %}
 {% for name, info in time_intervals.items() %}
@@ -295,6 +311,14 @@
 {%- endfor %}
 {% for name, info in time_intervals.items() %}
 {
+  "name": "esql_average_container_cpu_{{name}}",
+  "operation-type": "esql",
+  "detailed-results": {{detailed_results | default("false")}},
+  "query": "FROM k8s-* | eval by_interval = date_trunc({{ info[2] }}, @timestamp), start_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ info[1] }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ end_time }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | STATS avg(kubernetes.container.cpu.usage.core.ns) BY kubernetes.container.name, by_interval | LIMIT 10000"
+},
+{%- endfor %}
+{% for name, info in time_intervals.items() %}
+{
   "name": "average_container_memory_usage_{{name}}",
   "data-stream": "k8s-*",
   "operation-type": "search",
@@ -384,6 +408,14 @@
       }
     }
   }
+},
+{%- endfor %}
+{% for name, info in time_intervals.items() %}
+{
+  "name": "esql_average_container_memory_usage_{{name}}",
+  "operation-type": "esql",
+  "detailed-results": {{detailed_results | default("false")}},
+  "query": "FROM k8s-* | eval by_interval = date_trunc({{ info[2] }}, @timestamp), start_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ info[1] }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ end_time }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | STATS avg(kubernetes.container.memory.usage.bytes) BY kubernetes.container.name, by_interval | LIMIT 10000"
 },
 {%- endfor %}
 {% for name, info in time_intervals.items() %}
@@ -482,6 +514,14 @@
 {%- endfor %}
 {% for name, info in time_intervals.items() %}
 {
+  "name": "esql_cpu_usage_per_container_{{name}}",
+  "operation-type": "esql",
+  "detailed-results": {{detailed_results | default("false")}},
+  "query": "FROM k8s-* | eval by_interval = date_trunc({{ info[2] }}, @timestamp), start_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ info[1] }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ end_time }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | STATS avg(kubernetes.container.cpu.usage.node.pct) BY kubernetes.container.name, by_interval | LIMIT 10000"
+},
+{%- endfor %}
+{% for name, info in time_intervals.items() %}
+{
   "name": "memory_usage_per_container_{{name}}",
   "data-stream": "k8s-*",
   "operation-type": "search",
@@ -575,6 +615,14 @@
 {%- endfor %}
 {% for name, info in time_intervals.items() %}
 {
+  "name": "esql_memory_usage_per_container_{{name}}",
+  "operation-type": "esql",
+  "detailed-results": {{detailed_results | default("false")}},
+  "query": "FROM k8s-* | eval by_interval = date_trunc({{ info[2] }}, @timestamp), start_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ info[1] }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ end_time }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | STATS avg(kubernetes.container.memory.usage.node.pct) BY kubernetes.container.name, by_interval | LIMIT 10000"
+},
+{%- endfor %}
+{% for name, info in time_intervals.items() %}
+{
   "name": "unique_deployment_count_{{name}}",
   "data-stream": "k8s-*",
   "operation-type": "search",
@@ -638,6 +686,14 @@
       }
     }
   }  
+},
+{%- endfor %}
+{% for name, info in time_intervals.items() %}
+{
+  "name": "esql_unique_deployment_count_{{name}}",
+  "operation-type": "esql",
+  "detailed-results": {{detailed_results | default("false")}},
+  "query": "FROM k8s-* | eval start_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ info[1] }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ end_time }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | STATS count_distinct(kubernetes.deployment.name)"
 },
 {%- endfor %}
 {% for name, info in time_intervals.items() %}
@@ -718,6 +774,14 @@
         }
       }
     } 
+},
+{%- endfor %}
+{% for name, info in time_intervals.items() %}
+{
+  "name": "esql_percentile_cpu_usage_per_container_{{name}}",
+  "operation-type": "esql",
+  "detailed-results": {{detailed_results | default("false")}},
+  "query": "FROM k8s-* | eval by_interval = date_trunc({{ info[2] }}, @timestamp), start_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ info[1] }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSSX\",\"{{ end_time }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | STATS percentile(kubernetes.container.cpu.usage.nanocores, 95) BY by_interval | LIMIT 10000"
 },
 {%- endfor %}
 {% for name, info in time_intervals.items() %}

--- a/tsdb_k8s_queries/track.json
+++ b/tsdb_k8s_queries/track.json
@@ -7,7 +7,7 @@
 {% set touch_bulk_size = touch_bulk_size | default(50) %}
 
 {% set end_time = "2023-05-16T21:00:00.000Z" %}
-{% set time_intervals = {"15_minutes": ["30s", "2023-05-16T20:45:00.000Z"], "2_hours": ["1m", "2023-05-16T19:00:00.000Z"], "24_hours": ["30m", "2023-05-15T21:00:00.000Z"]} %}
+{% set time_intervals = {"15_minutes": ["30s", "2023-05-16T20:45:00.000Z", "30 seconds"], "2_hours": ["1m", "2023-05-16T19:00:00.000Z", "1 minute"], "24_hours": ["30m", "2023-05-15T21:00:00.000Z", "30 minutes"]} %}
 
 {
   "version": 2,


### PR DESCRIPTION
This PR adds es|ql queries to the tsdb k8s track based on the following already defined searches: `esql_cpu_usage_per_pod_*`, `memory_usage_per_pod_*`, `average_container_cpu_*`, `average_container_memory_usage_*`, `cpu_usage_per_container_*`, `memory_usage_per_container_*`, `unique_deployment_count_*` and `percentile_cpu_usage_per_container_*`.

There is one caveat with the newly defined es|ql queries and that is that es|ql queries group by pod/container and then time interval. Whereas the searches also group by just pod/container. For example `cpu_usage_per_pod_15_minutes` computes average cpu usage by pod and 30 second interval and by pod, whereas the esql variant only computes cpu usage by pod and 30 second interval. In es|ql grouping currently can only be done by one set of aggregation keys. Maybe supporting multiple sets of aggregation kets will be supported in the future by the inline stats command.

Additionally the following searches couldn't be ported to esql queries:

- The `status_per_pod_*` searches, because there is no equivalent yet for the `top_metrics` aggregation in es|ql.
- The `tx_network_usage_per_pod_*` searches, because this search uses an average aggregation on a counter field and es|ql doesn't allow stats operations to be performed yet on counter fields. 