### PR TITLE
Use new name for frequent items agg

### DIFF
--- a/so/operations/default.json
+++ b/so/operations/default.json
@@ -166,7 +166,7 @@
         "size": 0,
         "aggs": {
           "fi": {
-            "frequent_items": {
+            "frequent_item_sets": {
               "minimum_set_size": 2,
               "minimum_support": 0.01,
               "size": 100,
@@ -217,7 +217,7 @@
         "size": 0,
         "aggs": {
           "fi": {
-            "frequent_items": {
+            "frequent_item_sets": {
               "minimum_set_size": 2,
               "minimum_support": 0.01,
               "size": 10,
@@ -262,7 +262,7 @@
         "size": 0,
         "aggs": {
           "fi": {
-            "frequent_items": {
+            "frequent_item_sets": {
               "minimum_set_size": 2,
               "minimum_support": 0.005,
               "size": 1000,


### PR DESCRIPTION
The `frequent_items` name was deprecated in 8.7 and replaced with `frequent_item_sets`. This change updates the SO track to use the new name for the aggregation. 

Closes #557