### PR TITLE
Disable lossy _source parameters on serverless

### DIFF
--- a/cohere_vector/index-vectors-only-mapping.json
+++ b/cohere_vector/index-vectors-only-mapping.json
@@ -10,9 +10,11 @@
   },
   "mappings": {
     "dynamic": false,
+    {%- if build_flavor != "serverless" -%}
     "_source": {
       "enabled": false
     },
+    {%- endif -%}
     "properties": {
       "emb": {
         "type": "dense_vector",

--- a/so_vector/index.json
+++ b/so_vector/index.json
@@ -10,9 +10,11 @@
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {
+    {%- if build_flavor != "serverless" -%}
     "_source": {
       "excludes": ["titleVector"]
     },
+    {%- endif -%}
     "properties": {
       "userId": {
         "type": "keyword"


### PR DESCRIPTION
No longer allowed as of elastic/elasticsearch-serverless#1679.