### PR TITLE
Allow the auto sharding track to change dsl rollover

### DIFF
--- a/elastic/logs/challenges/datastream-autosharding.json
+++ b/elastic/logs/challenges/datastream-autosharding.json
@@ -19,6 +19,9 @@
            {% if p_dsl_poll_interval %}
              "data_streams.lifecycle.poll_interval": "{{ dsl_poll_interval }}",
            {% endif %}
+           {% if p_dsl_default_rollover %}
+             "cluster.lifecycle.default.rollover": "{{ dsl_default_rollover }}",
+           {% endif %}
            "data_streams.auto_sharding.excludes": "{{ ds_autosharding_excludes | list }}", 
             "data_streams.auto_sharding.increase_shards.cooldown": "{{ ds_autosharding_increase_cooldown }}",
             "data_streams.auto_sharding.decrease_shards.cooldown": "{{ ds_autosharding_decrease_cooldown }}",


### PR DESCRIPTION
This will allow us to better control when rollover happens
(based on time - which will correlate nicely with benchmark steps
execution times) so we can make sure a reduction in number of
shards is executed as part of the benchmark.