### PR TITLE
Add a logging-indexing variation track for data stream autosharding

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -375,6 +375,22 @@ Indexes logs to the default (local) cluster, snapshots the resulting data stream
 
 Note that this challenge requires you to be able to successfully create a snapshot repository using the `snapshot_repo_name`, `snapshot_repo_type`, and `snapshot_repo_settings` track parameters.
 
+### Parameters specific to datastream-autosharding challenge
+
+This challenge is intended for serverless data streams auto sharding testing. It consists of configurable number of steps provided with array parameters.
+Note: `include_target_throughput` parameter is ignored in this challenge.
+
+* `as_clients` (default: [8,16,32]): An array with the number of indexing clients to be used in each step.
+* `as_warmup_time_periods` (default: [300,300,300]): An array with warm-up time period, in seconds, of every step.
+* `as_time_periods` (default: [300,300,300]): An array with time period, in seconds, of every step.
+* `as_target_throughputs` (default: [2,4,8]): An array with target throughput of each step, expressed in requests/s. Please use `bulk_size` parameter to translate this into docs/s. Target throughput is not configured if the values specified in this array are negative.
+* `ds_autosharding_excludes` (default: []) a list of data stream name patterns to exclude from auto sharding.
+* `ds_autosharding_increase_cooldown` (default: "270s") A time value indicating the amount of time to cooldown before increasing the number of shards.
+* `ds_autosharding_decrease_cooldown` (default: "3d") A time value indicating the amount of time to cooldown before decreasing the number of shards.
+* `ds_autosharding_min_threads` (default: 2) The minimum number of write threads in the auto *scaling* function.
+* `ds_autosharding_max_threads` (default: 32) The maximum number of write threads in the auto *scaling* function.
+* `dsl_poll_interval` (default: "5m") A time value indicating the interval data stream lifecycle runs at. This is relevant in the context of auto sharding as data stream lifecycle periodically triggers the rollover operations that will recalcualte and implement the (auto)sharding scheme.
+
 ## Changing the Datasets
 
 The generated dataset is influenced by 2 key configurations:

--- a/elastic/logs/challenges/datastream-autosharding.json
+++ b/elastic/logs/challenges/datastream-autosharding.json
@@ -1,0 +1,75 @@
+{% import "rally.helpers" as rally %}
+{
+  "name": "datastream-autosharding",
+  "description": "Indexes logs un-throttled, for a specified time period and volume per day",
+  "schedule": [
+    {% include "tasks/index-setup.json" %},
+    {% set p_ds_autosharding_excludes = (ds_autosharding_excludes | default([]) ) %}
+    {% set p_ds_autosharding_increase_cooldown = (ds_autosharding_increase_cooldown | default("270s") ) %}
+    {% set p_ds_autosharding_decrease_cooldown = (ds_autosharding_decrease_cooldown | default("3d") ) %}
+    {% set p_ds_autosharding_min_threads = (ds_autosharding_min_threads | default(2) ) %}
+    {% set p_ds_autosharding_max_threads = (ds_autosharding_max_threads | default(32) ) %}
+    {
+      "name":"update-autosharding-settings",
+      "tags": ["setup"],
+      "operation": {
+        "operation-type": "put-settings",
+        "body": {
+          "persistent": {
+           {% if p_dsl_poll_interval %}
+             "data_streams.lifecycle.poll_interval": "{{ dsl_poll_interval }}",
+           {% endif %}
+           "data_streams.auto_sharding.excludes": "{{ ds_autosharding_excludes }}", 
+            "data_streams.auto_sharding.increase_shards.cooldown": "{{ ds_autosharding_increase_cooldown }}",
+            "data_streams.auto_sharding.decrease_shards.cooldown": "{{ ds_autosharding_decrease_cooldown }}",
+	    "cluster.auto_sharding.min_write_threads": "{{ ds_autosharding_min_threads }}",
+	    "cluster.auto_sharding.max_write_threads": "{{ ds_autosharding_max_threads }}"
+          }
+        }
+      }
+    }
+    {%- set p_as_clients = (as_clients | default([8,16,32]))%}
+    {%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([300,300,300]))%}
+    {%- set p_as_time_periods = (as_time_periods | default([300,300,300]))%}
+    {%- set p_as_target_throughputs = (as_target_throughputs | default([2,4,8]))%}
+    {%- set p_bulk_size = (bulk_size | default(5000))%}
+    {%- for i in range(as_clients|length) %},
+      {%- if p_as_target_throughputs[i] < 0 %}
+      {
+        "name": "bulk-{{loop.index}}-c{{p_as_clients[i]}}-b{{p_bulk_size}}",
+        "clients": {{p_as_clients[i]}},
+        "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+        "operation": {
+          "operation-type": "raw-bulk",
+          "param-source": "processed-source",
+          "time-format": "milliseconds",
+          "profile": "fixed_interval",
+          "bulk-size": {{ p_bulk_size }},
+          "detailed-results": true,
+          "looped": true
+        },
+        "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+        "time-period": {{p_as_time_periods[i]}}
+      }
+      {%- else %}
+      {
+        "name": "bulk-{{loop.index}}-c{{p_as_clients[i]}}-b{{p_bulk_size}}-t{{p_as_target_throughputs[i]}}",
+        "clients": {{p_as_clients[i]}},
+        "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+        "operation": {
+          "operation-type": "raw-bulk",
+          "param-source": "processed-source",
+          "time-format": "milliseconds",
+          "profile": "fixed_interval",
+          "bulk-size": {{ p_bulk_size }},
+          "detailed-results": true,
+          "looped": true
+        },
+        "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+        "time-period": {{p_as_time_periods[i]}},
+        "target-throughput": {{p_as_target_throughputs[i]}}
+      }
+      {%- endif %}
+    {%- endfor %}
+  ]
+}


### PR DESCRIPTION
This takes some inspiration from the autoscale track - i.e. we'll want to run it in several steps, increasing the load for a few steps and decreasing it for the last stage and check that the number of shards increases and decreases accordingly (we'll also want to modify the cooldown periods, especially the one for decreasing the number of shards which is very large by default i.e. `3d`)