### PR TITLE
Add autoscale-v2 challenge to NYC Taxis track

### DIFF
--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -84,7 +84,7 @@ This challenge is intended for serverless index tier autoscaler testing. It cons
 Note: `include_target_throughput` parameter is ignored in this challenge.
 
 * `as_clients` (default: []): An array with the number of indexing clients to be used in each step.
-* `as_time_periods` (default: []): An array with time period of every step. Time period is divided in halves. The first half is configured as warm-up.
+* `as_time_periods` (default: []): An array with time period, in seconds, of every step. Time period is divided in halves. The first half is configured as warm-up.
 * `as_target_throughputs` (default: []): An array with target throughput of each step, expressed in requests/s. Please use `bulk_size` parameter to translate this into docs/s. Target throughput is not configured if the values specified in this array are negative.
 
 ### License

--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -78,6 +78,15 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `include_force_merge` (default: true for non-serverless clusters, false for serverless clusters): Whether to include force merge operation.
 * `include_target_throughput` (default: true for non-serverless clusters, false for serverless clusters): Whether to apply target throughput.
 
+### Parameters specific to autoscale-v2 challenge
+
+This challenge is intended for serverless index tier autoscaler testing. It consists of configurable number of steps provided with array parameters.
+Note: `include_target_throughput` parameter is ignored in this challenge.
+
+* `as_clients` (default: []): An array with the number of indexing clients to be used in each step.
+* `as_time_periods` (default: []): An array with time period of every step. Time period is divided in halves. The first half is configured as warm-up.
+* `as_target_throughputs` (default: []): An array with target throughput of each step, expressed in requests/s. Please use `bulk_size` parameter to translate this into docs/s. Target throughput is not configured if the values specified in this array are negative.
+
 ### License
 
 According to the [Open Data Law](https://opendata.cityofnewyork.us/open-data-law/) this data is available as public domain.

--- a/nyc_taxis/README.md
+++ b/nyc_taxis/README.md
@@ -83,9 +83,10 @@ This track allows to overwrite the following parameters using `--track-params`:
 This challenge is intended for serverless index tier autoscaler testing. It consists of configurable number of steps provided with array parameters.
 Note: `include_target_throughput` parameter is ignored in this challenge.
 
-* `as_clients` (default: []): An array with the number of indexing clients to be used in each step.
-* `as_time_periods` (default: []): An array with time period, in seconds, of every step. Time period is divided in halves. The first half is configured as warm-up.
-* `as_target_throughputs` (default: []): An array with target throughput of each step, expressed in requests/s. Please use `bulk_size` parameter to translate this into docs/s. Target throughput is not configured if the values specified in this array are negative.
+* `as_clients` (default: [8,16,32]): An array with the number of indexing clients to be used in each step.
+* `as_warmup_time_periods` (default: [300,300,300]): An array with warm-up time period, in seconds, of every step.
+* `as_time_periods` (default: [300,300,300]): An array with time period, in seconds, of every step.
+* `as_target_throughputs` (default: [2,4,8]): An array with target throughput of each step, expressed in requests/s. Please use `bulk_size` parameter to translate this into docs/s. Target throughput is not configured if the values specified in this array are negative.
 
 ### License
 

--- a/nyc_taxis/challenges/common/autoscale-v2-schedule.json
+++ b/nyc_taxis/challenges/common/autoscale-v2-schedule.json
@@ -27,9 +27,10 @@
     "retry-until-success": true
   }
 }
-{%- set p_as_clients = (as_clients | default([]))%}
-{%- set p_as_time_periods = (as_time_periods | default([]))%}
-{%- set p_as_target_throughputs = (as_target_throughputs | default([]))%}
+{%- set p_as_clients = (as_clients | default([8,16,32]))%}
+{%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([300,300,300]))%}
+{%- set p_as_time_periods = (as_time_periods | default([300,300,300]))%}
+{%- set p_as_target_throughputs = (as_target_throughputs | default([2,4,8]))%}
 {%- set p_bulk_size = (bulk_size | default(5000))%}
 {%- for i in range(as_clients|length) %},
   {%- if p_as_target_throughputs[i] < 0 %}
@@ -42,8 +43,8 @@
     "bulk-size": {{p_bulk_size}},
     "looped": true
   },
-  "warmup-time-period": {{(p_as_time_periods[i] / 2)|int}},
-  "time-period": {{(p_as_time_periods[i] / 2)|int}}
+  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+  "time-period": {{p_as_time_periods[i]}}
 }
   {%- else %}
 {
@@ -55,8 +56,8 @@
     "bulk-size": {{p_bulk_size}},
     "looped": true
   },
-  "warmup-time-period": {{(p_as_time_periods[i] / 2)|int}},
-  "time-period": {{(p_as_time_periods[i] / 2)|int}},
+  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+  "time-period": {{p_as_time_periods[i]}},
   "target-throughput": {{p_as_target_throughputs[i]}}
 }
   {%- endif %}

--- a/nyc_taxis/challenges/common/autoscale-v2-schedule.json
+++ b/nyc_taxis/challenges/common/autoscale-v2-schedule.json
@@ -1,0 +1,63 @@
+{
+  "name": "delete-index",
+  "operation": {
+    "operation-type": "delete-index"
+  }
+},
+{
+  "name": "create-index",
+  "operation": {
+    "operation-type": "create-index",
+    "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
+      {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      "index.store.type": "{{store_type | default('fs')}}",
+      {%- endif -%}{# non-serverless-index-settings-marker-end #}
+      "index.codec": "best_compression"
+    }{%- endif %}
+  }
+},
+{
+  "name": "check-cluster-health",
+  "operation": {
+    "operation-type": "cluster-health",
+    "index": "nyc_taxis",
+    "request-params": {
+      "wait_for_status": "{{cluster_health | default('green')}}"
+    },
+    "retry-until-success": true
+  }
+}
+{%- set p_as_clients = (as_clients | default([]))%}
+{%- set p_as_time_periods = (as_time_periods | default([]))%}
+{%- set p_as_target_throughputs = (as_target_throughputs | default([]))%}
+{%- set p_bulk_size = (bulk_size | default(5000))%}
+{%- for i in range(as_clients|length) %},
+  {%- if p_as_target_throughputs[i] < 0 %}
+{
+  "name": "bulk-{{loop.index}}-c{{p_as_clients[i]}}-b{{p_bulk_size}}",
+  "clients": {{p_as_clients[i]}},
+  "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+  "operation": {
+    "operation-type": "bulk",
+    "bulk-size": {{p_bulk_size}},
+    "looped": true
+  },
+  "warmup-time-period": {{(p_as_time_periods[i] / 2)|int}},
+  "time-period": {{(p_as_time_periods[i] / 2)|int}}
+}
+  {%- else %}
+{
+  "name": "bulk-{{loop.index}}-c{{p_as_clients[i]}}-b{{p_bulk_size}}-t{{p_as_target_throughputs[i]}}",
+  "clients": {{p_as_clients[i]}},
+  "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+  "operation": {
+    "operation-type": "bulk",
+    "bulk-size": {{p_bulk_size}},
+    "looped": true
+  },
+  "warmup-time-period": {{(p_as_time_periods[i] / 2)|int}},
+  "time-period": {{(p_as_time_periods[i] / 2)|int}},
+  "target-throughput": {{p_as_target_throughputs[i]}}
+}
+  {%- endif %}
+{%- endfor %}

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -1442,3 +1442,11 @@
         {{ rally.collect(parts="common/autoscale-schedule.json") }}
       ]
     }
+    {
+      "name": "autoscale-v2",
+      "description": "Bulk index with configurable steps",
+      "default": false,
+      "schedule": [
+        {{ rally.collect(parts="common/autoscale-v2-schedule.json") }}
+      ]
+    }

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -1441,7 +1441,7 @@
       "schedule": [
         {{ rally.collect(parts="common/autoscale-schedule.json") }}
       ]
-    }
+    },
     {
       "name": "autoscale-v2",
       "description": "Bulk index with configurable steps",


### PR DESCRIPTION
This adds a new version of `autoscale` challenge where each step is defined with an array, instead of a fixed formula. The new version of the challange allows to specify both clients and target throughput, or only clients.

The challenge relies on bulk `looped` mode introduced in https://github.com/elastic/rally/pull/1830.