### PR TITLE
ESQL Intersects, Contains, Within, Disjoint benchmarks

### DIFF
--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -141,8 +141,8 @@
         },
         {
           "operation": "polygon-within-esql",
-          "warmup-iterations": 100,
-          "iterations": 50,
+          "warmup-iterations": 200,
+          "iterations": 100,
           "tags": ["polygon", "esql"]
         },
         {
@@ -150,6 +150,30 @@
           "warmup-iterations": 200,
           "iterations": 100,
           "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-centroid",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon", "centroid"]
+        },
+        {
+          "operation": "polygon-centroid-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon", "centroid", "esql"]
+        },
+        {
+          "operation": "centroid",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["centroid"]
+        },
+        {
+          "operation": "centroid-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["centroid", "esql"]
         },
         {
           "operation": "bbox-intersects",

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -176,6 +176,12 @@
           "tags": ["centroid", "esql"]
         },
         {
+          "operation": "centroid-to_geopoint-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["centroid", "esql"]
+        },
+        {
           "operation": "bbox-intersects",
           "warmup-iterations": 200,
           "iterations": 100,

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -4,13 +4,15 @@
       "default": true,
       "schedule": [
         {
-          "operation": "delete-index"
+          "operation": "delete-index",
+          "tags": ["setup"]
         },
         {
           "operation": {
             "operation-type": "create-index",
             "settings": {{index_settings | default({}) | tojson}}
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "name": "check-cluster-health",
@@ -22,17 +24,20 @@
               "wait_for_no_relocating_shards": "true"
             },
             "retry-until-success": true
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "operation": "index-append",
           "warmup-time-period": 120,
           "clients": {{bulk_indexing_clients | default(8)}},
-          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+          "tags": ["setup"]
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh"
+          "operation": "refresh",
+          "tags": ["setup"]
         },
         {% if p_include_force_merge %}
         {
@@ -41,11 +46,13 @@
             "request-timeout": 7200{%- if max_num_segments is defined %},
             "max-num-segments": {{max_num_segments}}
              {%- endif %}
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh"
+          "operation": "refresh",
+          "tags": ["setup"]
         },
         {
           "name": "wait-until-merges-finish",
@@ -58,7 +65,8 @@
             },
             "retry-until-success": true,
             "include-in-reporting": false
-          }
+          },
+          "tags": ["setup"]
         },
         {% endif %}
         {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
@@ -67,66 +75,141 @@
           "operation": {
             "operation-type": "sleep",
             "duration": {{ post_ingest_sleep_duration|default(30) }}
-          }
+          },
+          "tags": ["setup"]
         },
         {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
-          "operation": "polygon",
+          "operation": "polygon-intersects",
           "warmup-iterations": 200,
-          "iterations": 100{% if p_include_target_throughput %},
-          "target-throughput": 2
-          {%- endif %}
+          "iterations": 100,
+          "tags": ["polygon"]
         },
         {
-          "operation": "bbox",
+          "operation": "polygon-intersects-esql",
           "warmup-iterations": 200,
-          "iterations": 100{% if p_include_target_throughput %},
-          "target-throughput": 2
-          {%- endif %}
+          "iterations": 100,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-intersects-count-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-contains",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-contains-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-contains-count-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-disjoint",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-disjoint-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-disjoint-count-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-within",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-within-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-within-count-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "bbox-intersects",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["bbox"]
+        },
+        {
+          "operation": "bbox-intersects-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["bbox", "esql"]
         },
         {
           "operation": "distance",
           "warmup-iterations": 200,
-          "iterations": 100{% if p_include_target_throughput %},
-          "target-throughput": 5
-          {%- endif %}
+          "iterations": 100,
+          "tags": ["distance"]
         },
         {
           "operation": "distanceRange",
           "warmup-iterations": 200,
-          "iterations": 100{% if p_include_target_throughput %},
-          "target-throughput": 0.5
-          {%- endif %}
+          "iterations": 100,
+          "tags": ["distance"]
         },
         {
           "operation": "geoGrid_geohash",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_geotile",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_geohex",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_aggs_geohash",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_aggs_geotile",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_aggs_geohex",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         }
       ]
     },

--- a/geopoint/operations/default.json
+++ b/geopoint/operations/default.json
@@ -158,6 +158,63 @@
       "query": "FROM osmgeopoints | WHERE ST_Within(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(*)"
     },
     {
+      "name": "polygon-centroid",
+      "operation-type": "search",
+      "index": "osmgeopoints",
+      "body": {
+        "size": 0,
+        "query": {
+          "geo_shape": {
+            "location": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              }
+            }
+          }
+        },
+        "aggs": {
+          "centroid": {
+            "geo_centroid": {
+              "field": "location"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-centroid-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Intersects(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS centroid=ST_CENTROID_AGG(location)"
+    },
+    {
+      "name": "centroid",
+      "operation-type": "search",
+      "index": "osmgeopoints",
+      "body": {
+        "size": 0,
+        "aggs": {
+          "centroid": {
+            "geo_centroid": {
+              "field": "location"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "centroid-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | STATS centroid=ST_CENTROID_AGG(location)"
+    },
+    {
       "name": "bbox-intersects",
       "operation-type": "search",
       "index": "osmgeopoints",

--- a/geopoint/operations/default.json
+++ b/geopoint/operations/default.json
@@ -15,28 +15,152 @@
       "recency": {{recency | default(0)}}
     },
     {
-      "name": "polygon",
+      "name": "polygon-intersects",
       "operation-type": "search",
+      "index": "osmgeopoints",
       "body": {
+        "size": 10,
         "query": {
-          "geo_polygon": {
+          "geo_shape": {
             "location": {
-              "points": [
-                [-0.1, 49.0],
-                [5.0, 48.0],
-                [15.0, 49.0],
-                [14.0, 60.0],
-                [-0.1, 61.0],
-                [-0.1, 49.0]
-              ]
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              }
             }
           }
         }
       }
     },
     {
-      "name": "bbox",
+      "name": "polygon-intersects-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Intersects(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-intersects-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Intersects(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(*)"
+    },
+    {
+      "name": "polygon-contains",
       "operation-type": "search",
+      "index": "osmgeopoints",
+      "body": {
+        "size": 10,
+        "query": {
+          "geo_shape": {
+            "location": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              },
+              "relation": "contains"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-contains-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Contains(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-contains-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Contains(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(*)"
+    },
+    {
+      "name": "polygon-disjoint",
+      "operation-type": "search",
+      "index": "osmgeopoints",
+      "body": {
+        "size": 10,
+        "query": {
+          "geo_shape": {
+            "location": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              },
+              "relation": "disjoint"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-disjoint-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Disjoint(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-disjoint-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Disjoint(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(*)"
+    },
+    {
+      "name": "polygon-within",
+      "operation-type": "search",
+      "index": "osmgeopoints",
+      "body": {
+        "size": 10,
+        "query": {
+          "geo_shape": {
+            "location": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              },
+              "relation": "within"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-within-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Within(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-within-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Within(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(*)"
+    },
+    {
+      "name": "bbox-intersects",
+      "operation-type": "search",
+      "index": "osmgeopoints",
       "body": {
         "query": {
           "geo_bounding_box": {
@@ -47,6 +171,11 @@
           }
         }
       }
+    },
+    {
+      "name": "bbox-intersects-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Intersects(location, TO_GEOSHAPE(\"BBOX((-0.1, 15.0, 61.0, 48.0))\")) | LIMIT 10"
     },
     {
       "name": "distance",

--- a/geopoint/operations/default.json
+++ b/geopoint/operations/default.json
@@ -215,6 +215,11 @@
       "query": "FROM osmgeopoints | STATS centroid=ST_CENTROID_AGG(location)"
     },
     {
+      "name": "centroid-to_geopoint-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | STATS centroid=ST_CENTROID_AGG(TO_GEOPOINT(location))"
+    },
+    {
       "name": "bbox-intersects",
       "operation-type": "search",
       "index": "osmgeopoints",

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -4,13 +4,15 @@
       "default": true,
       "schedule": [
         {
-          "operation": "delete-index"
+          "operation": "delete-index",
+          "tags": ["setup"]
         },
         {
           "operation": {
             "operation-type": "create-index",
             "settings": {{index_settings | default({}) | tojson}}
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "name": "check-cluster-health",
@@ -22,28 +24,33 @@
               "wait_for_no_relocating_shards": "true"
             },
             "retry-until-success": true
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "operation": "index-append",
           "warmup-time-period": 120,
           "clients": {{bulk_indexing_clients | default(8)}},
-          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+          "tags": ["setup"]
         },
         {
           "name": "refresh-after-index",
-          "operation": "refresh"
+          "operation": "refresh",
+          "tags": ["setup"]
         },
         {
           "operation": {
             "operation-type": "force-merge",
             "max-num-segments": {{ max_num_segments | default(1) }},
             "request-timeout": 7200
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "name": "refresh-after-force-merge",
-          "operation": "refresh"
+          "operation": "refresh",
+          "tags": ["setup"]
         },
         {
           "name": "wait-until-merges-finish",
@@ -56,7 +63,8 @@
             },
             "retry-until-success": true,
             "include-in-reporting": false
-          }
+          },
+          "tags": ["setup"]
         },
         {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
         {
@@ -64,50 +72,131 @@
           "operation": {
             "operation-type": "sleep",
             "duration": {{ post_ingest_sleep_duration|default(30) }}
-          }
+          },
+          "tags": ["setup"]
         },
         {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
-          "operation": "polygon",
+          "operation": "polygon-intersects",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 2
+          "target-throughput": 2,
+          "tags": ["polygon"]
         },
         {
-          "operation": "bbox",
+          "operation": "polygon-intersects-esql",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 2
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-intersects-count-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-contains",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-contains-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-contains-count-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-disjoint",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-disjoint-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-disjoint-count-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-within",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-within-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "polygon-within-count-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["polygon", "esql"]
+        },
+        {
+          "operation": "bbox-intersects",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "target-throughput": 2,
+          "tags": ["bbox"]
+        },
+        {
+          "operation": "bbox-intersects-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["bbox", "esql"]
         },
         {
           "operation": "geoGrid_geohash",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_geotile",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_geohex",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_aggs_geohash",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_aggs_geotile",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_aggs_geohex",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         }
       ]
     },

--- a/geopointshape/challenges/default.json
+++ b/geopointshape/challenges/default.json
@@ -80,7 +80,6 @@
           "operation": "polygon-intersects",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 2,
           "tags": ["polygon"]
         },
         {
@@ -153,7 +152,6 @@
           "operation": "bbox-intersects",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 2,
           "tags": ["bbox"]
         },
         {

--- a/geopointshape/operations/default.json
+++ b/geopointshape/operations/default.json
@@ -15,22 +15,24 @@
       "recency": {{recency | default(0)}}
     },
     {
-      "name": "polygon",
+      "name": "polygon-intersects",
       "operation-type": "search",
+      "index": "osmgeoshapes",
       "body": {
+        "size": 10,
         "query": {
           "geo_shape": {
             "location": {
-               "shape": {
-                  "type": "polygon",
-                  "coordinates" : [[
-                    [-0.1, 49.0],
-                    [5.0, 48.0],
-                    [15.0, 49.0],
-                    [14.0, 60.0],
-                    [-0.1, 61.0],
-                    [-0.1, 49.0]
-                  ]]
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
               }
             }
           }
@@ -38,15 +40,134 @@
       }
     },
     {
-      "name": "bbox",
+      "name": "polygon-intersects-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeoshapes | WHERE ST_Intersects(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-intersects-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeoshapes | WHERE ST_Intersects(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(*)"
+    },
+    {
+      "name": "polygon-contains",
       "operation-type": "search",
+      "index": "osmgeoshapes",
+      "body": {
+        "size": 10,
+        "query": {
+          "geo_shape": {
+            "location": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              },
+              "relation": "contains"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-contains-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeoshapes | WHERE ST_Contains(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-contains-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeoshapes | WHERE ST_Contains(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(*)"
+    },
+    {
+      "name": "polygon-disjoint",
+      "operation-type": "search",
+      "index": "osmgeoshapes",
+      "body": {
+        "size": 10,
+        "query": {
+          "geo_shape": {
+            "location": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              },
+              "relation": "disjoint"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-disjoint-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeoshapes | WHERE ST_Disjoint(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-disjoint-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeoshapes | WHERE ST_Disjoint(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(*)"
+    },
+    {
+      "name": "polygon-within",
+      "operation-type": "search",
+      "index": "osmgeoshapes",
+      "body": {
+        "size": 10,
+        "query": {
+          "geo_shape": {
+            "location": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              },
+              "relation": "within"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-within-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeoshapes | WHERE ST_Within(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-within-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeoshapes | WHERE ST_Within(location, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(*)"
+    },
+    {
+      "name": "bbox-intersects",
+      "operation-type": "search",
+      "index": "osmgeoshapes",
       "body": {
         "query": {
           "geo_shape": {
             "location": {
               "shape": {
-                 "type": "envelope",
-                 "coordinates" : [[-0.1, 61.0], [15.0, 48.0]]
+                "type": "envelope",
+                "coordinates" : [[-0.1, 61.0], [15.0, 48.0]]
               }
             }
           }
@@ -54,8 +175,14 @@
       }
     },
     {
+      "name": "bbox-intersects-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeoshapes | WHERE ST_Intersects(location, TO_GEOSHAPE(\"BBOX((-0.1, 15.0, 61.0, 48.0))\")) | LIMIT 10"
+    },
+    {
       "name": "geoGrid_geohash",
       "operation-type": "search",
+      "index": "osmgeoshapes",
       "body": {
         "query": {
           "geo_grid": {
@@ -69,6 +196,7 @@
     {
       "name": "geoGrid_geotile",
       "operation-type": "search",
+      "index": "osmgeoshapes",
       "body": {
         "query": {
           "geo_grid": {
@@ -82,6 +210,7 @@
     {
       "name": "geoGrid_geohex",
       "operation-type": "search",
+      "index": "osmgeoshapes",
       "body": {
         "query": {
           "geo_grid": {
@@ -95,6 +224,7 @@
     {
       "name": "geoGrid_aggs_geohash",
       "operation-type": "search",
+      "index": "osmgeoshapes",
       "body": {
         "query": {
           "geo_bounding_box": {
@@ -122,6 +252,7 @@
     {
       "name": "geoGrid_aggs_geotile",
       "operation-type": "search",
+      "index": "osmgeoshapes",
       "body": {
         "query": {
           "geo_bounding_box": {
@@ -149,6 +280,7 @@
     {
       "name": "geoGrid_aggs_geohex",
       "operation-type": "search",
+      "index": "osmgeoshapes",
       "body": {
         "query": {
           "geo_bounding_box": {

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -169,7 +169,7 @@
           "operation": "polygon-intersects-esql",
           "warmup-iterations": 100,
           "iterations": 50,
-          "tags": ["polygon"]
+          "tags": ["polygon", "esql"]
         },
         {
           "operation": "polygon-intersects-count",
@@ -181,7 +181,7 @@
           "operation": "polygon-intersects-count-esql",
           "warmup-iterations": 100,
           "iterations": 50,
-          "tags": ["polygon"]
+          "tags": ["polygon", "esql"]
         },
         {
           "operation": "polygon-intersects-oresund",
@@ -193,7 +193,7 @@
           "operation": "polygon-intersects-oresund-esql",
           "warmup-iterations": 400,
           "iterations": 200,
-          "tags": ["polygon"]
+          "tags": ["polygon", "esql"]
         },
         {
           "operation": "polygon-intersects-oresund-count",
@@ -205,7 +205,7 @@
           "operation": "polygon-intersects-oresund-count-esql",
           "warmup-iterations": 400,
           "iterations": 200,
-          "tags": ["polygon"]
+          "tags": ["polygon", "esql"]
         },
         {
           "operation": "polygon-contains",
@@ -223,13 +223,13 @@
           "operation": "polygon-contains-esql",
           "warmup-iterations": 100,
           "iterations": 50,
-          "tags": ["polygon"]
+          "tags": ["polygon", "esql"]
         },
         {
           "operation": "polygon-contains-count-esql",
           "warmup-iterations": 100,
           "iterations": 50,
-          "tags": ["polygon"]
+          "tags": ["polygon", "esql"]
         },
         {
           "operation": "polygon-disjoint",
@@ -247,78 +247,96 @@
           "operation": "polygon-disjoint-esql",
           "warmup-iterations": 100,
           "iterations": 50,
-          "tags": ["polygon"]
+          "tags": ["polygon", "esql"]
         },
         {
           "operation": "polygon-disjoint-count-esql",
           "warmup-iterations": 100,
           "iterations": 50,
-          "tags": ["polygon"]
+          "tags": ["polygon", "esql"]
         },
         {
           "operation": "polygon-within",
-          "warmup-iterations": 100,
+          "warmup-iterations": 50,
           "iterations": 50,
           "tags": ["polygon"]
         },
         {
           "operation": "polygon-within-count",
-          "warmup-iterations": 100,
+          "warmup-iterations": 50,
           "iterations": 50,
           "tags": ["polygon"]
         },
         {
           "operation": "polygon-within-esql",
-          "warmup-iterations": 100,
+          "warmup-iterations": 50,
           "iterations": 50,
-          "tags": ["polygon"]
+          "tags": ["polygon", "esql"]
         },
         {
           "operation": "polygon-within-count-esql",
-          "warmup-iterations": 100,
+          "warmup-iterations": 50,
           "iterations": 50,
-          "tags": ["polygon"]
+          "tags": ["polygon", "esql"]
         },
         {
           "operation": "bbox-intersects",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": 100,
+          "iterations": 50,
           "tags": ["bbox"]
         },
         {
           "operation": "bbox-intersects-esql",
-          "warmup-iterations": 200,
-          "iterations": 100,
-          "tags": ["bbox"]
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["bbox", "esql"]
         },
         {
           "operation": "bbox-contains",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": 100,
+          "iterations": 50,
           "tags": ["bbox"]
+        },
+        {
+          "operation": "bbox-contains-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["bbox", "esql"]
         },
         {
           "operation": "bbox-disjoint",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": 100,
+          "iterations": 50,
           "tags": ["bbox"]
+        },
+        {
+          "operation": "bbox-disjoint-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["bbox", "esql"]
         },
         {
           "operation": "bbox-within",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": 50,
+          "iterations": 50,
           "tags": ["bbox"]
         },
         {
+          "operation": "bbox-within-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["bbox", "esql"]
+        },
+        {
           "operation": "mvt-hits",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": 50,
+          "iterations": 50,
           "tags": ["mvt"]
         },
         {
           "operation": "mvt-grid",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": 50,
+          "iterations": 50,
           "tags": ["mvt"]
         },
         {
@@ -353,8 +371,8 @@
         },
         {
           "operation": "geoGrid_aggs_geohex",
-          "warmup-iterations": 200,
-          "iterations": 100,
+          "warmup-iterations": 100,
+          "iterations": 50,
           "tags": ["geo_grid"]
         }
       ]

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -4,13 +4,15 @@
       "default": true,
       "schedule": [
         {
-          "operation": "delete-index"
+          "operation": "delete-index",
+          "tags": ["setup"]
         },
         {
           "operation": {
             "operation-type": "create-index",
             "settings": {{index_settings | default({}) | tojson}}
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "name": "check-cluster-health",
@@ -22,18 +24,21 @@
               "wait_for_no_relocating_shards": "true"
             },
             "retry-until-success": true
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "operation": "index-append-linestrings",
           "warmup-time-period": 120,
           "clients": {{bulk_indexing_clients | default(8)}},
-          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+          "tags": ["setup"]
         },
         {
           "name": "refresh-after-linestrings-index",
           "operation": "refresh",
-          "index": "osmlinestrings"
+          "index": "osmlinestrings",
+          "tags": ["setup"]
         },
         {
           "name": "force-merge-linestrings",
@@ -42,7 +47,8 @@
             "max-num-segments": 1,
             "index": "osmlinestrings",
             "request-timeout": 7200
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "name": "wait-until-linestrings-merges-finish",
@@ -55,18 +61,21 @@
             },
             "retry-until-success": true,
             "include-in-reporting": false
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "operation": "index-append-multilinestrings",
           "warmup-time-period": 120,
           "clients": {{bulk_indexing_clients | default(8)}},
-          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+          "tags": ["setup"]
         },
         {
           "name": "refresh-after-multilinestrings-index",
           "operation": "refresh",
-          "index": "osmmultilinestrings"
+          "index": "osmmultilinestrings",
+          "tags": ["setup"]
         },
         {
           "name": "force-merge-multilinestrings",
@@ -75,7 +84,8 @@
             "max-num-segments": 1,
             "index": "osmmultilinestrings",
             "request-timeout": 7200
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "name": "wait-until-multilinestrings-merges-finish",
@@ -88,18 +98,21 @@
             },
             "retry-until-success": true,
             "include-in-reporting": false
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "operation": "index-append-polygons",
           "warmup-time-period": 120,
           "clients": {{bulk_indexing_clients | default(8)}},
-          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+          "tags": ["setup"]
         },
         {
           "name": "refresh-after-polygons-index",
           "operation": "refresh",
-          "index": "osmpolygons"
+          "index": "osmpolygons",
+          "tags": ["setup"]
         },
         {
           "name": "force-merge-polygons",
@@ -108,11 +121,13 @@
             "max-num-segments": 1,
             "index": "osmpolygons",
             "request-timeout": 7200
-          }
+          },
+          "tags": ["setup"]
         },
         {
           "name": "refresh-after-all-indices",
-          "operation": "refresh"
+          "operation": "refresh",
+          "tags": ["setup"]
         },
         {
           "name": "wait-until-polygon-merges-finish",
@@ -125,7 +140,8 @@
             },
             "retry-until-success": true,
             "include-in-reporting": false
-          }
+          },
+          "tags": ["setup"]
         },
         {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
         {
@@ -133,88 +149,213 @@
           "operation": {
             "operation-type": "sleep",
             "duration": {{ post_ingest_sleep_duration|default(30) }}
-          }
+          },
+          "tags": ["setup"]
         },
         {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
+          "operation": "polygon-intersects-orig",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
           "operation": "polygon-intersects",
-          "warmup-iterations": 200,
-          "iterations": 100
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-intersects-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-intersects-count",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-intersects-count-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-intersects-oresund",
+          "warmup-iterations": 400,
+          "iterations": 200,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-intersects-oresund-esql",
+          "warmup-iterations": 400,
+          "iterations": 200,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-intersects-oresund-count",
+          "warmup-iterations": 400,
+          "iterations": 200,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-intersects-oresund-count-esql",
+          "warmup-iterations": 400,
+          "iterations": 200,
+          "tags": ["polygon"]
         },
         {
           "operation": "polygon-contains",
-          "warmup-iterations": 200,
-          "iterations": 100
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-contains-count",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-contains-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-contains-count-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
         },
         {
           "operation": "polygon-disjoint",
-          "warmup-iterations": 200,
-          "iterations": 100
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-disjoint-count",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-disjoint-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-disjoint-count-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
         },
         {
           "operation": "polygon-within",
-          "warmup-iterations": 200,
-          "iterations": 100
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-within-count",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-within-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
+        },
+        {
+          "operation": "polygon-within-count-esql",
+          "warmup-iterations": 100,
+          "iterations": 50,
+          "tags": ["polygon"]
         },
         {
           "operation": "bbox-intersects",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["bbox"]
+        },
+        {
+          "operation": "bbox-intersects-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["bbox"]
         },
         {
           "operation": "bbox-contains",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["bbox"]
         },
         {
           "operation": "bbox-disjoint",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["bbox"]
         },
         {
           "operation": "bbox-within",
           "warmup-iterations": 200,
-          "iterations": 100
-        },  
+          "iterations": 100,
+          "tags": ["bbox"]
+        },
         {
           "operation": "mvt-hits",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["mvt"]
         },
         {
           "operation": "mvt-grid",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["mvt"]
         },
         {
           "operation": "geoGrid_geohash",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_geotile",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_geohex",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_aggs_geohash",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_aggs_geotile",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         },
         {
           "operation": "geoGrid_aggs_geohex",
           "warmup-iterations": 200,
-          "iterations": 100
+          "iterations": 100,
+          "tags": ["geo_grid"]
         }
       ]
     },

--- a/geoshape/operations/default.json
+++ b/geoshape/operations/default.json
@@ -456,6 +456,11 @@
       }
     },
     {
+      "name": "bbox-contains-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Contains(shape, TO_GEOSHAPE(\"BBOX((-0.1, 15.0, 61.0, 48.0))\")) | LIMIT 10"
+    },
+    {
       "name": "bbox-disjoint",
       "operation-type": "search",
       "index": "osm*",
@@ -474,6 +479,11 @@
       }
     },
     {
+      "name": "bbox-disjoint-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Disjoint(shape, TO_GEOSHAPE(\"BBOX((-0.1, 15.0, 61.0, 48.0))\")) | LIMIT 10"
+    },
+    {
       "name": "bbox-within",
       "operation-type": "search",
       "index": "osm*",
@@ -490,7 +500,12 @@
           }
         }
       }
-    },            
+    },
+    {
+      "name": "bbox-within-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Within(shape, TO_GEOSHAPE(\"BBOX((-0.1, 15.0, 61.0, 48.0))\")) | LIMIT 10"
+    },
     {
       "name": "mvt-hits",
       "operation-type": "search",

--- a/geoshape/operations/default.json
+++ b/geoshape/operations/default.json
@@ -92,7 +92,7 @@
     {
       "name": "polygon-intersects-esql",
       "operation-type": "esql",
-      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
     },
     {
       "name": "polygon-intersects-count",
@@ -129,7 +129,7 @@
     {
       "name": "polygon-intersects-count-esql",
       "operation-type": "esql",
-      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
     },
     {
       "name": "polygon-intersects-oresund",
@@ -164,7 +164,7 @@
     {
       "name": "polygon-intersects-oresund-esql",
       "operation-type": "esql",
-      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((12.5706 55.45074, 12.04631 55.70469, 12.06618 55.7991, 12.68098 55.93474, 13.48894 55.88091, 13.60262 55.68478, 13.44479 55.32661, 12.64235 55.32723, 12.5706 55.45074))\")) | LIMIT 10"
+      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((12.5706 55.45074, 12.04631 55.70469, 12.06618 55.7991, 12.68098 55.93474, 13.48894 55.88091, 13.60262 55.68478, 13.44479 55.32661, 12.64235 55.32723, 12.5706 55.45074))\")) | LIMIT 10"
     },
     {
       "name": "polygon-intersects-oresund-count",
@@ -206,7 +206,7 @@
     {
       "name": "polygon-intersects-oresund-count-esql",
       "operation-type": "esql",
-      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((12.5706 55.45074, 12.04631 55.70469, 12.06618 55.7991, 12.68098 55.93474, 13.48894 55.88091, 13.60262 55.68478, 13.44479 55.32661, 12.64235 55.32723, 12.5706 55.45074))\")) | STATS count=COUNT(size)"
+      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((12.5706 55.45074, 12.04631 55.70469, 12.06618 55.7991, 12.68098 55.93474, 13.48894 55.88091, 13.60262 55.68478, 13.44479 55.32661, 12.64235 55.32723, 12.5706 55.45074))\")) | STATS count=COUNT(size)"
     },
     {
       "name": "polygon-contains",
@@ -237,7 +237,7 @@
     {
       "name": "polygon-contains-esql",
       "operation-type": "esql",
-      "query": "FROM osm* | WHERE ST_Contains(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Contains(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
     },
     {
       "name": "polygon-contains-count",
@@ -275,7 +275,7 @@
     {
       "name": "polygon-contains-count-esql",
       "operation-type": "esql",
-      "query": "FROM osm* | WHERE ST_Contains(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Contains(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
     },
     {
       "name": "polygon-disjoint",
@@ -306,7 +306,7 @@
     {
       "name": "polygon-disjoint-esql",
       "operation-type": "esql",
-      "query": "FROM osm* | WHERE ST_Disjoint(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Disjoint(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
     },
     {
       "name": "polygon-disjoint-count",
@@ -344,7 +344,7 @@
     {
       "name": "polygon-disjoint-count-esql",
       "operation-type": "esql",
-      "query": "FROM osm* | WHERE ST_Disjoint(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Disjoint(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
     },
     {
       "name": "polygon-within",
@@ -375,7 +375,7 @@
     {
       "name": "polygon-within-esql",
       "operation-type": "esql",
-      "query": "FROM osm* | WHERE ST_Within(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Within(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
     },
     {
       "name": "polygon-within-count",
@@ -413,7 +413,7 @@
     {
       "name": "polygon-within-count-esql",
       "operation-type": "esql",
-      "query": "FROM osm* | WHERE ST_Within(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Within(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
     },
     {
       "name": "bbox-intersects",
@@ -435,7 +435,7 @@
     {
       "name": "bbox-intersects-esql",
       "operation-type": "esql",
-      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"BBOX((-0.1, 15.0, 61.0, 48.0))\")) | LIMIT 10"
+      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"BBOX((-0.1, 15.0, 61.0, 48.0))\")) | LIMIT 10"
     },
     {
       "name": "bbox-contains", 

--- a/geoshape/operations/default.json
+++ b/geoshape/operations/default.json
@@ -39,9 +39,9 @@
       "bulk-size": {{polygon_bulk_size | default(100)}},
       "ingest-percentage": {{ingest_percentage | default(100)}},
       "corpora": "default-polygons"
-    },            
+    },
     {
-      "name": "polygon-intersects",
+      "name": "polygon-intersects-orig",
       "operation-type": "search",
       "index": "osm*",
       "body": {
@@ -63,12 +63,157 @@
           }
         }
       }
-    }, 
+    },
+    {
+      "name": "polygon-intersects",
+      "operation-type": "search",
+      "index": "osm*",
+      "body": {
+        "size": 10,
+        "query": {
+          "geo_shape": {
+            "shape": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-intersects-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-intersects-count",
+      "operation-type": "search",
+      "index": "osm*",
+      "body": {
+        "size": 0,
+        "query": {
+          "geo_shape": {
+            "shape": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              }
+            }
+          }
+        },
+        "aggs": {
+          "count": {
+            "value_count": {
+               "field": "size"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-intersects-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+    },
+    {
+      "name": "polygon-intersects-oresund",
+      "operation-type": "search",
+      "index": "osm*",
+      "body": {
+        "size": 10,
+        "query": {
+          "geo_shape": {
+            "ignore_unmapped": true,
+            "shape": {
+              "relation": "intersects",
+              "shape": {
+                "coordinates": [[
+                  [12.5706, 55.45074],
+                  [12.04631, 55.70469],
+                  [12.06618, 55.7991],
+                  [12.68098, 55.93474],
+                  [13.48894, 55.88091],
+                  [13.60262, 55.68478],
+                  [13.44479, 55.32661],
+                  [12.64235, 55.32723],
+                  [12.5706, 55.45074]
+                ]],
+                "type": "Polygon"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-intersects-oresund-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((12.5706 55.45074, 12.04631 55.70469, 12.06618 55.7991, 12.68098 55.93474, 13.48894 55.88091, 13.60262 55.68478, 13.44479 55.32661, 12.64235 55.32723, 12.5706 55.45074))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-intersects-oresund-count",
+      "operation-type": "search",
+      "index": "osm*",
+      "body": {
+        "size": 0,
+        "query": {
+          "geo_shape": {
+            "ignore_unmapped": true,
+            "shape": {
+              "relation": "intersects",
+              "shape": {
+                "coordinates": [[
+                  [12.5706, 55.45074],
+                  [12.04631, 55.70469],
+                  [12.06618, 55.7991],
+                  [12.68098, 55.93474],
+                  [13.48894, 55.88091],
+                  [13.60262, 55.68478],
+                  [13.44479, 55.32661],
+                  [12.64235, 55.32723],
+                  [12.5706, 55.45074]
+                ]],
+                "type": "Polygon"
+              }
+            }
+          }
+        },
+        "aggs": {
+          "count": {
+            "value_count": {
+              "field": "size"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-intersects-oresund-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((12.5706 55.45074, 12.04631 55.70469, 12.06618 55.7991, 12.68098 55.93474, 13.48894 55.88091, 13.60262 55.68478, 13.44479 55.32661, 12.64235 55.32723, 12.5706 55.45074))\")) | STATS count=COUNT(size)"
+    },
     {
       "name": "polygon-contains",
       "operation-type": "search",
       "index": "osm*",
       "body": {
+        "size": 10,
         "query": {
           "geo_shape": {
             "shape": {
@@ -88,12 +233,56 @@
           }
         }
       }
-    },      
+    },
+    {
+      "name": "polygon-contains-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Contains(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-contains-count",
+      "operation-type": "search",
+      "index": "osm*",
+      "body": {
+        "size": 0,
+        "query": {
+          "geo_shape": {
+            "shape": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              },
+              "relation": "contains"
+            }
+          }
+        },
+        "aggs": {
+          "count": {
+            "value_count": {
+              "field": "size"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-contains-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Contains(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+    },
     {
       "name": "polygon-disjoint",
       "operation-type": "search",
       "index": "osm*",
       "body": {
+        "size": 10,
         "query": {
           "geo_shape": {
             "shape": {
@@ -115,10 +304,54 @@
       }
     },
     {
+      "name": "polygon-disjoint-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Disjoint(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-disjoint-count",
+      "operation-type": "search",
+      "index": "osm*",
+      "body": {
+        "size": 0,
+        "query": {
+          "geo_shape": {
+            "shape": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              },
+              "relation": "disjoint"
+            }
+          }
+        },
+        "aggs": {
+          "count": {
+            "value_count": {
+              "field": "size"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-disjoint-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Disjoint(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+    },
+    {
       "name": "polygon-within",
       "operation-type": "search",
       "index": "osm*",
       "body": {
+        "size": 10,
         "query": {
           "geo_shape": {
             "shape": {
@@ -138,7 +371,50 @@
           }
         }
       }
-    },   
+    },
+    {
+      "name": "polygon-within-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Within(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+    },
+    {
+      "name": "polygon-within-count",
+      "operation-type": "search",
+      "index": "osm*",
+      "body": {
+        "size": 0,
+        "query": {
+          "geo_shape": {
+            "shape": {
+              "shape": {
+                "type": "polygon",
+                "coordinates" : [[
+                  [-0.1, 49.0],
+                  [5.0, 48.0],
+                  [15.0, 49.0],
+                  [14.0, 60.0],
+                  [-0.1, 61.0],
+                  [-0.1, 49.0]
+                ]]
+              },
+              "relation": "within"
+            }
+          }
+        },
+        "aggs": {
+          "count": {
+            "value_count": {
+              "field": "size"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "polygon-within-count-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Within(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+    },
     {
       "name": "bbox-intersects",
       "operation-type": "search",
@@ -155,6 +431,11 @@
           }
         }
       }
+    },
+    {
+      "name": "bbox-intersects-esql",
+      "operation-type": "esql",
+      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"BBOX((-0.1, 15.0, 61.0, 48.0))\")) | LIMIT 10"
     },
     {
       "name": "bbox-contains", 


### PR DESCRIPTION
ESQL added a nuch of spatial search features in 8.14, so we should benchmark them.

We add also matching _search API calls for comparison purposes.

Since we explicitly added a new size:10 to the _search API calls, we include a new -origin benchmark to verify that this has no impact. We should remove that later.

Since the benchmarks take a while to run, and each iteration takes a while, I also shortened the iteration could for the long running queries.
