### PR TITLE
Add three searches that fetch _source as separate challenges to elastic/logs track

### DIFF
--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -82,20 +82,20 @@
     {
       "operation": "discovery-search-request-size-100",
       "clients": 1,
-      "warmup-iterations": 10,
+      "warmup-iterations": 0,
       "iterations": 50
     },
     {
       "operation": "discovery-search-request-size-500",
       "clients": 1,
-      "warmup-iterations": 10,
+      "warmup-iterations": 0,
       "iterations": 50
     },
 
     {
       "operation": "discovery-search-request-size-1000",
       "clients": 1,
-      "warmup-iterations": 10,
+      "warmup-iterations": 0,
       "iterations": 50
     },
     {

--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -80,13 +80,20 @@
       ,
     {% endif %}
     {
-      "operation": "initial-discovery-search-request",
+      "operation": "discovery-search-request-size-100",
       "clients": 1,
       "warmup-iterations": 10,
       "iterations": 50
     },
     {
-      "operation": "query-discovery-search-request",
+      "operation": "discovery-search-request-size-500",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50
+    },
+
+    {
+      "operation": "discovery-search-request-size-1000",
       "clients": 1,
       "warmup-iterations": 10,
       "iterations": 50

--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -80,6 +80,18 @@
       ,
     {% endif %}
     {
+      "operation": "initial-discovery-search-request",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50
+    },
+    {
+      "operation": "query-discovery-search-request",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50
+    },
+    {
       "name": "logging-queries",
       "parallel": {
         "time-period": {{ p_query_time_period }},

--- a/elastic/logs/operations/search-with-source.json
+++ b/elastic/logs/operations/search-with-source.json
@@ -1,0 +1,243 @@
+  {
+    "name": "initial-discovery-search-request",
+    "operation-type": "search",
+    "index": "logs-*",
+    "request-params": {
+      "batched_reduce_size": "64",
+      "ignore_unavailable": "true",
+      "track_total_hits": "false",
+      "enable_fields_emulation": "true",
+      "preference": "1650039059666"
+    },
+    "body": {
+      "sort": [
+        {
+          "@timestamp": {
+            "order": "desc",
+            "unmapped_type": "boolean"
+          }
+        }
+      ],
+      "fields": [
+        {
+          "field": "*",
+          "include_unmapped": "true"
+        },
+        {
+          "field": "@timestamp",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "eden.created_at",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.created",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.end",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.ingested",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.start",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.accessed",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.created",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.ctime",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.mtime",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "postgresql.log.session_start_time",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "process.parent.start",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "process.start",
+          "format": "strict_date_optional_time"
+        }
+      ],
+      "size": 500,
+      "version": true,
+      "script_fields": {},
+      "stored_fields": [
+        "*"
+      ],
+      "runtime_mappings": {},
+      "_source": false,
+      "query": {
+        "bool": {
+          "must": [],
+          "filter": [
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "strict_date_optional_time",
+                  "gte": "2022-04-14T16:36:52.359Z",
+                  "lte": "2022-04-15T16:36:52.359Z"
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must_not": []
+        }
+      },
+      "highlight": {
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ],
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647
+      }
+    }
+  },
+  {
+    "name": "query-discovery-search-request",
+    "operation-type": "search",
+    "index": "logs-*",
+    "request-params": {
+      "batched_reduce_size": "64",
+      "ignore_unavailable": "true",
+      "track_total_hits": "false",
+      "enable_fields_emulation": "true",
+      "preference": "1650039059666"
+    },
+    "body": {
+      "sort": [
+        {
+          "@timestamp": {
+            "order": "desc",
+            "unmapped_type": "boolean"
+          }
+        }
+      ],
+      "fields": [
+        {
+          "field": "*",
+          "include_unmapped": "true"
+        },
+        {
+          "field": "@timestamp",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "eden.created_at",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.created",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.end",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.ingested",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.start",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.accessed",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.created",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.ctime",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.mtime",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "postgresql.log.session_start_time",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "process.parent.start",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "process.start",
+          "format": "strict_date_optional_time"
+        }
+      ],
+      "size": 500,
+      "version": true,
+      "script_fields": {},
+      "stored_fields": [
+        "*"
+      ],
+      "runtime_mappings": {},
+      "_source": false,
+      "query": {
+        "bool": {
+          "must": [],
+          "filter": [
+            {
+              "multi_match": {
+                "type": "best_fields",
+                "query": "error",
+                "lenient": true
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "format": "strict_date_optional_time",
+                  "gte": "2022-04-14T16:38:05.612Z",
+                  "lte": "2022-04-15T16:38:05.612Z"
+                }
+              }
+            }
+          ],
+          "should": [],
+          "must_not": []
+        }
+      },
+      "highlight": {
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ],
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647
+      }
+    }
+  }

--- a/elastic/logs/operations/search-with-source.json
+++ b/elastic/logs/operations/search-with-source.json
@@ -1,5 +1,5 @@
   {
-    "name": "initial-discovery-search-request",
+    "name": "discovery-search-request-size-100",
     "operation-type": "search",
     "index": "logs-*",
     "request-params": {
@@ -76,7 +76,7 @@
           "format": "strict_date_optional_time"
         }
       ],
-      "size": 500,
+      "size": 100,
       "version": true,
       "script_fields": {},
       "stored_fields": [
@@ -84,24 +84,6 @@
       ],
       "runtime_mappings": {},
       "_source": false,
-      "query": {
-        "bool": {
-          "must": [],
-          "filter": [
-            {
-              "range": {
-                "@timestamp": {
-                  "format": "strict_date_optional_time",
-                  "gte": "2022-04-14T16:36:52.359Z",
-                  "lte": "2022-04-15T16:36:52.359Z"
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must_not": []
-        }
-      },
       "highlight": {
         "pre_tags": [
           "@kibana-highlighted-field@"
@@ -117,7 +99,7 @@
     }
   },
   {
-    "name": "query-discovery-search-request",
+    "name": "discovery-search-request-size-500",
     "operation-type": "search",
     "index": "logs-*",
     "request-params": {
@@ -202,31 +184,106 @@
       ],
       "runtime_mappings": {},
       "_source": false,
-      "query": {
-        "bool": {
-          "must": [],
-          "filter": [
-            {
-              "multi_match": {
-                "type": "best_fields",
-                "query": "error",
-                "lenient": true
-              }
-            },
-            {
-              "range": {
-                "@timestamp": {
-                  "format": "strict_date_optional_time",
-                  "gte": "2022-04-14T16:38:05.612Z",
-                  "lte": "2022-04-15T16:38:05.612Z"
-                }
-              }
-            }
-          ],
-          "should": [],
-          "must_not": []
+      "highlight": {
+        "pre_tags": [
+          "@kibana-highlighted-field@"
+        ],
+        "post_tags": [
+          "@/kibana-highlighted-field@"
+        ],
+        "fields": {
+          "*": {}
+        },
+        "fragment_size": 2147483647
+      }
+    }
+  },
+  {
+    "name": "discovery-search-request-size-1000",
+    "operation-type": "search",
+    "index": "logs-*",
+    "request-params": {
+      "batched_reduce_size": "64",
+      "ignore_unavailable": "true",
+      "track_total_hits": "false",
+      "enable_fields_emulation": "true",
+      "preference": "1650039059666"
+    },
+    "body": {
+      "sort": [
+        {
+          "@timestamp": {
+            "order": "desc",
+            "unmapped_type": "boolean"
+          }
         }
-      },
+      ],
+      "fields": [
+        {
+          "field": "*",
+          "include_unmapped": "true"
+        },
+        {
+          "field": "@timestamp",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "eden.created_at",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.created",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.end",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.ingested",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "event.start",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.accessed",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.created",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.ctime",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "file.mtime",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "postgresql.log.session_start_time",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "process.parent.start",
+          "format": "strict_date_optional_time"
+        },
+        {
+          "field": "process.start",
+          "format": "strict_date_optional_time"
+        }
+      ],
+      "size": 1000,
+      "version": true,
+      "script_fields": {},
+      "stored_fields": [
+        "*"
+      ],
+      "runtime_mappings": {},
+      "_source": false,
       "highlight": {
         "pre_tags": [
           "@kibana-highlighted-field@"


### PR DESCRIPTION
These search are based from searches that are executed by search/discovery search challenge that fetch top documents. The queries are without query and fetch 100, 500 and 1000 documents. The source is fetches using the field fetch feature, like in the searches that execute as part of search/discovery workflow.

The problem is that we see combined latency and service time for search/discovery challenge and not for each search that is executed as part of this challenge (it is composite operation). 

By adding these searches we can get latency and service time of searches that specifically fetch _source. This information is useful for the logsdb effort. Synthetic source makes fetching _source more expensive, but currently we can't introspect at a closer level what the impact is (since search/discovery search challenge report latency / service time for multiple operations).