### PR TITLE
Use documented track param parallel_indexing_target_throughput

### DIFF
--- a/wikipedia/challenges/default.json
+++ b/wikipedia/challenges/default.json
@@ -71,7 +71,8 @@
             "operation": "query-string-search",
             "clients": {{ parallel_indexing_search_clients | default(20) | int }},
             "time-period": {{ parallel_indexing_search_time_period | default(300) | int }},
-            "warmup-time-period": {{ parallel_indexing_search_warmup_time_period | default(10) | int }}
+            "warmup-time-period": {{ parallel_indexing_search_warmup_time_period | default(10) | int }},
+            "target-throughput": {{ parallel_indexing_target_throughput | default(100) | int }}
           }
         ]
       }


### PR DESCRIPTION
The [Wikipedia](https://github.com/elastic/rally-tracks/tree/master/wikipedia) track documented that it supported track param `parallel_indexing_target_throughput` but it doesn't. 

This PR updates the track to use the param `parallel_indexing_target_throughput`