### PR TITLE
Adjust elastic/logs update-custom-package-templates for serverless

### DIFF
--- a/elastic/logs/tasks/index-setup.json
+++ b/elastic/logs/tasks/index-setup.json
@@ -77,8 +77,10 @@
         "settings": {
           "index" : {
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+              {% if p_include_non_serverless_index_settings %}
             "number_of_replicas" : "{{ number_of_replicas | default('1')}}",
             "number_of_shards" : "{{ number_of_shards | default('1')}}"
+              {% endif %}
             {%- endif -%}{# non-serverless-index-settings-marker-end #}
           }
         },

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -20,6 +20,7 @@
 {% set p_query_warmup_time_period = (query_warmup_time_period | default(120)) %}
 {% set p_query_time_period = (query_time_period | default(900)) %}
 {% set p_query_request_params = (query_request_params | default({}))%}
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 {% set p_include_esql_queries = (include_esql_queries | default(build_flavor != "serverless")) %}
 
 {% set p_throttle_indexing = (throttle_indexing | default(false)) %}


### PR DESCRIPTION
Follow-up to https://github.com/elastic/rally-tracks/pull/563 which missed to update `update-custom-package-templates` task based on the presence and value of `include_non_serverless_index_settings` track parameter.

We have 2 overlapping mechanisms for specifying index settings in `elastic/logs`:
* static assets: specifically `track-custom-shared-settings.json` component template referenced in composable templates, introduced in https://github.com/elastic/rally-tracks/pull/504, it accompanies another `track-custom-mappings.json` component template,
* pre-existing assets: `update-custom-package-templates` task from `index-setup.json`, introduced in https://github.com/elastic/rally-tracks/pull/336, based on a custom runner which updates _all_ component templates ending with `@custom` in the cluster.

The initial idea in https://github.com/elastic/rally-tracks/pull/336 was to only trigger modification of pre-existing assets if specific track parameter is set, but ultimately an overlap scenario was chosen (see [this](https://github.com/elastic/rally-tracks/pull/336#issuecomment-1284522228) comment). The plan that was never implemented was to get rid of static assets in favor of the custom runner (see [this](https://github.com/elastic/rally-tracks/pull/336#issuecomment-1285712498) comment).

What I don't like about the custom runner approach is that it modifies _all_ component templates ending with `@custom` in the cluster ([src](https://github.com/elastic/rally-tracks/blob/2794e4c4c641c3e0096b08f1b084f2142d8672f3/elastic/shared/runners/update_custom_templates.py#L19)). What about benchmarks against live clusters? This should be an opt-in, not a default, right?

What I'm proposing in this PR is a logical extension to https://github.com/elastic/rally-tracks/pull/563 which maintains the status quo, but I'm open to extending the scope a bit, and making `update-custom-package-templates` optional and disabled by default. WDYT?