### PR TITLE
Use a pipeline to generate doc id and use correct doc id values

### DIFF
--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -331,6 +331,14 @@
         },
         {%- endif %}
         {
+          "operation": "delete-doc-id-pipeline",
+          "tags": ["setup"]
+        },
+        {
+          "operation": "create-doc-id-pipeline",
+          "tags": ["setup"]
+        },
+        {
           "operation": "index",
           "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}},

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -339,10 +339,10 @@
           "tags": ["setup"]
         },
         {
-          "operation": "index",
+          "operation": "index-with-doc-id-gen-pipeline",
           "warmup-time-period": 240,
-          "clients": {{bulk_indexing_clients | default(8)}},
-          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+          "clients": {{bulk_indexing_clients | default(8)}}
         },
         {
           "name": "refresh-after-index",

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -372,17 +372,18 @@
         {
           "name": "refresh-after-force-merge",
           "operation": "refresh"
-        },
+        }
         {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
-        {
+        ,{
           "name": "post-ingest-sleep",
           "operation": {
             "operation-type": "sleep",
             "duration": {{ post_ingest_sleep_duration|default(30) }}
           }
-        },
+        }
         {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
-        {
+        {% if index_mode | default('time_series') is equalto 'standard' %}
+        ,{
           "operation": "search_by_doc_id",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
@@ -402,5 +403,6 @@
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
         }
+        {%- endif %}
       ]
     }

--- a/tsdb/operations/default.json
+++ b/tsdb/operations/default.json
@@ -1,4 +1,40 @@
-{% set p_document_ids = (document_ids | default(["iDH7i8eakdbK877gAAABeRl9KLI", "kKKPKRU4dO9K65O1AAABeRl9KLI", "m3hDF7ZzOutzSPPOAAABeRl9KLI", "PEmhv9AzEQsjTKPAAAABeRl9KLI"])) %}
+{% set p_document_ids = (document_ids | default(["gS4gXAQ2PymeYUeeAAABeRl9KLI", "RsqXDZi2PmyLnlR_AAABeRl9KLI", "Vc8ytLUcdMYQHBSXAAABeRl9KLI", "rrRboS8C1s3V__3rAAABeRl9KLI"])) %}
+{
+  "name": "delete-doc-id-pipeline",
+  "operation-type": "raw-request",
+  "ignore": [404],
+  "include-in-reporting": false,
+  "method": "DELETE",
+  "path": "/_ingest/pipeline/doc_id_gen"
+},
+{
+  "name": "create-doc-id-pipeline",
+  "operation-type": "raw-request",
+  "method": "PUT",
+  "path": "/_ingest/pipeline/doc_id_gen",
+  "body": {
+    "processors": [
+      {
+        "fingerprint": {
+          "fields": [
+            "@timestamp",
+            "kubernetes.pod.name",
+            "metricset.name",
+            "kubernetes.container.id",
+            "kubernetes.container.name",
+            "kubernetes.volume.name",
+            "kubernetes.node.name",
+            "kubernetes.system.container",
+            "kubernetes.event.involved_object.uid"
+          ],
+          "target_field": "_id",
+          "salt": "17",
+          "method": "MurmurHash3"
+        }
+      }
+    ]
+  }
+},
 {
   "name": "index",
   "operation-type": "bulk",

--- a/tsdb/operations/default.json
+++ b/tsdb/operations/default.json
@@ -1,4 +1,4 @@
-{% set p_document_ids = (document_ids | default(["gS4gXAQ2PymeYUeeAAABeRl9KLI", "RsqXDZi2PmyLnlR_AAABeRl9KLI", "Vc8ytLUcdMYQHBSXAAABeRl9KLI", "rrRboS8C1s3V__3rAAABeRl9KLI"])) %}
+{% set p_document_ids = (document_ids | default(["Rpgg6gSYETjE4x8VrIAPNQ==", "AVdIG3TktHA+a3U2gW29QA==", "DeiNU57QgAml0UMiPg7hWA==", "3o6jhoyitLP3RPjSAEMRgQ=="])) %}
 {
   "name": "delete-doc-id-pipeline",
   "operation-type": "raw-request",
@@ -18,8 +18,8 @@
         "fingerprint": {
           "fields": [
             "@timestamp",
-            "kubernetes.pod.name",
             "metricset.name",
+            "kubernetes.pod.name",
             "kubernetes.container.id",
             "kubernetes.container.name",
             "kubernetes.volume.name",
@@ -27,9 +27,10 @@
             "kubernetes.system.container",
             "kubernetes.event.involved_object.uid"
           ],
-          "target_field": "_id",
           "salt": "17",
-          "method": "MurmurHash3"
+          "target_field": "_id",
+          "method": "MurmurHash3",
+          "ignore_missing": true
         }
       }
     ]
@@ -40,6 +41,13 @@
   "operation-type": "bulk",
   "bulk-size": {{bulk_size | default(5000)}},
   "ingest-percentage": {{ingest_percentage | default(100)}}
+},
+{
+  "name": "index-with-doc-id-gen-pipeline",
+  "operation-type": "bulk",
+  "bulk-size": {{bulk_size | default(5000)}},
+  "ingest-percentage": {{ingest_percentage | default(100)}},
+  "pipeline": "doc_id_gen"
 },
 {
   "name": "default",


### PR DESCRIPTION
Indexing documents in standard mode results in documents
whose document id is random. Random document ids prevent
us from testing `get` and `mget` since every indexing operation
would result in different document ids. Here we use a pipeline
taking advantage of the fingerprint processor to generate consistent
document id and use some of those values as parameters for
testing `get` and `mget`.

This PR needs to be backported to Elasticsearch `8.13` and `8.14`
since we need to run benchmarks for those versions too so that we can
evaluate the impact of ZSTD on such APIs.