### PR TITLE
Add the ability to override track data source url

### DIFF
--- a/cohere_vector/README.md
+++ b/cohere_vector/README.md
@@ -41,6 +41,7 @@ The `queries.json` can be rebuilt using the `_tools/parse_queries.py`, this will
 
 This track accepts the following parameters with Rally 0.8.0+ using `--track-params`:
 
+ - base_url (default: `https://rally-tracks.elastic.co/cohere-miracl-en-corpus-22-12`): Specifies the bucket path from where to download the data set.
  - initial_indexing_bulk_indexing_clients (default: 5)
  - initial_indexing_ingest_percentage (default: 100)
  - initial_indexing_bulk_size (default: 500)

--- a/cohere_vector/track.json
+++ b/cohere_vector/track.json
@@ -1,5 +1,5 @@
 {% import "rally.helpers" as rally with context %}
-
+{% set _base_url = (base_url | default("https://rally-tracks.elastic.co/cohere-miracl-en-corpus-22-12")) %}
 {
   "version": 2,
   "description": "Benchmark for vector search with Cohere Wikipedia data",
@@ -12,7 +12,7 @@
   "corpora": [
     {
       "name": "cohere-initial-indexing",
-      "base-url": "https://rally-tracks.elastic.co/cohere-miracl-en-corpus-22-12",
+      "base-url": "{{_base_url}}",
       "documents": [
         {
           "source-file": "cohere-documents-01.json.bz2",

--- a/wikipedia/README.md
+++ b/wikipedia/README.md
@@ -45,6 +45,8 @@ python3 _tools/parse_clicks.py --year 2023 --month 6 --lang en > queries.csv
 ### Parameters
 
 This track accepts the following parameters with Rally 0.8.0+ using `--track-params`:
+- General settings:
+  - `base_url` (default: `https://rally-tracks.elastic.co/wikipedia`): Specifies the bucket path from where to download the data set.
 - Index settings:
   - `number_of_replicas` (default: `0`)
   - `number_of_shards` (default: `1`)

--- a/wikipedia/track.json
+++ b/wikipedia/track.json
@@ -1,4 +1,5 @@
 {% import "rally.helpers" as rally with context %}
+{% set _base_url = (base_url | default( "https://rally-tracks.elastic.co/wikipedia")) %}
 {
   "version": 2,
   "description": "Benchmark for search with Wikipedia data",
@@ -12,7 +13,7 @@
     {
       "name": "wikipedia",
       "includes-action-and-meta-data": true,
-      "base-url": "https://rally-tracks.elastic.co/wikipedia",
+      "base-url": "{{_base_url}}",
       "documents": [
         {
           "source-file": "pages.json.bz2",


### PR DESCRIPTION
Both of these tracks (and probably others as well), have very large corpora, which takes a lot of time to download if downloading cross region. To enable to use a local mirror, I have added an option to allow us to easily override the location via a track parameter.