### PR TITLE
Remove index sorting overwrite

### DIFF
--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -3,10 +3,7 @@
       "settings": {
         {% if index_mode %}
         "index": {
-            "mode": {{ index_mode | tojson }},
-            "sort.field": [ "host.name", "@timestamp" ],
-            "sort.order": [ "asc", "desc" ],
-            "sort.missing": ["_first", "_last"]
+            "mode": {{ index_mode | tojson }}
         }
         {% endif %}
       }


### PR DESCRIPTION
The default is now `host.name` AND `@timestamp`

Closes elastic/elasticsearch#109523