### PR TITLE
elastic/apm: remove force-merge operation

### DIFF
--- a/elastic/apm/track.json
+++ b/elastic/apm/track.json
@@ -64,14 +64,7 @@
     },
     {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
     {
-      "operation": {
-        "operation-type": "force-merge",
-        "max-num-segments": 1
-      }
-    },
-    {
       "name": "delete-all-datastreams",
-      "tags": ["setup"],
       "operation": "delete-data-stream"
     }
   ]


### PR DESCRIPTION
- Remove unnecessary force-merge operation and tag in elastic/apm 