### PR TITLE
Update sync workflow to 8.13

### DIFF
--- a/.github/workflows/sync-latest-branch.yml
+++ b/.github/workflows/sync-latest-branch.yml
@@ -1,5 +1,5 @@
-# Synchronize all pushes to 'master' branch with '8.11' branch to reduce backport burden
-name: "Sync 8.11 branch"
+# Synchronize all pushes to 'master' branch with '8.13' branch to reduce backport burden
+name: "Sync 8.13 branch"
 on:
   push:
     branches:
@@ -14,13 +14,13 @@ jobs:
       - name: Checkout target repo
         uses: actions/checkout@v3
         with:
-          ref: 8.11
+          ref: 8.13
 
       - name: Sync upstream changes
         id: sync
         uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
         with:
-          target_sync_branch: 8.11
+          target_sync_branch: 8.13
           target_repo_token: ${{ secrets.GITHUB_TOKEN }}
           upstream_sync_branch: master
           upstream_sync_repo: elastic/rally-tracks


### PR DESCRIPTION
Changes most recent branch from 8.11 to 8.13. Triggered by https://github.com/elastic/rally-tracks/pull/525.