### PR TITLE
Adjust elastic/logs for serverless benchmarks

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -219,6 +219,7 @@ The following parameters are available:
 * `end_date` (default: `2020-01-02` ) - The end date of the data. This value minus the `start_date` will determine the time range assigned to the data and also directly impact the total volume indexed. Must be greater than the `start_date`.
 * `corpora_uri_base` (default: `https://rally-tracks.elastic.co`) - Specify the base location of the datasets used by this track.
 * `lifecycle` (default: unset to fall back on Serverless detection) - Specifies the lifecycle management feature to use for data streams. Use `ilm` for index lifecycle management or `dlm` for data lifecycle management. By default, `dlm` will be used for benchmarking Serverless Elasticsearch.
+* `workflow-request-cache` (default: `true`) - Explicit control of request cache query parameter in searches executed in a workflow. This can be further overriden at an operation level with `request-cache` parameter.
 
 ### Data Download Parameters
 
@@ -249,6 +250,7 @@ The following parameters are available:
 * `index_sorting` (default: unset): Whether index sorting should be used. Accepted values: `hostname` and `timestamp`. 
 * `synthetic_source_mode` (default: `false`): Whether to enable synthetic source.
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use. Only supported in `logging-querying` track.
+* `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
 
 ### Querying parameters
 
@@ -264,6 +266,7 @@ The following parameters are available:
 * `query_average_interval` (optional) - Average time interval for queries to use. If unset, we use the durations and intervals set in the original action definitions.
 * `query_request_params` (optional) - A map of query parameters that will be used with any querying.
 * `query_workflows` (optional) - A list of workflows to execute. By default, all workflows are used.
+* `include_esql_queries` (default: true for non-serverless clusters, false for serverless clusters): Whether to include ESQL and ESQL-related queries.
 
 ### Snapshot parameters
 * `snapshot_counts` (default: `100`) - Specifies the number of back to back snapshots to issue and wait until all have completed. Applicable only to [many-shards-snapshots challenge](#many-shards-snapshots-many-shards-snapshots).

--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -103,7 +103,7 @@
           {% endfor %}
         ]
       }
-    },
+    }{%- if p_include_esql_queries %},
     {
       "operation": "esql_basic_count_group_0_limit_0",
       "clients": 1,
@@ -259,5 +259,6 @@
       "operation": "enable_query_cache",
       "tags": ["esql", "settings"]
     }{%- endif %}
+    {%- endif %}
   ]
 }

--- a/elastic/logs/templates/component/track-custom-shared-settings.json
+++ b/elastic/logs/templates/component/track-custom-shared-settings.json
@@ -1,10 +1,13 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 {
   "template": {
     "settings": {
       "index": {
         {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+          {% if p_include_non_serverless_index_settings %}
         "number_of_shards": "{{ number_of_shards | default(1) }}",
         "number_of_replicas": "{{ number_of_replicas | default(1) }}"{%- if refresh_interval -%},{%- endif -%}
+          {% endif %}
         {%- endif -%}{# non-serverless-index-settings-marker-end #}
         {% if refresh_interval -%}
         "refresh_interval": "{{ refresh_interval }}"

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -20,6 +20,7 @@
 {% set p_query_warmup_time_period = (query_warmup_time_period | default(120)) %}
 {% set p_query_time_period = (query_time_period | default(900)) %}
 {% set p_query_request_params = (query_request_params | default({}))%}
+{% set p_include_esql_queries = (include_esql_queries | default(build_flavor != "serverless")) %}
 
 {% set p_throttle_indexing = (throttle_indexing | default(false)) %}
 {% set p_max_download_gb = (max_total_download_gb | default(2 * num_corpus)) %}
@@ -146,7 +147,8 @@
     "wait-for-status": "{{ wait_for_status | default('green') }}",
     "force-data-generation": {{ force_data_generation | default(false) | tojson }},
     "detailed-results": {{ detailed_results | default(false) | tojson }},
-    "number-of-workflows": {{ p_num_query_workflows }}
+    "number-of-workflows": {{ p_num_query_workflows }},
+    "workflow-request-cache": {{ workflow_request_cache | default(true) | tojson }}
   },
   "data-streams": [
     {

--- a/elastic/tests/parameter_sources/workflow_selector_test.py
+++ b/elastic/tests/parameter_sources/workflow_selector_test.py
@@ -622,6 +622,25 @@ async def test_detailed_results():
         assert param_source.workflows[i][1]["requests"][2]["detailed-results"]
 
 
+@pytest.mark.asyncio
+async def test_request_cache():
+    param_source = WorkflowSelectorParamSource(
+        track=StaticTrack(parameters={"workflow-request-cache": True}),
+        params={
+            "workflow": "a",
+            "workflows-folder": "tests/parameter_sources/resources/workflows",
+            "task-offset": 0,
+        },
+    )
+    assert param_source.workflows[0][0] == "5"
+    assert "cache" in param_source.workflows[0][1]["requests"][0]["stream"][0]
+    # all workflows in workflows/a are identical
+    for i in range(5):
+        assert param_source.workflows[i][1]["requests"][0]["stream"][0]["cache"] == "true"
+        assert param_source.workflows[i][1]["requests"][1]["stream"][0]["cache"] == "true"
+        assert param_source.workflows[i][1]["requests"][2]["cache"] == "true"
+
+
 def test_seeding():
     seed = 15
     param_source = WorkflowSelectorParamSource(


### PR DESCRIPTION
The change introduces the following parameters:
* `workflow-request-cache` (default: `true`) - Explicit control of request cache query parameter in searches executed in a workflow. This can be further overriden at an operation level with `request-cache` parameter.
* `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
* `include_esql_queries` (default: true for non-serverless clusters, false for serverless clusters): Whether to include ESQL and ESQL-related queries.

Rally defaults to disabled request cache for serverless non-operator runs, but we want to have request cache enabled in this track. The PR moves from implicit request cache setting to explicit one to align all possible modes of execution (stateful, serverless operator and serverless non-operator).

ESQL operator is currently blocked for serverless in Rally, so ESQL queries of `logging-querying` challenge do not get executed automatically, but ESQL queries are accompanied by non-ESQL reference queries which do not make sense if ESQL queries are not included. Hence `include_esql_queries` control to disable/enable entire ESQL block.