### PR TITLE
Attempt to fix osm* issue in ESQL benchmarks

### DIFF
--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -8,6 +8,18 @@
           "tags": ["setup"]
         },
         {
+          "name": "delete-index-osmgeopoints",
+          "operation": "delete-index",
+          "index": "osmgeopoints",
+          "tags": ["setup"]
+        },
+        {
+          "name": "delete-index-osmgeoshapes",
+          "operation": "delete-index",
+          "index": "osmgeoshapes",
+          "tags": ["setup"]
+        },
+        {
           "operation": {
             "operation-type": "create-index",
             "settings": {{index_settings | default({}) | tojson}}

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -8,15 +8,19 @@
           "tags": ["setup"]
         },
         {
-          "name": "delete-index-osmgeopoints",
-          "operation": "delete-index",
-          "index": "osmgeopoints",
+          "operation": {
+            "name": "delete-index-osmgeopoints",
+            "operation-type": "delete-index",
+            "index": "osmgeopoints"
+          },
           "tags": ["setup"]
         },
         {
-          "name": "delete-index-osmgeoshapes",
-          "operation": "delete-index",
-          "index": "osmgeoshapes",
+          "operation": {
+            "name": "delete-index-osmgeoshapes",
+            "operation-type": "delete-index",
+            "index": "osmgeoshapes"
+          },
           "tags": ["setup"]
         },
         {

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -11,17 +11,9 @@
           "operation": {
             "name": "delete-index-osmgeopoints",
             "operation-type": "delete-index",
-            "index": "osmgeopoints"
+            "index": "osmgeo*"
           },
-          "tags": ["setup"]
-        },
-        {
-          "operation": {
-            "name": "delete-index-osmgeoshapes",
-            "operation-type": "delete-index",
-            "index": "osmgeoshapes"
-          },
-          "tags": ["setup"]
+          "tags": ["setup", "external"]
         },
         {
           "operation": {

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -11,9 +11,17 @@
           "operation": {
             "name": "delete-index-osmgeopoints",
             "operation-type": "delete-index",
-            "index": "osmgeo*"
+            "index": "osmgeopoints"
           },
-          "tags": ["setup", "external"]
+          "tags": ["setup"]
+        },
+        {
+          "operation": {
+            "name": "delete-index-osmgeoshapes",
+            "operation-type": "delete-index",
+            "index": "osmgeoshapes"
+          },
+          "tags": ["setup"]
         },
         {
           "operation": {

--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -13,7 +13,7 @@
             "operation-type": "delete-index",
             "index": "osmgeopoints"
           },
-          "tags": ["setup"]
+          "tags": ["setup", "external"]
         },
         {
           "operation": {
@@ -21,7 +21,7 @@
             "operation-type": "delete-index",
             "index": "osmgeoshapes"
           },
-          "tags": ["setup"]
+          "tags": ["setup", "external"]
         },
         {
           "operation": {

--- a/geoshape/operations/default.json
+++ b/geoshape/operations/default.json
@@ -92,7 +92,7 @@
     {
       "name": "polygon-intersects-esql",
       "operation-type": "esql",
-      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
     },
     {
       "name": "polygon-intersects-count",
@@ -129,7 +129,7 @@
     {
       "name": "polygon-intersects-count-esql",
       "operation-type": "esql",
-      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
     },
     {
       "name": "polygon-intersects-oresund",
@@ -164,7 +164,7 @@
     {
       "name": "polygon-intersects-oresund-esql",
       "operation-type": "esql",
-      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((12.5706 55.45074, 12.04631 55.70469, 12.06618 55.7991, 12.68098 55.93474, 13.48894 55.88091, 13.60262 55.68478, 13.44479 55.32661, 12.64235 55.32723, 12.5706 55.45074))\")) | LIMIT 10"
+      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((12.5706 55.45074, 12.04631 55.70469, 12.06618 55.7991, 12.68098 55.93474, 13.48894 55.88091, 13.60262 55.68478, 13.44479 55.32661, 12.64235 55.32723, 12.5706 55.45074))\")) | LIMIT 10"
     },
     {
       "name": "polygon-intersects-oresund-count",
@@ -206,7 +206,7 @@
     {
       "name": "polygon-intersects-oresund-count-esql",
       "operation-type": "esql",
-      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((12.5706 55.45074, 12.04631 55.70469, 12.06618 55.7991, 12.68098 55.93474, 13.48894 55.88091, 13.60262 55.68478, 13.44479 55.32661, 12.64235 55.32723, 12.5706 55.45074))\")) | STATS count=COUNT(size)"
+      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"POLYGON((12.5706 55.45074, 12.04631 55.70469, 12.06618 55.7991, 12.68098 55.93474, 13.48894 55.88091, 13.60262 55.68478, 13.44479 55.32661, 12.64235 55.32723, 12.5706 55.45074))\")) | STATS count=COUNT(size)"
     },
     {
       "name": "polygon-contains",
@@ -237,7 +237,7 @@
     {
       "name": "polygon-contains-esql",
       "operation-type": "esql",
-      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Contains(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+      "query": "FROM osm* | WHERE ST_Contains(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
     },
     {
       "name": "polygon-contains-count",
@@ -275,7 +275,7 @@
     {
       "name": "polygon-contains-count-esql",
       "operation-type": "esql",
-      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Contains(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+      "query": "FROM osm* | WHERE ST_Contains(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
     },
     {
       "name": "polygon-disjoint",
@@ -306,7 +306,7 @@
     {
       "name": "polygon-disjoint-esql",
       "operation-type": "esql",
-      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Disjoint(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+      "query": "FROM osm* | WHERE ST_Disjoint(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
     },
     {
       "name": "polygon-disjoint-count",
@@ -344,7 +344,7 @@
     {
       "name": "polygon-disjoint-count-esql",
       "operation-type": "esql",
-      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Disjoint(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+      "query": "FROM osm* | WHERE ST_Disjoint(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
     },
     {
       "name": "polygon-within",
@@ -375,7 +375,7 @@
     {
       "name": "polygon-within-esql",
       "operation-type": "esql",
-      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Within(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
+      "query": "FROM osm* | WHERE ST_Within(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | LIMIT 10"
     },
     {
       "name": "polygon-within-count",
@@ -413,7 +413,7 @@
     {
       "name": "polygon-within-count-esql",
       "operation-type": "esql",
-      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Within(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
+      "query": "FROM osm* | WHERE ST_Within(shape, TO_GEOSHAPE(\"POLYGON((-0.1 49.0, 5.0 48.0, 15.0 49.0, 14.0 60.0, -0.1 61.0, -0.1 49.0))\")) | STATS count=COUNT(size)"
     },
     {
       "name": "bbox-intersects",
@@ -435,7 +435,7 @@
     {
       "name": "bbox-intersects-esql",
       "operation-type": "esql",
-      "query": "FROM osmpolygons, osmlinestrings, osmmultilinestrings | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"BBOX((-0.1, 15.0, 61.0, 48.0))\")) | LIMIT 10"
+      "query": "FROM osm* | WHERE ST_Intersects(shape, TO_GEOSHAPE(\"BBOX((-0.1, 15.0, 61.0, 48.0))\")) | LIMIT 10"
     },
     {
       "name": "bbox-contains", 


### PR DESCRIPTION
We try to delete the conflicting indices first. This does not seem to be working, though.

The error we get is when running `geoshape` track is:

```
{
  "type":"query_shard_exception",
  "reason":"failed to find type for field [shape]",
  "index_uuid":"mdXPYZ0XQNG1DIEOtDBgeg",
  "index":"osmgeopoints"
}
```

The index `osmgeopoints` is not defined for the track `geoshape`, so this appears to be a leftover from a previous track. This issue occurs when running `--test-mode`, as well as local full runs if the previous track was `geopoint`.

This PR tries to delete the `osmgeopoints` index, and the `osmgeoshapes` index (which might also exist, and would cause the same error presumably, since it also has no `shape` field).
