### PR TITLE
Update default value for auto sharding excludes

### DIFF
--- a/elastic/logs/challenges/datastream-autosharding.json
+++ b/elastic/logs/challenges/datastream-autosharding.json
@@ -19,7 +19,7 @@
            {% if p_dsl_poll_interval %}
              "data_streams.lifecycle.poll_interval": "{{ dsl_poll_interval }}",
            {% endif %}
-           "data_streams.auto_sharding.excludes": "{{ ds_autosharding_excludes }}", 
+           "data_streams.auto_sharding.excludes": "{{ ds_autosharding_excludes | list }}", 
             "data_streams.auto_sharding.increase_shards.cooldown": "{{ ds_autosharding_increase_cooldown }}",
             "data_streams.auto_sharding.decrease_shards.cooldown": "{{ ds_autosharding_decrease_cooldown }}",
 	    "cluster.auto_sharding.min_write_threads": "{{ ds_autosharding_min_threads }}",


### PR DESCRIPTION
This updates the default for the auto sharding excludes
cluster setting to correctly default to emtpy array `[]` when
not specified (as opposed to `""`)