### PR TITLE
Added many more distance benchmarks for ESQL

### DIFF
--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -200,28 +200,154 @@
           "tags": ["distance"]
         },
         {
+          "operation": "distanceFilter-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterEQ",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterEQ-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterGTE",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterGTE-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilter10kGTE",
+          "warmup-iterations": 20,
+          "iterations": 10,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilter10kGTE-esql",
+          "warmup-iterations": 20,
+          "iterations": 10,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterCount100",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance"]
+        },
+        {
+          "operation": "distanceFilterCount100-esql",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterCount100x200",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterCount100x200-esql",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterCount200",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance"]
+        },
+        {
+          "operation": "distanceFilterCount200-esql",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterCount200x300",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterCount200x300-esql",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterCount300",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance"]
+        },
+        {
+          "operation": "distanceFilterCount300-esql",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterCount300x400",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterCount300x400-esql",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance", "esql"]
+        },
+        {
           "operation": "distanceSort",
           "warmup-iterations": 200,
           "iterations": 100,
-          "tags": ["distance"]
+          "tags": ["distance", "sort"]
+        },
+        {
+          "operation": "distanceSort-esql",
+          "warmup-iterations": 1,
+          "iterations": 1,
+          "tags": ["distance", "esql", "sort"]
         },
         {
           "operation": "distanceFilterSort",
           "warmup-iterations": 200,
           "iterations": 100,
-          "tags": ["distance"]
+          "tags": ["distance", "sort"]
+        },
+        {
+          "operation": "distanceFilterSort-esql",
+          "warmup-iterations": 1,
+          "iterations": 1,
+          "tags": ["distance", "esql", "sort"]
         },
         {
           "operation": "distanceRange",
           "warmup-iterations": 40,
           "iterations": 20,
-          "tags": ["distance"]
+          "tags": ["distance", "aggs"]
         },
         {
           "operation": "distanceFilterRange",
           "warmup-iterations": 200,
           "iterations": 100,
-          "tags": ["distance"]
+          "tags": ["distance", "aggs"]
         },
         {
           "operation": "geoGrid_geohash",

--- a/geopoint/operations/default.json
+++ b/geopoint/operations/default.json
@@ -252,6 +252,277 @@
       }
     },
     {
+      "name": "distanceFilter-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) <= 400000 | LIMIT 10"
+    },
+    {
+      "name": "distanceFilterEQ",
+      "operation-type": "search",
+      "body": {
+        "size": 10,
+        "query": {
+          "bool": {
+            "must": [
+              {
+                "geo_shape": {
+                  "location": {
+                    "shape": { "type": "circle", "radius": "73204.78m", "coordinates": [7, 55] },
+                    "relation": "intersects"
+                  }
+                }
+              },
+              {
+                "geo_shape": {
+                  "location": {
+                    "shape": { "type": "circle", "radius": "73204.77m", "coordinates": [7, 55] },
+                    "relation": "disjoint"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "distanceFilterEQ-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) == 73204.77053637545 | LIMIT 10"
+    },
+    {
+      "name": "distanceFilterGTE",
+      "operation-type": "search",
+      "body": {
+        "size": 10,
+        "query": {
+          "geo_shape": {
+            "location": {
+              "shape": { "type": "circle", "radius": "400km", "coordinates": [7.0, 55.0] },
+              "relation": "disjoint"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "distanceFilterGTE-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) >= 400000 | LIMIT 10"
+    },
+    {
+      "name": "distanceFilter10kGTE",
+      "operation-type": "search",
+      "body": {
+        "size": 10000,
+        "query": {
+          "geo_shape": {
+            "location": {
+              "shape": { "type": "circle", "radius": "400km", "coordinates": [7.0, 55.0] },
+              "relation": "disjoint"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "distanceFilter10kGTE-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) >= 400000 | LIMIT 10000"
+    },
+    {
+      "name": "distanceFilterCount100",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "geo_distance": {
+            "distance": "100km",
+            "location": [7.0, 55.0]
+          }
+        },
+        "aggs": {
+          "count": {
+          "value_count": {
+            "field": "location"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "distanceFilterCount100-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) <= 100000 | STATS count=COUNT(*)"
+    },
+    {
+      "name": "distanceFilterCount100x200",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "bool": {
+            "must": [
+              {
+                "geo_shape": {
+                  "location": {
+                    "shape": { "type": "circle", "radius": "200km", "coordinates": [7, 55] },
+                    "relation": "intersects"
+                  }
+                }
+              },
+              {
+                "geo_shape": {
+                  "location": {
+                    "shape": { "type": "circle", "radius": "100km", "coordinates": [7, 55] },
+                    "relation": "disjoint"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "aggs": {
+          "count": {
+            "value_count": {
+              "field": "location"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "distanceFilterCount100x200-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) >= 100000 AND ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) <= 200000 | STATS count=COUNT(*)"
+    },
+    {
+      "name": "distanceFilterCount200",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "geo_distance": {
+            "distance": "200km",
+            "location": [7.0, 55.0]
+          }
+        },
+        "aggs": {
+          "count": {
+            "value_count": {
+              "field": "location"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "distanceFilterCount200-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) <= 200000 | STATS count=COUNT(*)"
+    },
+    {
+      "name": "distanceFilterCount200x300",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "bool": {
+            "must": [
+              {
+              "geo_shape": {
+                "location": {
+                    "shape": { "type": "circle", "radius": "300km", "coordinates": [7, 55] },
+                    "relation": "intersects"
+                  }
+                }
+              },
+              {
+                "geo_shape": {
+                  "location": {
+                    "shape": { "type": "circle", "radius": "200km", "coordinates": [7, 55] },
+                    "relation": "disjoint"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "aggs": {
+          "count": {
+            "value_count": {
+              "field": "location"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "distanceFilterCount200x300-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) >= 200000 AND ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) <= 300000 | STATS count=COUNT(*)"
+    },
+    {
+      "name": "distanceFilterCount300",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "geo_distance": {
+            "distance": "300km",
+            "location": [7.0, 55.0]
+          }
+        },
+        "aggs": {
+          "count": {
+            "value_count": {
+              "field": "location"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "distanceFilterCount300-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) <= 300000 | STATS count=COUNT(*)"
+    },
+    {
+      "name": "distanceFilterCount300x400",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "bool": {
+            "must": [
+              {
+                "geo_shape": {
+                  "location": {
+                    "shape": { "type": "circle", "radius": "400km", "coordinates": [7, 55] },
+                    "relation": "intersects"
+                  }
+                }
+              },
+              {
+                "geo_shape": {
+                  "location": {
+                    "shape": { "type": "circle", "radius": "300km", "coordinates": [7, 55] },
+                    "relation": "disjoint"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "aggs": {
+          "count": {
+            "value_count": {
+              "field": "location"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "distanceFilterCount300x400-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | WHERE ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) >= 300000 AND ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) <= 400000 | STATS count=COUNT(*)"
+    },
+    {
       "name": "distanceSort",
       "operation-type": "search",
       "body": {
@@ -268,6 +539,11 @@
           }
         ]
       }
+    },
+    {
+      "name": "distanceSort-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | EVAL distance = ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) | SORT distance ASC | LIMIT 10"
     },
     {
       "name": "distanceFilterSort",
@@ -292,6 +568,11 @@
           }
         ]
       }
+    },
+    {
+      "name": "distanceFilterSort-esql",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints  | EVAL distance = ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) | WHERE distance <= 400000 | SORT distance ASC | LIMIT 10"
     },
     {
       "name": "distanceRange",


### PR DESCRIPTION
Most of these are optimized in main, except two, the ESQL versions of sorting by distance, which we've set to one iteration for now to save on benchmarking time before we do performance optimizations on those.