### PR TITLE
msmarco-v2-vector: fix bzip2 data corruption and vector normalization

### DIFF
--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -23,7 +23,7 @@ done
 
 # Zip each document file for uploading
 $ for file in cohere-documents-*; do
-  pv $file | bzip2 -k >> $file.bz2
+  bzip2 -k $file
 done
 $ ls -1 cohere-documents-* > files.txt
 ```

--- a/msmarco-v2-vector/_tools/parse_documents.py
+++ b/msmarco-v2-vector/_tools/parse_documents.py
@@ -1,6 +1,8 @@
 import json
 import sys
 
+import numpy
+import vg
 from datasets import DownloadMode, load_dataset
 
 DATASET_NAME: str = f"Cohere/msmarco-v2-embed-english-v3"
@@ -47,9 +49,10 @@ def output_documents(docs_file, start_index, end_index):
 
     progress_bar(doc_count, dataset_size)
     for doc in docs:
+        normalized_embed = vg.normalize(numpy.array(doc["emb"])).tolist()
         docs_file.write(
             json.dumps(
-                {"docid": doc["_id"], "title": doc["title"], "text": doc["text"], "emb": doc["emb"]},
+                {"docid": doc["_id"], "title": doc["title"], "text": doc["text"], "emb": normalized_embed},
                 ensure_ascii=True,
             )
         )

--- a/msmarco-v2-vector/track.json
+++ b/msmarco-v2-vector/track.json
@@ -17,278 +17,278 @@
         {
           "source-file": "cohere-documents-01.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 24091471872,
-          "uncompressed-bytes": 69370756479
+          "compressed-bytes": 10167562872,
+          "uncompressed-bytes": 62426792517
         },
         {
           "source-file": "cohere-documents-02.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23684055040,
-          "uncompressed-bytes": 69372610608
+          "compressed-bytes": 9023617247,
+          "uncompressed-bytes": 62431388180
         },
         {
           "source-file": "cohere-documents-03.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23281082368,
-          "uncompressed-bytes": 69357935898
+          "compressed-bytes": 9014397783,
+          "uncompressed-bytes": 62415887338
         },
         {
           "source-file": "cohere-documents-04.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23697383424,
-          "uncompressed-bytes": 69387568508
+          "compressed-bytes": 9013049047,
+          "uncompressed-bytes": 62443828815
         },
         {
           "source-file": "cohere-documents-05.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23197581312,
-          "uncompressed-bytes": 69365547764
+          "compressed-bytes": 9016167931,
+          "uncompressed-bytes": 62423572615
         },
         {
           "source-file": "cohere-documents-06.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23240339456,
-          "uncompressed-bytes": 69376763339
+          "compressed-bytes": 9009486262,
+          "uncompressed-bytes": 62435005146
         },
         {
           "source-file": "cohere-documents-07.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23336865792,
-          "uncompressed-bytes": 69373769167
+          "compressed-bytes": 9013361731,
+          "uncompressed-bytes": 62429316906
         },
         {
           "source-file": "cohere-documents-08.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 24184270848,
-          "uncompressed-bytes": 69394717950
+          "compressed-bytes": 9012875082,
+          "uncompressed-bytes": 62454822138
         },
         {
           "source-file": "cohere-documents-09.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23995482112,
-          "uncompressed-bytes": 69390811579
+          "compressed-bytes": 9013585508,
+          "uncompressed-bytes": 62445678372
         },
         {
           "source-file": "cohere-documents-10.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 24223752192,
-          "uncompressed-bytes": 69393991300
+          "compressed-bytes": 9015888230,
+          "uncompressed-bytes": 62452496345
         },
         {
           "source-file": "cohere-documents-11.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23422566400,
-          "uncompressed-bytes": 69382658750
+          "compressed-bytes": 9005477048,
+          "uncompressed-bytes": 62437674522
         },
         {
           "source-file": "cohere-documents-12.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23992938496,
-          "uncompressed-bytes": 69368235356
+          "compressed-bytes": 9007929649,
+          "uncompressed-bytes": 62421760980
         },
         {
           "source-file": "cohere-documents-13.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23385133056,
-          "uncompressed-bytes": 69289448579
+          "compressed-bytes": 9022865470,
+          "uncompressed-bytes": 62335983748
         },
         {
           "source-file": "cohere-documents-14.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23105699840,
-          "uncompressed-bytes": 69293416266
+          "compressed-bytes": 9021767458,
+          "uncompressed-bytes": 62339360404
         },
         {
           "source-file": "cohere-documents-15.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 24220241920,
-          "uncompressed-bytes": 69328439091
+          "compressed-bytes": 9017052224,
+          "uncompressed-bytes": 62378338804
         },
         {
           "source-file": "cohere-documents-16.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23662002176,
-          "uncompressed-bytes": 69386227011
+          "compressed-bytes": 9011163972,
+          "uncompressed-bytes": 62438697579
         },
         {
           "source-file": "cohere-documents-17.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23656529920,
-          "uncompressed-bytes": 69382208085
+          "compressed-bytes": 9000705935,
+          "uncompressed-bytes": 62440814620
         },
         {
           "source-file": "cohere-documents-18.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 24168706048,
-          "uncompressed-bytes": 69394344603
+          "compressed-bytes": 9014544145,
+          "uncompressed-bytes": 62451264085
         },
         {
           "source-file": "cohere-documents-19.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23345139712,
-          "uncompressed-bytes": 69388976244
+          "compressed-bytes": 9009433164,
+          "uncompressed-bytes": 62445111613
         },
         {
           "source-file": "cohere-documents-20.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23306567680,
-          "uncompressed-bytes": 69392178441
+          "compressed-bytes": 9015213691,
+          "uncompressed-bytes": 62450476592
         },
         {
           "source-file": "cohere-documents-21.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23851991040,
-          "uncompressed-bytes": 69370862933
+          "compressed-bytes": 9006779852,
+          "uncompressed-bytes": 62427430956
         },
         {
           "source-file": "cohere-documents-22.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23261933568,
-          "uncompressed-bytes": 69383010026
+          "compressed-bytes": 9017053077,
+          "uncompressed-bytes": 62438658995
         },
         {
           "source-file": "cohere-documents-23.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 24116342784,
-          "uncompressed-bytes": 69390110271
+          "compressed-bytes": 9001426853,
+          "uncompressed-bytes": 62447092753
         },
         {
           "source-file": "cohere-documents-24.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23184752640,
-          "uncompressed-bytes": 69383061433
+          "compressed-bytes": 9012051376,
+          "uncompressed-bytes": 62437229959
         },
         {
           "source-file": "cohere-documents-25.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23517933568,
-          "uncompressed-bytes": 69386599821
+          "compressed-bytes": 9003111786,
+          "uncompressed-bytes": 62441915901
         },
         {
           "source-file": "cohere-documents-26.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 24073601024,
-          "uncompressed-bytes": 69386821759
+          "compressed-bytes": 8999751211,
+          "uncompressed-bytes": 62438222993
         },
         {
           "source-file": "cohere-documents-27.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23725772800,
-          "uncompressed-bytes": 69381473943
+          "compressed-bytes": 9013223524,
+          "uncompressed-bytes": 62436418889
         },
         {
           "source-file": "cohere-documents-28.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 24023793664,
-          "uncompressed-bytes": 69375548612
+          "compressed-bytes": 9003075996,
+          "uncompressed-bytes": 62430332379
         },
         {
           "source-file": "cohere-documents-29.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23182348288,
-          "uncompressed-bytes": 69375103260
+          "compressed-bytes": 8998437968,
+          "uncompressed-bytes": 62431002502
         },
         {
           "source-file": "cohere-documents-30.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23308730368,
-          "uncompressed-bytes": 69383630261
+          "compressed-bytes": 12755649321,
+          "uncompressed-bytes": 62441853692
         },
         {
           "source-file": "cohere-documents-31.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23352705024,
-          "uncompressed-bytes": 69381562222
+          "compressed-bytes": 9005583332,
+          "uncompressed-bytes": 62440281456
         },
         {
           "source-file": "cohere-documents-32.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23595974656,
-          "uncompressed-bytes": 69381166684
+          "compressed-bytes": 9016105680,
+          "uncompressed-bytes": 62432757168
         },
         {
           "source-file": "cohere-documents-33.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23204438016,
-          "uncompressed-bytes": 69376424253
+          "compressed-bytes": 9006404963,
+          "uncompressed-bytes": 62434564510
         },
         {
           "source-file": "cohere-documents-34.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 24084611072,
-          "uncompressed-bytes": 69376031578
+          "compressed-bytes": 9007435117,
+          "uncompressed-bytes": 62429883776
         },
         {
           "source-file": "cohere-documents-35.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 24142282752,
-          "uncompressed-bytes": 69383349470
+          "compressed-bytes": 9009489026,
+          "uncompressed-bytes": 62438761319
         },
         {
           "source-file": "cohere-documents-36.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23719182336,
-          "uncompressed-bytes": 69371848380
+          "compressed-bytes": 8998524624,
+          "uncompressed-bytes": 62431216586
         },
         {
           "source-file": "cohere-documents-37.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23709847552,
-          "uncompressed-bytes": 69385430084
+          "compressed-bytes": 9015821136,
+          "uncompressed-bytes": 62442273308
         },
         {
           "source-file": "cohere-documents-38.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23427416064,
-          "uncompressed-bytes": 69385863364
+          "compressed-bytes": 9011439598,
+          "uncompressed-bytes": 62439634948
         },
         {
           "source-file": "cohere-documents-39.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23215988736,
-          "uncompressed-bytes": 69389450168
+          "compressed-bytes": 9020956341,
+          "uncompressed-bytes": 62448009886
         },
         {
           "source-file": "cohere-documents-40.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23419813888,
-          "uncompressed-bytes": 69387079658
+          "compressed-bytes": 9016767842,
+          "uncompressed-bytes": 62444075017
         },
         {
           "source-file": "cohere-documents-41.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23438286848,
-          "uncompressed-bytes": 69389464744
+          "compressed-bytes": 9016776148,
+          "uncompressed-bytes": 62447733461
         },
         {
           "source-file": "cohere-documents-42.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23439466496,
-          "uncompressed-bytes": 69379016493
+          "compressed-bytes": 9011341797,
+          "uncompressed-bytes": 62438457190
         },
         {
           "source-file": "cohere-documents-43.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23588528128,
-          "uncompressed-bytes": 69380110843
+          "compressed-bytes": 9030578850,
+          "uncompressed-bytes": 62435343952
         },
         {
           "source-file": "cohere-documents-44.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23675887616,
-          "uncompressed-bytes": 69381438130
+          "compressed-bytes": 8997470628,
+          "uncompressed-bytes": 62435908305
         },
         {
           "source-file": "cohere-documents-45.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23299817472,
-          "uncompressed-bytes": 69427888107
+          "compressed-bytes": 9018181611,
+          "uncompressed-bytes": 62490442945
         },
         {
           "source-file": "cohere-documents-46.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 23402364928,
-          "uncompressed-bytes": 69398460297
+          "compressed-bytes": 8992442578,
+          "uncompressed-bytes": 62450710315
         }
       ]
     },
@@ -299,8 +299,8 @@
         {
           "source-file": "cohere-documents-47.json.bz2",
           "document-count": 364198,
-          "compressed-bytes": 2952946287,
-          "uncompressed-bytes": 8421544547
+          "compressed-bytes": 1093528974,
+          "uncompressed-bytes": 7578704343
         }
       ]
     }

--- a/msmarco-v2-vector/track.json
+++ b/msmarco-v2-vector/track.json
@@ -17,278 +17,278 @@
         {
           "source-file": "cohere-documents-01.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 10167562872,
-          "uncompressed-bytes": 62426792517
+          "compressed-bytes": 24341521883,
+          "uncompressed-bytes": 69370756479
         },
         {
           "source-file": "cohere-documents-02.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9023617247,
-          "uncompressed-bytes": 62431388180
+          "compressed-bytes": 24344084315,
+          "uncompressed-bytes": 69372610608
         },
         {
           "source-file": "cohere-documents-03.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9014397783,
-          "uncompressed-bytes": 62415887338
+          "compressed-bytes": 24333676455,
+          "uncompressed-bytes": 69357935898
         },
         {
           "source-file": "cohere-documents-04.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9013049047,
-          "uncompressed-bytes": 62443828815
+          "compressed-bytes": 24327754482,
+          "uncompressed-bytes": 69387568508
         },
         {
           "source-file": "cohere-documents-05.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9016167931,
-          "uncompressed-bytes": 62423572615
+          "compressed-bytes": 24327151939,
+          "uncompressed-bytes": 69365547764
         },
         {
           "source-file": "cohere-documents-06.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9009486262,
-          "uncompressed-bytes": 62435005146
+          "compressed-bytes": 24304245317,
+          "uncompressed-bytes": 69376763339
         },
         {
           "source-file": "cohere-documents-07.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9013361731,
-          "uncompressed-bytes": 62429316906
+          "compressed-bytes": 24330276564,
+          "uncompressed-bytes": 69373769167
         },
         {
           "source-file": "cohere-documents-08.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9012875082,
-          "uncompressed-bytes": 62454822138
+          "compressed-bytes": 24327213399,
+          "uncompressed-bytes": 69394717950
         },
         {
           "source-file": "cohere-documents-09.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9013585508,
-          "uncompressed-bytes": 62445678372
+          "compressed-bytes": 24341383810,
+          "uncompressed-bytes": 69390811579
         },
         {
           "source-file": "cohere-documents-10.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9015888230,
-          "uncompressed-bytes": 62452496345
+          "compressed-bytes": 24340443500,
+          "uncompressed-bytes": 69393991300
         },
         {
           "source-file": "cohere-documents-11.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9005477048,
-          "uncompressed-bytes": 62437674522
+          "compressed-bytes": 24327211992,
+          "uncompressed-bytes": 69382658750
         },
         {
           "source-file": "cohere-documents-12.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9007929649,
-          "uncompressed-bytes": 62421760980
+          "compressed-bytes": 24330195327,
+          "uncompressed-bytes": 69368235356
         },
         {
           "source-file": "cohere-documents-13.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9022865470,
-          "uncompressed-bytes": 62335983748
+          "compressed-bytes": 24336397493,
+          "uncompressed-bytes": 69289448579
         },
         {
           "source-file": "cohere-documents-14.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9021767458,
-          "uncompressed-bytes": 62339360404
+          "compressed-bytes": 24334810222,
+          "uncompressed-bytes": 69293416266
         },
         {
           "source-file": "cohere-documents-15.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9017052224,
-          "uncompressed-bytes": 62378338804
+          "compressed-bytes": 24335644924,
+          "uncompressed-bytes": 69328439091
         },
         {
           "source-file": "cohere-documents-16.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9011163972,
-          "uncompressed-bytes": 62438697579
+          "compressed-bytes": 24337276221,
+          "uncompressed-bytes": 69386227011
         },
         {
           "source-file": "cohere-documents-17.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9000705935,
-          "uncompressed-bytes": 62440814620
+          "compressed-bytes": 24324025297,
+          "uncompressed-bytes": 69382208085
         },
         {
           "source-file": "cohere-documents-18.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9014544145,
-          "uncompressed-bytes": 62451264085
+          "compressed-bytes": 24336830800,
+          "uncompressed-bytes": 69394344603
         },
         {
           "source-file": "cohere-documents-19.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9009433164,
-          "uncompressed-bytes": 62445111613
+          "compressed-bytes": 24327568555,
+          "uncompressed-bytes": 69388976244
         },
         {
           "source-file": "cohere-documents-20.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9015213691,
-          "uncompressed-bytes": 62450476592
+          "compressed-bytes": 24338535758,
+          "uncompressed-bytes": 69392178441
         },
         {
           "source-file": "cohere-documents-21.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9006779852,
-          "uncompressed-bytes": 62427430956
+          "compressed-bytes": 24312787753,
+          "uncompressed-bytes": 69370862933
         },
         {
           "source-file": "cohere-documents-22.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9017053077,
-          "uncompressed-bytes": 62438658995
+          "compressed-bytes": 24342339495,
+          "uncompressed-bytes": 69383010026
         },
         {
           "source-file": "cohere-documents-23.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9001426853,
-          "uncompressed-bytes": 62447092753
+          "compressed-bytes": 24318209060,
+          "uncompressed-bytes": 69390110271
         },
         {
           "source-file": "cohere-documents-24.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9012051376,
-          "uncompressed-bytes": 62437229959
+          "compressed-bytes": 24335274356,
+          "uncompressed-bytes": 69383061433
         },
         {
           "source-file": "cohere-documents-25.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9003111786,
-          "uncompressed-bytes": 62441915901
+          "compressed-bytes": 24322730610,
+          "uncompressed-bytes": 69386599821
         },
         {
           "source-file": "cohere-documents-26.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 8999751211,
-          "uncompressed-bytes": 62438222993
+          "compressed-bytes": 24321890052,
+          "uncompressed-bytes": 69386821759
         },
         {
           "source-file": "cohere-documents-27.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9013223524,
-          "uncompressed-bytes": 62436418889
+          "compressed-bytes": 24335299432,
+          "uncompressed-bytes": 69381473943
         },
         {
           "source-file": "cohere-documents-28.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9003075996,
-          "uncompressed-bytes": 62430332379
+          "compressed-bytes": 24314611344,
+          "uncompressed-bytes": 69375548612
         },
         {
           "source-file": "cohere-documents-29.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 8998437968,
-          "uncompressed-bytes": 62431002502
+          "compressed-bytes": 24316232312,
+          "uncompressed-bytes": 69375103260
         },
         {
           "source-file": "cohere-documents-30.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 12755649321,
-          "uncompressed-bytes": 62441853692
+          "compressed-bytes": 24310982312,
+          "uncompressed-bytes": 69383630261
         },
         {
           "source-file": "cohere-documents-31.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9005583332,
-          "uncompressed-bytes": 62440281456
+          "compressed-bytes": 24315443808,
+          "uncompressed-bytes": 69381562222
         },
         {
           "source-file": "cohere-documents-32.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9016105680,
-          "uncompressed-bytes": 62432757168
+          "compressed-bytes": 24335809108,
+          "uncompressed-bytes": 69381166684
         },
         {
           "source-file": "cohere-documents-33.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9006404963,
-          "uncompressed-bytes": 62434564510
+          "compressed-bytes": 24318616482,
+          "uncompressed-bytes": 69376424253
         },
         {
           "source-file": "cohere-documents-34.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9007435117,
-          "uncompressed-bytes": 62429883776
+          "compressed-bytes": 24328419041,
+          "uncompressed-bytes": 69376031578
         },
         {
           "source-file": "cohere-documents-35.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9009489026,
-          "uncompressed-bytes": 62438761319
+          "compressed-bytes": 24325198811,
+          "uncompressed-bytes": 69383349470
         },
         {
           "source-file": "cohere-documents-36.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 8998524624,
-          "uncompressed-bytes": 62431216586
+          "compressed-bytes": 24279323957,
+          "uncompressed-bytes": 69371848380
         },
         {
           "source-file": "cohere-documents-37.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9015821136,
-          "uncompressed-bytes": 62442273308
+          "compressed-bytes": 24329789068,
+          "uncompressed-bytes": 69385430084
         },
         {
           "source-file": "cohere-documents-38.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9011439598,
-          "uncompressed-bytes": 62439634948
+          "compressed-bytes": 24326900089,
+          "uncompressed-bytes": 69385863364
         },
         {
           "source-file": "cohere-documents-39.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9020956341,
-          "uncompressed-bytes": 62448009886
+          "compressed-bytes": 24338474900,
+          "uncompressed-bytes": 69389450168
         },
         {
           "source-file": "cohere-documents-40.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9016767842,
-          "uncompressed-bytes": 62444075017
+          "compressed-bytes": 24333163417,
+          "uncompressed-bytes": 69387079658
         },
         {
           "source-file": "cohere-documents-41.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9016776148,
-          "uncompressed-bytes": 62447733461
+          "compressed-bytes": 24337194583,
+          "uncompressed-bytes": 69389464744
         },
         {
           "source-file": "cohere-documents-42.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9011341797,
-          "uncompressed-bytes": 62438457190
+          "compressed-bytes": 24328882204,
+          "uncompressed-bytes": 69379016493
         },
         {
           "source-file": "cohere-documents-43.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9030578850,
-          "uncompressed-bytes": 62435343952
+          "compressed-bytes": 24354244795,
+          "uncompressed-bytes": 69380110843
         },
         {
           "source-file": "cohere-documents-44.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 8997470628,
-          "uncompressed-bytes": 62435908305
+          "compressed-bytes": 24313512767,
+          "uncompressed-bytes": 69381438130
         },
         {
           "source-file": "cohere-documents-45.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 9018181611,
-          "uncompressed-bytes": 62490442945
+          "compressed-bytes": 24329665775,
+          "uncompressed-bytes": 69427888107
         },
         {
           "source-file": "cohere-documents-46.json.bz2",
           "document-count": 3000000,
-          "compressed-bytes": 8992442578,
-          "uncompressed-bytes": 62450710315
+          "compressed-bytes": 24312283331,
+          "uncompressed-bytes": 69398460297
         }
       ]
     },
@@ -299,8 +299,8 @@
         {
           "source-file": "cohere-documents-47.json.bz2",
           "document-count": 364198,
-          "compressed-bytes": 1093528974,
-          "uncompressed-bytes": 7578704343
+          "compressed-bytes": 2953583160,
+          "uncompressed-bytes": 8421544547
         }
       ]
     }


### PR DESCRIPTION
- Using `pv` with `bzip2` on extremely large dataset files is leading to corruption, so dataset regenerated just with straight `pbzip2` and instructions updated in readme.
- Dataset published by Cohere despite previous PR's confusion _definitely is not normalized_ so I've added normalization to the `parse_documents.py` script that generates the dataset.
- Compressed file sizes have changed to match uncorrupted bzip2 data in GCS, uncompressed has not as previous dataset run was done using nomalization in the script, when investigating previous issue.