### PR TITLE
Skip non-operator serverless IT tests for elastic/logs, geonames and http_logs

### DIFF
--- a/it_serverless/conftest.py
+++ b/it_serverless/conftest.py
@@ -204,3 +204,14 @@ def pytest_generate_tests(metafunc):
         operator = metafunc.config.getoption("operator")
         label = "operator" if operator else "user"
         metafunc.parametrize("operator", [operator], ids=[label])
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "operator_only: mark test for operator only")
+
+
+def pytest_collection_modifyitems(config, items):
+    skip = pytest.mark.skip()
+    for item in items:
+        if not config.getoption("operator") and "operator_only" in item.keywords:
+            item.add_marker(skip)

--- a/it_serverless/test_logs.py
+++ b/it_serverless/test_logs.py
@@ -42,6 +42,7 @@ def params(updates=None):
         return {**base, **updates}
 
 
+@pytest.mark.operator_only
 class TestLogs:
     def test_logs_fails_if_assets_not_installed(self, operator, rally, capsys, project_config: ServerlessProjectConfig):
         ret = rally.race(

--- a/it_serverless/test_selected_tracks_and_challenges.py
+++ b/it_serverless/test_selected_tracks_and_challenges.py
@@ -52,6 +52,8 @@ class TestTrackRepository:
         "tsdb_k8s_queries": ["esql"],
     }
     skip_challenges_user = {
+        "geonames": ["append-no-conflicts"],
+        "http_logs": ["append-no-conflicts", "runtime-fields"],
         "k8s_metrics": ["append-no-conflicts-metrics-with-fast-refresh", "fast-refresh-index-only", "fast-refresh-index-with-search"],
     }
     disable_assertions = {


### PR DESCRIPTION
Some of the query parameters like `batched_reduce_size` became unavailable in serverless which has broken `elastic/logs` track for regular user. This PR skips `elastic/logs` from IT tests when run without `--operator` flag.

`elastic/logs` has a dedicated Python module, so I've used pytest marker at the class level as documented [here](https://docs.pytest.org/en/stable/example/simple.html#control-skipping-of-tests-according-to-command-line-option).

Reference: ES-8366