### PR TITLE
[elastic/logs] Allow datastream-autosharding to use default cluster settings

### DIFF
--- a/elastic/logs/challenges/datastream-autosharding.json
+++ b/elastic/logs/challenges/datastream-autosharding.json
@@ -23,10 +23,10 @@
              "cluster.lifecycle.default.rollover": "{{ dsl_default_rollover }}",
            {% endif %}
            "data_streams.auto_sharding.excludes": "{{ ds_autosharding_excludes | list }}", 
-            "data_streams.auto_sharding.increase_shards.cooldown": "{{ ds_autosharding_increase_cooldown }}",
-            "data_streams.auto_sharding.decrease_shards.cooldown": "{{ ds_autosharding_decrease_cooldown }}",
-	    "cluster.auto_sharding.min_write_threads": "{{ ds_autosharding_min_threads }}",
-	    "cluster.auto_sharding.max_write_threads": "{{ ds_autosharding_max_threads }}"
+            "data_streams.auto_sharding.increase_shards.cooldown": "{{ p_ds_autosharding_increase_cooldown }}",
+            "data_streams.auto_sharding.decrease_shards.cooldown": "{{ p_ds_autosharding_decrease_cooldown }}",
+	    "cluster.auto_sharding.min_write_threads": "{{ p_ds_autosharding_min_threads }}",
+	    "cluster.auto_sharding.max_write_threads": "{{ p_ds_autosharding_max_threads }}"
           }
         }
       }

--- a/elastic/logs/challenges/datastream-autosharding.json
+++ b/elastic/logs/challenges/datastream-autosharding.json
@@ -16,17 +16,17 @@
         "operation-type": "put-settings",
         "body": {
           "persistent": {
-           {% if p_dsl_poll_interval %}
+           {%- if p_dsl_poll_interval %}
              "data_streams.lifecycle.poll_interval": "{{ dsl_poll_interval }}",
            {% endif %}
-           {% if p_dsl_default_rollover %}
+           {%- if p_dsl_default_rollover %}
              "cluster.lifecycle.default.rollover": "{{ dsl_default_rollover }}",
            {% endif %}
-           "data_streams.auto_sharding.excludes": "{{ ds_autosharding_excludes | list }}", 
-            "data_streams.auto_sharding.increase_shards.cooldown": "{{ p_ds_autosharding_increase_cooldown }}",
-            "data_streams.auto_sharding.decrease_shards.cooldown": "{{ p_ds_autosharding_decrease_cooldown }}",
-	    "cluster.auto_sharding.min_write_threads": "{{ p_ds_autosharding_min_threads }}",
-	    "cluster.auto_sharding.max_write_threads": "{{ p_ds_autosharding_max_threads }}"
+             "data_streams.auto_sharding.excludes": "{{ p_ds_autosharding_excludes | list }}", 
+             "data_streams.auto_sharding.increase_shards.cooldown": "{{ p_ds_autosharding_increase_cooldown }}",
+             "data_streams.auto_sharding.decrease_shards.cooldown": "{{ p_ds_autosharding_decrease_cooldown }}",
+	           "cluster.auto_sharding.min_write_threads": "{{ p_ds_autosharding_min_threads }}",
+	           "cluster.auto_sharding.max_write_threads": "{{ p_ds_autosharding_max_threads }}"
           }
         }
       }


### PR DESCRIPTION
The `datastream-autosharding` challenge does not pick up the cluster settings track defaults for unset track parameters resulting in an error at race completion:

```sh
[WARNING] Error rate is 100.0 for operation 'update-autosharding-settings'. Please check the logs.
[WARNING] No throughput metrics available for [update-autosharding-settings]. Likely cause: Error rate is 100.0%. Please check the logs.
```

* Assign the default values defined in the track challenge.
* Address some formatting nits