### PR TITLE
Fix variable overwriting in ELSER ingest speed test

### DIFF
--- a/elser-ingest-speedtest/challenges/Min-Latency-Multi-Doc-Multi-Parametric.json
+++ b/elser-ingest-speedtest/challenges/Min-Latency-Multi-Doc-Multi-Parametric.json
@@ -3,13 +3,13 @@
   "description": "Test the throughput of ELSER in various scenarios",
   "default": false,
   "schedule": [
-    {%- set model_id = model_id | default('default') %}
+    {%- set p_model_id = model_id | default('default') %}
     {
       "name": "put elser",
       "operation": {
         "operation-type": "put-elser",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
@@ -22,7 +22,7 @@
           "processors": [
             {
               "inference": {
-                "model_id": "{{ model_id }}",
+                "model_id": "{{ p_model_id }}",
                 "target_field": "ml",
                 "field_map": {
                   "body": "text_field"
@@ -59,48 +59,48 @@
     {%- set p_min_doc_size = min_doc_size | default(128) %}
     {%- set p_max_doc_size = max_doc_size | default(128) %}
     {%- set p_doc_size_delta = doc_size_delta | default(128) %}
-    {%- set bulk_size = 1 %}
-    {%- set bulk_indexing_clients = 1 %}
+    {%- set p_bulk_size = 1 %}
+    {%- set p_bulk_indexing_clients = 1 %}
 
 
-    {%- for doc_size in range(p_min_doc_size, p_max_doc_size + 1, p_doc_size_delta) %}
+    {%- for l_doc_size in range(p_min_doc_size, p_max_doc_size + 1, p_doc_size_delta) %}
 
     {%- for l_num_allocations in range(p_min_number_of_allocations, p_max_number_of_allocations + 1, 1) %}
     {%- for l_num_threads in [1, 2, 4, 8, 16] %}
 
-    {%- set itr_keys = doc_size ~ "-doc-size--" ~ l_num_threads ~ "-threads--" ~ l_num_allocations ~ "-allocations--" ~ bulk_size ~ "-bulk-size"%}
+    {%- set itr_keys = l_doc_size ~ "-doc-size--" ~ l_num_threads ~ "-threads--" ~ l_num_allocations ~ "-allocations--" ~ p_bulk_size ~ "-bulk-size"%}
 
     {
       "operation": "create-index",
       "name": "loop-create-index-{{ itr_keys }}"
     },
     {
-      "name": "stop any existing trained model deployment of {{ model_id }}--{{ itr_keys }}",
+      "name": "stop any existing trained model deployment of {{ p_model_id }}--{{ itr_keys }}",
       "operation": {
         "operation-type": "stop-trained-model-deployment",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
-      "name": "start new trained model deployment of {{ model_id }} with {{ itr_keys }}",
+      "name": "start new trained model deployment of {{ p_model_id }} with {{ itr_keys }}",
       "operation": {
         "operation-type": "start-trained-model-deployment",
         "number_of_allocations": {{ l_num_allocations | default(1) }},
         "threads_per_allocation": {{ l_num_threads | default(1) }},
         "queue_capacity": {{ queue_capacity | default(200000) }},
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
-      "name": "bulk--{{ itr_keys }}--{{ bulk_indexing_clients }}-clients--{{ ingest_percentage }}-ingest-percent",
-      "clients": {{ bulk_indexing_clients }},
+      "name": "bulk--{{ itr_keys }}--{{ p_bulk_indexing_clients }}-clients--{{ ingest_percentage }}-ingest-percent",
+      "clients": {{ p_bulk_indexing_clients }},
       "operation": {
         "operation-type": "bulk",
         "ingest-percentage": {{ ingest_percentage | default(100) }},
-        "corpora": "size{{ doc_size }}-small-bert-vocab-whole-words",
-        "bulk-size": {{  bulk_size }},
+        "corpora": "size{{ l_doc_size }}-small-bert-vocab-whole-words",
+        "bulk-size": {{  p_bulk_size }},
         "pipeline": "{{ pipeline_name | default('default-pipeline')}}",
         "request-timeout": 60.0,
         "include-in-reporting": true
@@ -119,7 +119,7 @@
       "operation": {
         "operation-type": "delete-elser",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     }
   ]

--- a/elser-ingest-speedtest/challenges/Multi-Doc-Multi-Parametric-Bulk-Size-Search.json
+++ b/elser-ingest-speedtest/challenges/Multi-Doc-Multi-Parametric-Bulk-Size-Search.json
@@ -3,13 +3,13 @@
   "description": "Test the throughput of ELSER in various scenarios",
   "default": false,
   "schedule": [
-    {%- set model_id = model_id | default('default') %}
+    {%- set p_model_id = model_id | default('default') %}
     {
       "name": "put elser",
       "operation": {
         "operation-type": "put-elser",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
@@ -22,7 +22,7 @@
           "processors": [
             {
               "inference": {
-                "model_id": "{{ model_id }}",
+                "model_id": "{{ p_model_id }}",
                 "target_field": "ml",
                 "field_map": {
                   "body": "text_field"
@@ -60,38 +60,38 @@
     {%- set p_max_doc_size = max_doc_size | default(128) %}
     {%- set p_doc_size_delta = doc_size_delta | default(128) %}
 
-    {%- for doc_size in range(p_min_doc_size, p_max_doc_size + 1, p_doc_size_delta) %}
+    {%- for l_doc_size in range(p_min_doc_size, p_max_doc_size + 1, p_doc_size_delta) %}
 
-    {%- set bulk_size = bulk_size | default(100) %}
-    {%- for bulk_size_multiplier in range(1, 17, 2) %}
-    {%- set bulk_size_mult_int = (bulk_size_multiplier/10)*(p_max_doc_size/doc_size) | round %}
-    {%- set adj_bulk_size = bulk_size*bulk_size_mult_int | default(100) %}
+    {%- set p_bulk_size = bulk_size | default(100) %}
+    {%- for l_bulk_size_multiplioer in range(1, 17, 2) %}
+    {%- set bulk_size_mult_int = (l_bulk_size_multiplier/10)*(p_max_doc_size/l_doc_size) | round %}
+    {%- set adj_bulk_size = p_bulk_size*bulk_size_mult_int | default(100) %}
 
     {%- for l_num_allocations in range(p_min_number_of_allocations, p_max_number_of_allocations + 1, 1) %}
 
-    {%- set itr_keys = doc_size ~ "-doc-size--" ~ l_num_allocations ~ "-allocations--" ~ adj_bulk_size ~ "-bulk-size"%}
+    {%- set itr_keys = l_doc_size ~ "-doc-size--" ~ l_num_allocations ~ "-allocations--" ~ adj_bulk_size ~ "-bulk-size"%}
 
     {
       "operation": "create-index",
       "name": "loop-create-index-{{ itr_keys }}"
     },
     {
-      "name": "stop any existing trained model deployment of {{ model_id }}--{{ itr_keys }}",
+      "name": "stop any existing trained model deployment of {{ p_model_id }}--{{ itr_keys }}",
       "operation": {
         "operation-type": "stop-trained-model-deployment",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
-      "name": "start new trained model deployment of {{ model_id }} with {{ itr_keys }}",
+      "name": "start new trained model deployment of {{ p_model_id }} with {{ itr_keys }}",
       "operation": {
         "operation-type": "start-trained-model-deployment",
         "number_of_allocations": {{ l_num_allocations | default(1) }},
         "threads_per_allocation": {{ threads_per_allocation | default(1) }},
         "queue_capacity": {{ queue_capacity | default(200000) }},
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
@@ -100,7 +100,7 @@
       "operation": {
         "operation-type": "bulk",
         "ingest-percentage": {{ ingest_percentage | default(100) }},
-        "corpora": "size{{ doc_size }}-small-bert-vocab-whole-words",
+        "corpora": "size{{ l_doc_size }}-small-bert-vocab-whole-words",
         "bulk-size": {{ adj_bulk_size | default(100) }},
         "pipeline": "{{ pipeline_name | default('default-pipeline')}}",
         "request-timeout": 60.0,
@@ -120,7 +120,7 @@
       "operation": {
         "operation-type": "delete-elser",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     }
   ]

--- a/elser-ingest-speedtest/challenges/Multi-Doc-Multi-Parametric-Bulk-Size-Search.json
+++ b/elser-ingest-speedtest/challenges/Multi-Doc-Multi-Parametric-Bulk-Size-Search.json
@@ -63,7 +63,7 @@
     {%- for l_doc_size in range(p_min_doc_size, p_max_doc_size + 1, p_doc_size_delta) %}
 
     {%- set p_bulk_size = bulk_size | default(100) %}
-    {%- for l_bulk_size_multiplioer in range(1, 17, 2) %}
+    {%- for l_bulk_size_multiplier in range(1, 17, 2) %}
     {%- set bulk_size_mult_int = (l_bulk_size_multiplier/10)*(p_max_doc_size/l_doc_size) | round %}
     {%- set adj_bulk_size = p_bulk_size*bulk_size_mult_int | default(100) %}
 

--- a/elser-ingest-speedtest/challenges/Multi-Doc-Size-Multi-allocations-Parametric.json
+++ b/elser-ingest-speedtest/challenges/Multi-Doc-Size-Multi-allocations-Parametric.json
@@ -3,13 +3,13 @@
   "description": "Test the throughput of ELSER at ingest varying the document length and number of allocations",
   "default": false,
   "schedule": [
-    {%- set model_id = model_id | default('default') %}
+    {%- set p_model_id = model_id | default('default') %}
     {
       "name": "put elser v2 platform specific",
       "operation": {
         "operation-type": "put-elser",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
@@ -22,7 +22,7 @@
           "processors": [
             {
               "inference": {
-                "model_id": "{{ model_id }}",
+                "model_id": "{{ p_model_id }}",
                 "target_field": "ml",
                 "field_map": {
                   "body": "text_field"
@@ -60,13 +60,13 @@
     {%- set p_max_doc_size = max_doc_size | default(128) %}
     {%- set p_doc_size_delta = doc_size_delta | default(128) %}
 
-    {%- for doc_size in range(p_min_doc_size, p_max_doc_size + 1, p_doc_size_delta) %}
+    {%- for l_doc_size in range(p_min_doc_size, p_max_doc_size + 1, p_doc_size_delta) %}
 
     {%- for l_num_allocations in range(p_min_number_of_allocations, p_max_number_of_allocations + 1, 1) %}
 
-    {%- set adj_bulk_size = 512 - doc_size + 25*l_num_allocations | default(100) | round | int %}
+    {%- set adj_bulk_size = 512 - l_doc_size + 25*l_num_allocations | default(100) | round | int %}
 
-    {%- set itr_keys = doc_size ~ "-doc-size--" ~ l_num_allocations ~ "-allocations--" ~ adj_bulk_size ~ "-bulk-size" %}
+    {%- set itr_keys = l_doc_size ~ "-doc-size--" ~ l_num_allocations ~ "-allocations--" ~ adj_bulk_size ~ "-bulk-size" %}
 
     {
       "name": "loop-create-index-{{ itr_keys }}",
@@ -82,22 +82,22 @@
       }
     },
     {
-      "name": "stop any existing trained model deployment of {{ model_id }}--{{ itr_keys }}",
+      "name": "stop any existing trained model deployment of {{ p_model_id }}--{{ itr_keys }}",
       "operation": {
         "operation-type": "stop-trained-model-deployment",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
-      "name": "start new trained model deployment of {{ model_id }} with {{ itr_keys }}",
+      "name": "start new trained model deployment of {{ p_model_id }} with {{ itr_keys }}",
       "operation": {
         "operation-type": "start-trained-model-deployment",
         "number_of_allocations": {{ l_num_allocations | default(1) }},
         "threads_per_allocation": {{ threads_per_allocation | default(1) }},
         "queue_capacity": {{ queue_capacity | default(200000) }},
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
@@ -106,7 +106,7 @@
       "operation": {
         "operation-type": "bulk",
         "ingest-percentage": {{ ingest_percentage | default(100) }},
-        "corpora": "size{{ doc_size }}-small-bert-vocab-whole-words",
+        "corpora": "size{{ l_doc_size }}-small-bert-vocab-whole-words",
         "bulk-size": {{ adj_bulk_size | default(100) }},
         "pipeline": "{{ pipeline_name | default('default-pipeline')}}",
         "request-timeout": 60.0,
@@ -125,7 +125,7 @@
       "operation": {
         "operation-type": "delete-elser",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     }
   ]

--- a/elser-ingest-speedtest/challenges/Multi-Parametric.json
+++ b/elser-ingest-speedtest/challenges/Multi-Parametric.json
@@ -3,13 +3,13 @@
   "description": "Test the throughput of ELSER at ingest with 256 token documents and varying number of allocations",
   "default": false,
   "schedule": [
-    {%- set model_id = model_id | default('default') %}
+    {%- set p_model_id = model_id | default('default') %}
     {
       "name": "put elser v2 platform specific",
       "operation": {
         "operation-type": "put-elser",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
@@ -22,7 +22,7 @@
           "processors": [
             {
               "inference": {
-                "model_id": "{{ model_id }}",
+                "model_id": "{{ p_model_id }}",
                 "target_field": "ml",
                 "field_map": {
                   "body": "text_field"
@@ -54,7 +54,7 @@
       "operation": "delete-index",
       "name": "first-delete-index"
     }
-    {%- set bulk_size = bulk_size | default(1) %}
+    {%- set p_bulk_size = bulk_size | default(1) %}
     {%- set p_number_of_allocations = number_of_allocations | default(1) %}
     {%- for l_num_allocations in range(1, p_number_of_allocations + 1, 1) %},
     {
@@ -62,32 +62,32 @@
       "name": "loop-create-index-{{ l_num_allocations }}"
     },
     {
-      "name": "stop any existing trained model deployment with name: [{{ model_id }}]--{{ l_num_allocations }}",
+      "name": "stop any existing trained model deployment with name: [{{ p_model_id }}]--{{ l_num_allocations }}",
       "operation": {
         "operation-type": "stop-trained-model-deployment",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
-      "name": "start new trained model deployment with name [{{ model_id }}] and [{{ l_num_allocations }}] allocations",
+      "name": "start new trained model deployment with name [{{ p_model_id }}] and [{{ l_num_allocations }}] allocations",
       "operation": {
         "operation-type": "start-trained-model-deployment",
         "number_of_allocations": {{ l_num_allocations | default(1) }},
         "threads_per_allocation": {{ threads_per_allocation | default(1) }},
         "queue_capacity": {{ queue_capacity | default(200000) }},
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     },
     {
-      "name": "bulk--{{ l_num_allocations }}-allocations--{{ bulk_indexing_clients }}-clients--{{ ingest_percentage }}-ingest-percent--{{ bulk_size }}-bulk-size",
+      "name": "bulk--{{ l_num_allocations }}-allocations--{{ bulk_indexing_clients }}-clients--{{ ingest_percentage }}-ingest-percent--{{ p_bulk_size }}-bulk-size",
       "clients": {{ bulk_indexing_clients | default(3) }},
       "operation": {
         "operation-type": "bulk",
         "ingest-percentage": {{ ingest_percentage | default(0.01) }},
         "corpora": "size256-bert-vocab-whole-words",
-        "bulk-size": {{ bulk_size}},
+        "bulk-size": {{ p_bulk_size}},
         "pipeline": "{{ pipeline_name | default('default-pipeline')}}",
         "request-timeout": 60.0,
         "include-in-reporting": true
@@ -103,7 +103,7 @@
       "operation": {
         "operation-type": "delete-elser",
         "include-in-reporting": false,
-        "model_id": "{{ model_id }}"
+        "model_id": "{{ p_model_id }}"
       }
     }
   ]


### PR DESCRIPTION
Closes [this issue](https://github.com/elastic/elasticsearch-benchmarks/issues/1905#issuecomment-1887658670), found by @gbanasiak. The elser-ingest-speedtest rally track has a bug which sometimes causes variables to be erroneously overwritten. This occurs because all challenges are assembled by rally into a single document with a single namespace for all variables. Setting variable values thus effects not only one challenge, but all challenges in a track. This change fixes this bug by always never overwriting the variable values which are parameters for the challenge, but rather creating new variables with prefixes of `p_` for setting parameters and `l_` for loops. 