### PR TITLE
[Wikipedia] Ensure that indexation always runs during the parallel ingest/search operation

### DIFF
--- a/wikipedia/operations/default.json
+++ b/wikipedia/operations/default.json
@@ -26,7 +26,8 @@
 {
   "name": "parallel-documents-indexing",
   "operation-type": "bulk",
-  "bulk-size": {{ parallel_indexing_bulk_size | default(250) }}
+  "bulk-size": {{ parallel_indexing_bulk_size | default(250) }},
+  "looped": true
 },
 {
   "name": "refresh-after-index",


### PR DESCRIPTION
Add `looped` option in the parallel-documents-indexing-bulk operation.