### PR TITLE
[8.13] Prepare elastic/logs track for the new logs index mode. (#612)

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -247,8 +247,7 @@ The following parameters are available:
 * `disable_pipelines` (default: `false`) - Prevent installing ingest node pipelines. This parameter is experimental and is to be used with indexing-only challenges.
 * `initial_indices_count` (default: 0) - Number of initial indices to create, each containing `100` auditbeat style documents. Parameter is applicable in [many-shards-quantitative challenge](#many-shards-quantitative-many-shards-quantitative) and in [many-shards-snapshots challenge](#many-shards-snapshots-many-shards-snapshots).
 * `ingest_percentage` (default: 100) - The percentage of data to be ingested.
-* `index_sorting` (default: unset): Whether index sorting should be used. Accepted values: `hostname` and `timestamp`. 
-* `synthetic_source_mode` (default: `false`): Whether to enable synthetic source.
+* `index_mode` (default: unset): What index mode to use. Accepted values: `standard` and `logs`. 
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use. Only supported in `logging-querying` track.
 * `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
 

--- a/elastic/logs/templates/component/auditbeat-mappings.json
+++ b/elastic/logs/templates/component/auditbeat-mappings.json
@@ -1785,9 +1785,6 @@
             "message": {
               "norms": false,
               "type": "text"
-              {% if synthetic_source_mode | default(false) is true %},
-              "store": true
-              {% endif %}
             },
             "stack_trace": {
               "fields": {
@@ -2944,9 +2941,6 @@
         "message": {
           "norms": false,
           "type": "text"
-          {% if synthetic_source_mode | default(false) is true %},
-          "store": true
-          {% endif %}
         },
         "network": {
           "properties": {

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -1,21 +1,13 @@
 {
     "template": {
       "settings": {
+        {% if index_mode %}
         "index": {
-          {% if index_sorting == "hostname" %}
+            "mode": {{ index_mode | tojson }},
             "sort.field": [ "host.name", "@timestamp" ],
-            "sort.order": [ "asc", "desc" ]
-          {% elif index_sorting == "timestamp" %}
-            "sort.field": [ "@timestamp", "host.name" ],
-            "sort.order": [ "desc", "asc" ]
-          {% endif %}
+            "sort.order": [ "asc", "desc" ],
+            "sort.missing": ["_first", "_last"]
         }
-      },
-      "mappings": {
-        {% if synthetic_source_mode | default(false) is true %}
-            "_source": {
-                "mode": "synthetic"
-            }
         {% endif %}
       }
     }

--- a/elastic/logs/templates/composable/logs-kafka.log.json
+++ b/elastic/logs/templates/composable/logs-kafka.log.json
@@ -158,9 +158,6 @@
                   "properties": {
                     "message": {
                       "type": "text"
-                      {% if synthetic_source_mode | default(false) is true %},
-                      "store": true
-                      {% endif %}
                     },
                     "class": {
                       "ignore_above": 1024,
@@ -269,17 +266,11 @@
         },
         "message": {
           "type": "text"
-          {% if synthetic_source_mode | default(false) is true %},
-          "store": true
-          {% endif %}
         },
         "error": {
           "properties": {
             "message": {
               "type": "text"
-              {% if synthetic_source_mode | default(false) is true %},
-              "store": true
-              {% endif %}
             }
           }
         },


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.13`:
 - [Prepare elastic/logs track for the new logs index mode. (#612)](https://github.com/elastic/rally-tracks/pull/612)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Martijn van Groningen","email":"martijn.v.groningen@gmail.com"},"sourceCommit":{"committedDate":"2024-06-04T13:45:33Z","message":"Prepare elastic/logs track for the new logs index mode. (#612)\n\nBy replacing index_sorting and synthetic_source_mode parameters by index_mode parameter.","sha":"a71ef117fd020fb5c3642abbdc8ff8e6222b1a53"},"sourcePullRequest":{"labels":[],"title":"Prepare elastic/logs track for the new logs index mode.","number":612,"url":"https://github.com/elastic/rally-tracks/pull/612","mergeCommit":{"message":"Prepare elastic/logs track for the new logs index mode. (#612)\n\nBy replacing index_sorting and synthetic_source_mode parameters by index_mode parameter.","sha":"a71ef117fd020fb5c3642abbdc8ff8e6222b1a53"}},"sourceBranch":"master","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->