### PR TITLE
Adds field-caps non empty field task in the many-shards-quantitative challenge

### DIFF
--- a/elastic/logs/challenges/many-shards-quantitative.json
+++ b/elastic/logs/challenges/many-shards-quantitative.json
@@ -83,7 +83,7 @@
         ]
       }
     },
-    {% include "tasks/field-caps.json" %}
+    {% include "tasks/field-caps.json" %},
     {% include "tasks/field-caps-non-empty-fields.json" %}
   ]
 }

--- a/elastic/logs/challenges/many-shards-quantitative.json
+++ b/elastic/logs/challenges/many-shards-quantitative.json
@@ -84,5 +84,6 @@
       }
     },
     {% include "tasks/field-caps.json" %}
+    {% include "tasks/field-caps-non-empty-fields.json" %}
   ]
 }

--- a/elastic/logs/tasks/field-caps-non-empty-fields.json
+++ b/elastic/logs/tasks/field-caps-non-empty-fields.json
@@ -1,0 +1,13 @@
+{
+  "name": "field-caps-exclude-empty-fields",
+  "operation": {
+    "operation-type": "field-caps",
+    "index": "auditbeat*",
+    "request-params": {
+      "include_empty_fields": false
+    }
+  },
+  "iterations": 200,
+  "warmup-iterations": 10,
+  "clients": 2
+}

--- a/elastic/logs/tasks/field-caps-non-empty-fields.json
+++ b/elastic/logs/tasks/field-caps-non-empty-fields.json
@@ -4,7 +4,7 @@
     "operation-type": "field-caps",
     "index": "auditbeat*",
     "request-params": {
-      "include_empty_fields": false
+      "include_empty_fields": "false"
     }
   },
   "iterations": 200,


### PR DESCRIPTION
Recently we added a new optional query parameter to the _field_caps API in order to 
filter out fields with no values. The parameter is called `include_empty_fields`  and 
defaults to true, and if set to false it will filter out from the field_caps response all the 
fields that has no value in the index. With this PR we want to benchmark this change 
by adding a new task to the many-shard-quantitative challenge.

relates to: https://github.com/elastic/elasticsearch/pull/103651 