### PR TITLE
Add a new `low-latency` challenge to `tsdb` track

### DIFF
--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -202,6 +202,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `corpus` (default: full) Should be `split16` to use a corpus split in 16 to be used with 16 indexing clients and index mostly in @timestamp order.
 * `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
+* `document_ids`: documentd IDs to use for search, get and mget apis in the `low-latency` challenge. If empty, a default set of 4 values is used.
 
 ### License
 

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -284,7 +284,7 @@
     },
     {
       "name": "low-latency",
-      "description": "Indexes the whole document corpus and executed low-latency queries as a separate challenge. Assertions might result in race failure.",
+      "description": "Indexes the whole document corpus and executes low-latency queries as a separate challenge. Assertions might result in race failure.",
       "schedule": [
         {# non-serverless-cluster-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         {

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -286,23 +286,6 @@
       "name": "low-latency",
       "description": "Indexes the whole document corpus and executes low-latency queries as a separate challenge. Assertions might result in race failure.",
       "schedule": [
-        {# non-serverless-cluster-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-        {
-          "name":"increase-max_buckets_setting",
-          "tags": ["setup"],
-          "operation": {
-            "operation-type": "raw-request",
-            "method": "PUT",
-            "path": "/_cluster/settings",
-            "body": {
-              "transient": {
-                "search.max_buckets" : 300000
-              }
-            },
-            "include-in-reporting": false
-          }
-        },
-        {%- endif -%}{# non-serverless-cluster-settings-marker-end #}
         {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
         {
           "name": "create-all-templates",

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -284,7 +284,7 @@
     },
     {
       "name": "low-latency",
-      "description": "Indexes the whole document corpus and executes low-latency queries as a separate challenge. Assertions might result in race failure.",
+      "description": "Indexes the whole document corpus and executes low-latency queries. Assertions might result in race failure.",
       "schedule": [
         {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
         {

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -392,18 +392,6 @@
         },
         {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
-          "operation": "default",
-          "warmup-iterations": 50,
-          "clients": {{ search_clients | default(1) | int }},
-          "iterations": 100
-        },
-        {
-          "operation": "default_1k",
-          "warmup-iterations": 50,
-          "clients": {{ search_clients | default(1) | int }},
-          "iterations": 100
-        },
-        {
           "operation": "search_by_doc_id",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -281,4 +281,163 @@
           "iterations": 100
         }
       ]
+    },
+    {
+      "name": "low-latency",
+      "description": "Indexes the whole document corpus and executed low-latency queries",
+      "schedule": [
+        {# non-serverless-cluster-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+        {
+          "name":"increase-max_buckets_setting",
+          "tags": ["setup"],
+          "operation": {
+            "operation-type": "raw-request",
+            "method": "PUT",
+            "path": "/_cluster/settings",
+            "body": {
+              "transient": {
+                "search.max_buckets" : 300000
+              }
+            },
+            "include-in-reporting": false
+          }
+        },
+        {%- endif -%}{# non-serverless-cluster-settings-marker-end #}
+        {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
+        {
+          "name": "create-all-templates",
+          "operation": {
+            "operation-type": "create-composable-template",
+            "request-params": {
+              "create": "true"
+            }
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            },
+            "retry-until-success": true
+          }
+        },
+        {%- else %}
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "tsdb",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            },
+            "retry-until-success": true
+          }
+        },
+        {%- endif %}
+        {
+          "operation": "index",
+          "warmup-time-period": 240,
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh"
+        },
+        {
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
+            "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+            {%- endif %}
+          }
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh"
+        },
+        {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+        {
+          "name": "post-ingest-sleep",
+          "operation": {
+            "operation-type": "sleep",
+            "duration": {{ post_ingest_sleep_duration|default(30) }}
+          }
+        },
+        {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
+        {
+          "operation": "default",
+          "warmup-iterations": 50,
+          "clients": {{ search_clients | default(1) | int }},
+          "iterations": 100
+        },
+        {
+          "operation": "default_1k",
+          "warmup-iterations": 50,
+          "clients": {{ search_clients | default(1) | int }},
+          "iterations": 100
+        },
+        {
+          "operation": "search_by_doc_id",
+          "warmup-iterations": 50,
+          "clients": {{ search_clients | default(1) | int }},
+          "iterations": 100
+        },
+        {
+          "operation": "get-xqRz7JSW4hGturbiAAABeRwHA58",
+          "warmup-iterations": 50,
+          "clients": {{ search_clients | default(1) | int }},
+          "iterations": 100
+        },
+        {
+          "operation": "get-QBJ7zzj0pGd4pRawAAABeR1ZbMQ",
+          "warmup-iterations": 50,
+          "clients": {{ search_clients | default(1) | int }},
+          "iterations": 100
+        },
+        {
+          "operation": "get-OWcU2UA5Xj8-fOqdAAABeRrCsc0",
+          "warmup-iterations": 50,
+          "clients": {{ search_clients | default(1) | int }},
+          "iterations": 100
+        },
+        {
+          "operation": "get-yarBSucyUHsSS-x8AAABeRrCsc0",
+          "warmup-iterations": 50,
+          "clients": {{ search_clients | default(1) | int }},
+          "iterations": 100
+        },
+        {
+          "operation": "mget",
+          "warmup-iterations": 50,
+          "clients": {{ search_clients | default(1) | int }},
+          "iterations": 100
+        }
+      ]
     }

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -381,25 +381,25 @@
           "iterations": 100
         },
         {
-          "operation": "get-xqRz7JSW4hGturbiAAABeRwHA58",
+          "operation": "get-iDH7i8eakdbK877gAAABeRl9KLI",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
         },
         {
-          "operation": "get-QBJ7zzj0pGd4pRawAAABeR1ZbMQ",
+          "operation": "get-kKKPKRU4dO9K65O1AAABeRl9KLI",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
         },
         {
-          "operation": "get-OWcU2UA5Xj8-fOqdAAABeRrCsc0",
+          "operation": "get-m3hDF7ZzOutzSPPOAAABeRl9KLI",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
         },
         {
-          "operation": "get-yarBSucyUHsSS-x8AAABeRrCsc0",
+          "operation": "get-PEmhv9AzEQsjTKPAAAABeRl9KLI",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -284,7 +284,7 @@
     },
     {
       "name": "low-latency",
-      "description": "Indexes the whole document corpus and executed low-latency queries",
+      "description": "Indexes the whole document corpus and executed low-latency queries as a separate challenge. Assertions might result in race failure.",
       "schedule": [
         {# non-serverless-cluster-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         {

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -380,30 +380,14 @@
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
         },
+        {% for doc_id in p_document_ids %}
         {
-          "operation": "get-iDH7i8eakdbK877gAAABeRl9KLI",
+          "operation": "get-{{doc_id}}",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
         },
-        {
-          "operation": "get-kKKPKRU4dO9K65O1AAABeRl9KLI",
-          "warmup-iterations": 50,
-          "clients": {{ search_clients | default(1) | int }},
-          "iterations": 100
-        },
-        {
-          "operation": "get-m3hDF7ZzOutzSPPOAAABeRl9KLI",
-          "warmup-iterations": 50,
-          "clients": {{ search_clients | default(1) | int }},
-          "iterations": 100
-        },
-        {
-          "operation": "get-PEmhv9AzEQsjTKPAAAABeRl9KLI",
-          "warmup-iterations": 50,
-          "clients": {{ search_clients | default(1) | int }},
-          "iterations": 100
-        },
+        {% endfor %}
         {
           "operation": "mget",
           "warmup-iterations": 50,

--- a/tsdb/operations/default.json
+++ b/tsdb/operations/default.json
@@ -38,38 +38,38 @@
     "query": {
       "terms": {
         "_id": [
-          "xqRz7JSW4hGturbiAAABeRwHA58",
-          "QBJ7zzj0pGd4pRawAAABeR1ZbMQ",
-          "OWcU2UA5Xj8-fOqdAAABeRrCsc0",
-          "yarBSucyUHsSS-x8AAABeRrCsc0"
+          "iDH7i8eakdbK877gAAABeRl9KLI",
+          "kKKPKRU4dO9K65O1AAABeRl9KLI",
+          "m3hDF7ZzOutzSPPOAAABeRl9KLI",
+          "PEmhv9AzEQsjTKPAAAABeRl9KLI"
         ]
       }
     }
   }
 },
 {
-  "name": "get-xqRz7JSW4hGturbiAAABeRwHA58",
+  "name": "get-iDH7i8eakdbK877gAAABeRl9KLI",
   "operation-type": "raw-request",
   "method": "GET",
-  "path": "/tsdb/_doc/xqRz7JSW4hGturbiAAABeRwHA58"
+  "path": "/tsdb/_doc/iDH7i8eakdbK877gAAABeRl9KLI"
 },
 {
-  "name": "get-QBJ7zzj0pGd4pRawAAABeR1ZbMQ",
+  "name": "get-kKKPKRU4dO9K65O1AAABeRl9KLI",
   "operation-type": "raw-request",
   "method": "GET",
-  "path": "/tsdb/_doc/QBJ7zzj0pGd4pRawAAABeR1ZbMQ"
+  "path": "/tsdb/_doc/kKKPKRU4dO9K65O1AAABeRl9KLI"
 },
 {
-  "name": "get-OWcU2UA5Xj8-fOqdAAABeRrCsc0",
+  "name": "get-m3hDF7ZzOutzSPPOAAABeRl9KLI",
   "operation-type": "raw-request",
   "method": "GET",
-  "path": "/tsdb/_doc/OWcU2UA5Xj8-fOqdAAABeRrCsc0"
+  "path": "/tsdb/_doc/m3hDF7ZzOutzSPPOAAABeRl9KLI"
 },
 {
-  "name": "get-yarBSucyUHsSS-x8AAABeRrCsc0",
+  "name": "get-PEmhv9AzEQsjTKPAAAABeRl9KLI",
   "operation-type": "raw-request",
   "method": "GET",
-  "path": "/tsdb/_doc/yarBSucyUHsSS-x8AAABeRrCsc0"
+  "path": "/tsdb/_doc/PEmhv9AzEQsjTKPAAAABeRl9KLI"
 },
 {
   "name": "mget",
@@ -80,16 +80,16 @@
     "docs": [
       {
         "_index": "tsdb",
-        "_id": "xqRz7JSW4hGturbiAAABeRwHA58"
+        "_id": "iDH7i8eakdbK877gAAABeRl9KLI"
       },{
         "_index": "tsdb",
-        "_id": "QBJ7zzj0pGd4pRawAAABeR1ZbMQ"
+        "_id": "kKKPKRU4dO9K65O1AAABeRl9KLI"
       },{
         "_index": "tsdb",
-        "_id": "OWcU2UA5Xj8-fOqdAAABeRrCsc0"
+        "_id": "m3hDF7ZzOutzSPPOAAABeRl9KLI"
       },{
         "_index": "tsdb",
-        "_id": "yarBSucyUHsSS-x8AAABeRrCsc0"
+        "_id": "PEmhv9AzEQsjTKPAAAABeRl9KLI"
       }
     ]
   }

--- a/tsdb/operations/default.json
+++ b/tsdb/operations/default.json
@@ -24,6 +24,77 @@
   }
 },
 {
+  "name": "search_by_doc_id",
+  "operation-type": "search",
+  "detailed-results": true,
+  "assertions": [
+    {
+      "property": "hits",
+      "condition": "==",
+      "value": 4
+    }
+  ],
+  "body": {
+    "query": {
+      "terms": {
+        "_id": [
+          "xqRz7JSW4hGturbiAAABeRwHA58",
+          "QBJ7zzj0pGd4pRawAAABeR1ZbMQ",
+          "OWcU2UA5Xj8-fOqdAAABeRrCsc0",
+          "yarBSucyUHsSS-x8AAABeRrCsc0"
+        ]
+      }
+    }
+  }
+},
+{
+  "name": "get-xqRz7JSW4hGturbiAAABeRwHA58",
+  "operation-type": "raw-request",
+  "method": "GET",
+  "path": "/tsdb/_doc/xqRz7JSW4hGturbiAAABeRwHA58"
+},
+{
+  "name": "get-QBJ7zzj0pGd4pRawAAABeR1ZbMQ",
+  "operation-type": "raw-request",
+  "method": "GET",
+  "path": "/tsdb/_doc/QBJ7zzj0pGd4pRawAAABeR1ZbMQ"
+},
+{
+  "name": "get-OWcU2UA5Xj8-fOqdAAABeRrCsc0",
+  "operation-type": "raw-request",
+  "method": "GET",
+  "path": "/tsdb/_doc/OWcU2UA5Xj8-fOqdAAABeRrCsc0"
+},
+{
+  "name": "get-yarBSucyUHsSS-x8AAABeRrCsc0",
+  "operation-type": "raw-request",
+  "method": "GET",
+  "path": "/tsdb/_doc/yarBSucyUHsSS-x8AAABeRrCsc0"
+},
+{
+  "name": "mget",
+  "operation-type": "raw-request",
+  "path": "/tsdb/_mget",
+  "method": "GET",
+  "body": {
+    "docs": [
+      {
+        "_index": "tsdb",
+        "_id": "xqRz7JSW4hGturbiAAABeRwHA58"
+      },{
+        "_index": "tsdb",
+        "_id": "QBJ7zzj0pGd4pRawAAABeR1ZbMQ"
+      },{
+        "_index": "tsdb",
+        "_id": "OWcU2UA5Xj8-fOqdAAABeRrCsc0"
+      },{
+        "_index": "tsdb",
+        "_id": "yarBSucyUHsSS-x8AAABeRrCsc0"
+      }
+    ]
+  }
+},
+{
   "name": "date-histo-entire-range-1m",
   "operation-type": "search",
   "index": "tsdb-1m",

--- a/tsdb/operations/default.json
+++ b/tsdb/operations/default.json
@@ -1,3 +1,4 @@
+{% set p_document_ids = (document_ids | default(["iDH7i8eakdbK877gAAABeRl9KLI", "kKKPKRU4dO9K65O1AAABeRl9KLI", "m3hDF7ZzOutzSPPOAAABeRl9KLI", "PEmhv9AzEQsjTKPAAAABeRl9KLI"])) %}
 {
   "name": "index",
   "operation-type": "bulk",
@@ -31,46 +32,30 @@
     {
       "property": "hits",
       "condition": "==",
-      "value": 4
+      "value": {{ p_document_ids|length }}
     }
   ],
   "body": {
     "query": {
       "terms": {
         "_id": [
-          "iDH7i8eakdbK877gAAABeRl9KLI",
-          "kKKPKRU4dO9K65O1AAABeRl9KLI",
-          "m3hDF7ZzOutzSPPOAAABeRl9KLI",
-          "PEmhv9AzEQsjTKPAAAABeRl9KLI"
+          {% for doc_id in p_document_ids %}
+          {{doc_id | tojson}}
+          {{ ", " if not loop.last else "" }}
+          {% endfor %}
         ]
       }
     }
   }
 },
+{% for doc_id in p_document_ids %}
 {
-  "name": "get-iDH7i8eakdbK877gAAABeRl9KLI",
+  "name": "get-{{doc_id}}",
   "operation-type": "raw-request",
   "method": "GET",
-  "path": "/tsdb/_doc/iDH7i8eakdbK877gAAABeRl9KLI"
+  "path": "/tsdb/_doc/{{doc_id}}"
 },
-{
-  "name": "get-kKKPKRU4dO9K65O1AAABeRl9KLI",
-  "operation-type": "raw-request",
-  "method": "GET",
-  "path": "/tsdb/_doc/kKKPKRU4dO9K65O1AAABeRl9KLI"
-},
-{
-  "name": "get-m3hDF7ZzOutzSPPOAAABeRl9KLI",
-  "operation-type": "raw-request",
-  "method": "GET",
-  "path": "/tsdb/_doc/m3hDF7ZzOutzSPPOAAABeRl9KLI"
-},
-{
-  "name": "get-PEmhv9AzEQsjTKPAAAABeRl9KLI",
-  "operation-type": "raw-request",
-  "method": "GET",
-  "path": "/tsdb/_doc/PEmhv9AzEQsjTKPAAAABeRl9KLI"
-},
+{% endfor %}
 {
   "name": "mget",
   "operation-type": "raw-request",
@@ -78,19 +63,12 @@
   "method": "GET",
   "body": {
     "docs": [
+      {% for doc_id in p_document_ids %}
       {
         "_index": "tsdb",
-        "_id": "iDH7i8eakdbK877gAAABeRl9KLI"
-      },{
-        "_index": "tsdb",
-        "_id": "kKKPKRU4dO9K65O1AAABeRl9KLI"
-      },{
-        "_index": "tsdb",
-        "_id": "m3hDF7ZzOutzSPPOAAABeRl9KLI"
-      },{
-        "_index": "tsdb",
-        "_id": "PEmhv9AzEQsjTKPAAAABeRl9KLI"
-      }
+        "_id": {{doc_id | tojson}}
+      }{{ ", " if not loop.last else "" }}
+      {% endfor %}
     ]
   }
 },


### PR DESCRIPTION
We use the tsdb track with standard index mode because:
* document ids are known upfront and do not change over time
* it does not use synthetic source and keeps the _source field stored

This new challenge is needed to evaluate the impact of ZSTD comrpession on stored fields for low latency queries such as get and mget. It also fills a gap in our benchmarks by also testing the get and mget apis which we do not really test in any other benchmark.

This addresses https://github.com/elastic/elasticsearch/issues/108091