### PR TITLE
Add DSL cluster settings in many-shards setup

### DIFF
--- a/elastic/logs/tasks/many-shards-setup.json
+++ b/elastic/logs/tasks/many-shards-setup.json
@@ -5,6 +5,12 @@
     "operation-type": "put-settings",
     "body": {
       "persistent": {
+        {% if p_dsl_poll_interval %}
+        "data_streams.lifecycle.poll_interval": "{{ dsl_poll_interval }}",
+        {% endif %}
+        {% if p_dsl_default_rollover %}
+        "cluster.lifecycle.default.rollover": "{{ dsl_default_rollover }}",
+        {% endif %}
         "cluster.max_shards_per_node":500000,
         "cluster.routing.allocation.node_concurrent_recoveries":200,
         "cluster.routing.allocation.node_initial_primaries_recoveries":100

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -41,6 +41,8 @@
 {% set p_restore_data_streams = (restore_data_streams | default("logs-*")) %}
 {% set p_snapshot_metadata = (snapshot_metadata | default({}))%}
 {% set p_snapshot_rename_suffix = (snapshot_rename_suffix | default("") ) %}
+{% set p_dsl_poll_interval = (dsl_poll_interval | default(false) ) %}
+{% set p_dsl_default_rollover = (dsl_default_rollover | default(false) ) %}
 
 {% set p_worker_threads_enabled = (worker_threads_enabled | default(true))  %}
 


### PR DESCRIPTION
I'm working on adding a "many-data streams" benchmark that assesses the stability of the cluster when there are a lot of data streams that are being managed by DSL. Since the `many-shards-quantitative` benchmark already allows you to do this (by specifying `lifecycle:dlm`), I'm just going to reuse that one. I only need to configure a couple of DSL cluster settings, which I've made possible in this PR.