### PR TITLE
Grant elasticsearch-team ability to rerun builds

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -50,6 +50,8 @@ spec:
       repository: elastic/rally-tracks
       teams:
         es-perf: {}
+        elasticsearch-team:
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 
@@ -84,5 +86,7 @@ spec:
           message: periodic it serverless
       teams:
         es-perf: {}
+        elasticsearch-team:
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
Currently only es-perf can rerun builds, this grants permissions to elasticsearch-team to rereun too