### PR TITLE
Normalize msmarco-v2-vector queries and switch to dot-product

### DIFF
--- a/msmarco-v2-vector/_tools/parse_documents.py
+++ b/msmarco-v2-vector/_tools/parse_documents.py
@@ -1,8 +1,6 @@
 import json
 import sys
 
-import numpy
-import vg
 from datasets import DownloadMode, load_dataset
 
 DATASET_NAME: str = f"Cohere/msmarco-v2-embed-english-v3"
@@ -49,10 +47,9 @@ def output_documents(docs_file, start_index, end_index):
 
     progress_bar(doc_count, dataset_size)
     for doc in docs:
-        normalized_vector = vg.normalize(numpy.array(doc["emb"])).tolist()
         docs_file.write(
             json.dumps(
-                {"docid": doc["_id"], "title": doc["title"], "text": doc["text"], "emb": normalized_vector},
+                {"docid": doc["_id"], "title": doc["title"], "text": doc["text"], "emb": doc["emb"]},
                 ensure_ascii=True,
             )
         )

--- a/msmarco-v2-vector/_tools/parse_documents.py
+++ b/msmarco-v2-vector/_tools/parse_documents.py
@@ -1,6 +1,8 @@
 import json
 import sys
 
+import numpy
+import vg
 from datasets import DownloadMode, load_dataset
 
 DATASET_NAME: str = f"Cohere/msmarco-v2-embed-english-v3"
@@ -47,9 +49,10 @@ def output_documents(docs_file, start_index, end_index):
 
     progress_bar(doc_count, dataset_size)
     for doc in docs:
+        normalized_vector = vg.normalize(numpy.array(doc["emb"])).tolist()
         docs_file.write(
             json.dumps(
-                {"docid": doc["_id"], "title": doc["title"], "text": doc["text"], "emb": doc["emb"]},
+                {"docid": doc["_id"], "title": doc["title"], "text": doc["text"], "emb": normalized_vector},
                 ensure_ascii=True,
             )
         )

--- a/msmarco-v2-vector/_tools/parse_queries.py
+++ b/msmarco-v2-vector/_tools/parse_queries.py
@@ -3,6 +3,8 @@ import json
 from os import environ
 
 import ir_datasets
+import numpy
+import vg
 from cohere import AsyncClient
 
 DATASET_NAME: str = "msmarco-passage-v2/train"
@@ -12,7 +14,7 @@ MAX_DOCS = 12_000
 
 async def retrieve_embed_for_query(co, text):
     response = await co.embed(texts=[text], model="embed-english-v3.0", input_type="search_query")
-    return response.embeddings[0]
+    return vg.normalize(numpy.array(response.embeddings[0])).tolist()
 
 
 async def output_queries(queries_file):

--- a/msmarco-v2-vector/_tools/requirements.txt
+++ b/msmarco-v2-vector/_tools/requirements.txt
@@ -1,3 +1,4 @@
 cohere
 datasets
 ir-datasets
+vg

--- a/msmarco-v2-vector/index-vectors-only-mapping.json
+++ b/msmarco-v2-vector/index-vectors-only-mapping.json
@@ -19,7 +19,7 @@
         "element_type": "float",
         "dims": 1024,
         "index": true,
-        "similarity": "max_inner_product",
+        "similarity": "dot_product",
         "index_options": {
           "type": {{ vector_index_type | default("int8_hnsw") | tojson }}
         }

--- a/msmarco-v2-vector/index-vectors-with-text-mapping.json
+++ b/msmarco-v2-vector/index-vectors-with-text-mapping.json
@@ -24,7 +24,7 @@
         "element_type": "float",
         "dims": 1024,
         "index": true,
-        "similarity": "max_inner_product",
+        "similarity": "dot_product",
         "index_options": {
           "type": {{ vector_index_type | default("int8_hnsw") |tojson }}
         }

--- a/msmarco-v2-vector/track.json
+++ b/msmarco-v2-vector/track.json
@@ -17,278 +17,278 @@
         {
           "source-file": "cohere-documents-01.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9021928056,
-          "uncompressed-bytes": 62426792517
+          "compressed-bytes": 24091471872,
+          "uncompressed-bytes": 69370756479
         },
         {
           "source-file": "cohere-documents-02.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9023617247,
-          "uncompressed-bytes": 62431388180
+          "compressed-bytes": 23684055040,
+          "uncompressed-bytes": 69372610608
         },
         {
           "source-file": "cohere-documents-03.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9014397783,
-          "uncompressed-bytes": 62415887338
+          "compressed-bytes": 23281082368,
+          "uncompressed-bytes": 69357935898
         },
         {
           "source-file": "cohere-documents-04.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9013049047,
-          "uncompressed-bytes": 62443828815
+          "compressed-bytes": 23697383424,
+          "uncompressed-bytes": 69387568508
         },
         {
           "source-file": "cohere-documents-05.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9016167931,
-          "uncompressed-bytes": 62423572615
+          "compressed-bytes": 23197581312,
+          "uncompressed-bytes": 69365547764
         },
         {
           "source-file": "cohere-documents-06.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9009486262,
-          "uncompressed-bytes": 62435005146
+          "compressed-bytes": 23240339456,
+          "uncompressed-bytes": 69376763339
         },
         {
           "source-file": "cohere-documents-07.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9013361731,
-          "uncompressed-bytes": 62429316906
+          "compressed-bytes": 23336865792,
+          "uncompressed-bytes": 69373769167
         },
         {
           "source-file": "cohere-documents-08.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9012875082,
-          "uncompressed-bytes": 62454822138
+          "compressed-bytes": 24184270848,
+          "uncompressed-bytes": 69394717950
         },
         {
           "source-file": "cohere-documents-09.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9013585508,
-          "uncompressed-bytes": 62445678372
+          "compressed-bytes": 23995482112,
+          "uncompressed-bytes": 69390811579
         },
         {
           "source-file": "cohere-documents-10.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9015888230,
-          "uncompressed-bytes": 62452496345
+          "compressed-bytes": 24223752192,
+          "uncompressed-bytes": 69393991300
         },
         {
           "source-file": "cohere-documents-11.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9005477048,
-          "uncompressed-bytes": 62437674522
+          "compressed-bytes": 23422566400,
+          "uncompressed-bytes": 69382658750
         },
         {
           "source-file": "cohere-documents-12.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9007929649,
-          "uncompressed-bytes": 62421760980
+          "compressed-bytes": 23992938496,
+          "uncompressed-bytes": 69368235356
         },
         {
           "source-file": "cohere-documents-13.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9022865470,
-          "uncompressed-bytes": 62335983748
+          "compressed-bytes": 23385133056,
+          "uncompressed-bytes": 69289448579
         },
         {
           "source-file": "cohere-documents-14.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9021767458,
-          "uncompressed-bytes": 62339360404
+          "compressed-bytes": 23105699840,
+          "uncompressed-bytes": 69293416266
         },
         {
           "source-file": "cohere-documents-15.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9017052224,
-          "uncompressed-bytes": 62378338804
+          "compressed-bytes": 24220241920,
+          "uncompressed-bytes": 69328439091
         },
         {
           "source-file": "cohere-documents-16.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9011163972,
-          "uncompressed-bytes": 62438697579
+          "compressed-bytes": 23662002176,
+          "uncompressed-bytes": 69386227011
         },
         {
           "source-file": "cohere-documents-17.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9000705935,
-          "uncompressed-bytes": 62440814620
+          "compressed-bytes": 23656529920,
+          "uncompressed-bytes": 69382208085
         },
         {
           "source-file": "cohere-documents-18.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9014544145,
-          "uncompressed-bytes": 62451264085
+          "compressed-bytes": 24168706048,
+          "uncompressed-bytes": 69394344603
         },
         {
           "source-file": "cohere-documents-19.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9009433164,
-          "uncompressed-bytes": 62445111613
+          "compressed-bytes": 23345139712,
+          "uncompressed-bytes": 69388976244
         },
         {
           "source-file": "cohere-documents-20.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9015213691,
-          "uncompressed-bytes": 62450476592
+          "compressed-bytes": 23306567680,
+          "uncompressed-bytes": 69392178441
         },
         {
           "source-file": "cohere-documents-21.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9006779852,
-          "uncompressed-bytes": 62427430956
+          "compressed-bytes": 23851991040,
+          "uncompressed-bytes": 69370862933
         },
         {
           "source-file": "cohere-documents-22.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9017053077,
-          "uncompressed-bytes": 62438658995
+          "compressed-bytes": 23261933568,
+          "uncompressed-bytes": 69383010026
         },
         {
           "source-file": "cohere-documents-23.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9001426853,
-          "uncompressed-bytes": 62447092753
+          "compressed-bytes": 24116342784,
+          "uncompressed-bytes": 69390110271
         },
         {
           "source-file": "cohere-documents-24.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9012051376,
-          "uncompressed-bytes": 62437229959
+          "compressed-bytes": 23184752640,
+          "uncompressed-bytes": 69383061433
         },
         {
           "source-file": "cohere-documents-25.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9003111786,
-          "uncompressed-bytes": 62441915901
+          "compressed-bytes": 23517933568,
+          "uncompressed-bytes": 69386599821
         },
         {
           "source-file": "cohere-documents-26.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 8999751211,
-          "uncompressed-bytes": 62438222993
+          "compressed-bytes": 24073601024,
+          "uncompressed-bytes": 69386821759
         },
         {
           "source-file": "cohere-documents-27.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9013223524,
-          "uncompressed-bytes": 62436418889
+          "compressed-bytes": 23725772800,
+          "uncompressed-bytes": 69381473943
         },
         {
           "source-file": "cohere-documents-28.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9003075996,
-          "uncompressed-bytes": 62430332379
+          "compressed-bytes": 24023793664,
+          "uncompressed-bytes": 69375548612
         },
         {
           "source-file": "cohere-documents-29.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 8998437968,
-          "uncompressed-bytes": 62431002502
+          "compressed-bytes": 23182348288,
+          "uncompressed-bytes": 69375103260
         },
         {
           "source-file": "cohere-documents-30.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 8994402609,
-          "uncompressed-bytes": 62441853692
+          "compressed-bytes": 23308730368,
+          "uncompressed-bytes": 69383630261
         },
         {
           "source-file": "cohere-documents-31.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9000482851,
-          "uncompressed-bytes": 62440281456
+          "compressed-bytes": 23352705024,
+          "uncompressed-bytes": 69381562222
         },
         {
           "source-file": "cohere-documents-32.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9011070190,
-          "uncompressed-bytes": 62432757168
+          "compressed-bytes": 23595974656,
+          "uncompressed-bytes": 69381166684
         },
         {
           "source-file": "cohere-documents-33.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9001407547,
-          "uncompressed-bytes": 62434564510
+          "compressed-bytes": 23204438016,
+          "uncompressed-bytes": 69376424253
         },
         {
           "source-file": "cohere-documents-34.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9002332451,
-          "uncompressed-bytes": 62429883776
+          "compressed-bytes": 24084611072,
+          "uncompressed-bytes": 69376031578
         },
         {
           "source-file": "cohere-documents-35.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9004398884,
-          "uncompressed-bytes": 62438761319
+          "compressed-bytes": 24142282752,
+          "uncompressed-bytes": 69383349470
         },
         {
           "source-file": "cohere-documents-36.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 8993589209,
-          "uncompressed-bytes": 62431216586
+          "compressed-bytes": 23719182336,
+          "uncompressed-bytes": 69371848380
         },
         {
           "source-file": "cohere-documents-37.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9010952003,
-          "uncompressed-bytes": 62442273308
+          "compressed-bytes": 23709847552,
+          "uncompressed-bytes": 69385430084
         },
         {
           "source-file": "cohere-documents-38.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9006306267,
-          "uncompressed-bytes": 62439634948
+          "compressed-bytes": 23427416064,
+          "uncompressed-bytes": 69385863364
         },
         {
           "source-file": "cohere-documents-39.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9015711986,
-          "uncompressed-bytes": 62448009886
+          "compressed-bytes": 23215988736,
+          "uncompressed-bytes": 69389450168
         },
         {
           "source-file": "cohere-documents-40.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9011654026,
-          "uncompressed-bytes": 62444075017
+          "compressed-bytes": 23419813888,
+          "uncompressed-bytes": 69387079658
         },
         {
           "source-file": "cohere-documents-41.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9011668480,
-          "uncompressed-bytes": 62447733461
+          "compressed-bytes": 23438286848,
+          "uncompressed-bytes": 69389464744
         },
         {
           "source-file": "cohere-documents-42.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9006338208,
-          "uncompressed-bytes": 62438457190
+          "compressed-bytes": 23439466496,
+          "uncompressed-bytes": 69379016493
         },
         {
           "source-file": "cohere-documents-43.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9025393800,
-          "uncompressed-bytes": 62435343952
+          "compressed-bytes": 23588528128,
+          "uncompressed-bytes": 69380110843
         },
         {
           "source-file": "cohere-documents-44.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 8992417787,
-          "uncompressed-bytes": 62435908305
+          "compressed-bytes": 23675887616,
+          "uncompressed-bytes": 69381438130
         },
         {
           "source-file": "cohere-documents-45.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9013275457,
-          "uncompressed-bytes": 62490442945
+          "compressed-bytes": 23299817472,
+          "uncompressed-bytes": 69427888107
         },
         {
           "source-file": "cohere-documents-46.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 8987243245,
-          "uncompressed-bytes": 62450710315
+          "compressed-bytes": 23402364928,
+          "uncompressed-bytes": 69398460297
         }
       ]
     },
@@ -299,8 +299,8 @@
         {
           "source-file": "cohere-documents-47.json.bz2",
           "document-count": 364198,
-          "compressed-bytes": 1092912890,
-          "uncompressed-bytes": 7578704343
+          "compressed-bytes": 2952946287,
+          "uncompressed-bytes": 8421544547
         }
       ]
     }


### PR DESCRIPTION
This:

- Normalizes vectors for queries that come back from the Cohere API
- Switches to using `dot-product` for vector similarity

After an investigation I found the vectors from the msmarco-v2 dataset cohere published **are** normalised, but the queries from their API, despite their API docs saying to the contrary, are not, and another ingestion issue made it look like it was the dataset and not the queries in CI.

Dataset file sizes changed in GCP, and so in `track.json`, due to playing around with normalisation, but is the same.