### PR TITLE
New `large-logs-dataset` challenge in `elastic/logs`

### DIFF
--- a/elastic/logs/challenges/large-logs-dataset.json
+++ b/elastic/logs/challenges/large-logs-dataset.json
@@ -122,9 +122,8 @@
             "rename_replacement": "$1{{ p_snapshot_rename_suffix }}-{{ snapshot_restore_iter }}"
           }
         }
-      } {{ ", " if not loop.last else "" }}
+      },
       {% endfor %}
-      ,
       {
         "name": "reset-recovery-settings-to-defaults",
         "operation": {

--- a/elastic/logs/challenges/large-logs-dataset.json
+++ b/elastic/logs/challenges/large-logs-dataset.json
@@ -113,7 +113,7 @@
           "operation-type": "restore-snapshot",
           "repository": {{ p_snapshot_repo_name | tojson }},
           "snapshot": {{ p_snapshot_name | tojson }},
-          "wait-for-completion": false,
+          "wait-for-completion": true,
           "body": {
             "indices": {{ p_restore_data_streams | tojson }},
             "ignore_unavailable": true,

--- a/elastic/logs/challenges/large-logs-dataset.json
+++ b/elastic/logs/challenges/large-logs-dataset.json
@@ -104,7 +104,7 @@
         "name": "refresh-after-force-merge",
         "index": "logs-*",
         "operation": "refresh"
-      }
+      },
       {%- endif %}
       {% for snapshot_restore_iter in range(p_snapshot_restore_counts) %}
       {

--- a/elastic/logs/challenges/large-logs-dataset.json
+++ b/elastic/logs/challenges/large-logs-dataset.json
@@ -1,0 +1,351 @@
+{% import "rally.helpers" as rally %}
+{
+  "name": "large-logs-dataset",
+  "description": "Applies a query workload after replicating data to increase the datset size. Ensures data streams exist so queries can be run, but does not remove existing data.",
+  "parameters": {
+    "generate-data": {{ true | tojson if bulk_start_date and bulk_end_date else false | tojson }}
+  },
+  "schedule": [
+    {
+      "name": "tune-recovery-settings",
+      "operation": {
+        "operation-type": "raw-request",
+        "method": "PUT",
+        "path": "/_cluster/settings",
+        "body": {
+          "transient": {
+            "indices.recovery.max_bytes_per_sec": {{ p_recovery_max_bytes_per_sec | tojson}},
+            "cluster.routing.allocation.node_concurrent_recoveries": {{ p_node_concurrent_recoveries | tojson }}
+          }
+        }
+      }
+    },
+    {
+      "name": "register-snapshot-repository",
+      "operation": {
+        "operation-type": "create-snapshot-repository",
+        "repository": "{{ p_snapshot_repo_name }}",
+        "body": {
+          "type": {{ p_snapshot_repo_type | tojson }},
+          "settings": {{ p_snapshot_repo_settings | tojson(indent=2)}}
+        }
+      }
+    },
+    {
+      "name": "mount-searchable-snapshot",
+      "operation": {
+        "operation-type": "mount-searchable-snapshot",
+        "repository": "{{ p_snapshot_repo_name }}",
+        "snapshot": "{{ p_snapshot_name }}",
+        "index_pattern": ".ds-logs-*",
+        "rename_pattern": "^.ds-",
+        "rename_replacement": "",
+        "storage": "shared_cache",
+        "ignore_index_settings": ["index.hidden"]
+      }
+    },
+    {% include "tasks/index-setup.json" %},
+    {% if bulk_start_date and bulk_end_date %}
+      {
+        "name": "bulk-index",
+        "operation": {
+          "operation-type": "raw-bulk",
+          "param-source": "processed-source",
+          "time-format": "milliseconds",
+          "profile": "fixed_interval",
+          "init-load": true,
+          "bulk-size": {{ p_bulk_size }},
+          "detailed-results": true
+        },
+        "clients": {{ p_bulk_indexing_clients }},
+        "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+      }
+      {%- if force_merge_max_num_segments is defined %},
+      {
+        "name": "refresh-after-index",
+        "index": "logs-*",
+        "operation": "refresh"
+      },
+      {
+        "name": "wait-until-index-merges-fininshes",
+        "operation": {
+          "operation-type": "index-stats",
+          "index": "logs-*",
+          "condition": {
+            "path": "_all.total.merges.current",
+            "expected-value": 0
+          },
+          "retry-until-success": true,
+          "include-in-reporting": false
+        }
+      },
+      {
+        "operation": {
+          "operation-type": "force-merge",
+          "index": "logs-*",
+          "request-timeout": 36000,
+          "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+        }
+      },
+      {
+        "name": "wait-until-merges-finish",
+        "operation": {
+          "operation-type": "index-stats",
+          "index": "logs-*",
+          "condition": {
+            "path": "_all.total.merges.current",
+            "expected-value": 0
+          },
+          "retry-until-success": true,
+          "include-in-reporting": false
+        }
+      },
+      {
+        "name": "refresh-after-force-merge",
+        "index": "logs-*",
+        "operation": "refresh"
+      }
+      {%- endif %}
+      {% for snapshot_restore_iter in range(p_snapshot_restore_counts) %}
+      {
+        "name": "recover-snapshot-{{ p_snapshot_name }}-{{ snapshot_restore_iter }}",
+        "operation": {
+          "operation-type": "restore-snapshot",
+          "repository": {{ p_snapshot_repo_name | tojson }},
+          "snapshot": {{ p_snapshot_name | tojson }},
+          "wait-for-completion": false,
+          "body": {
+            "indices": {{ p_restore_data_streams | tojson }},
+            "ignore_unavailable": true,
+            "include_global_state": false,
+            "rename_pattern": "(.+)",
+            "rename_replacement": "$1{{ p_snapshot_rename_suffix }}-{{ snapshot_restore_iter }}"
+          }
+        }
+      },
+      {
+        "name": "wait-for-snapshot-recovery-{{ p_snapshot_name }}",
+        "operation": {
+          "operation-type": "wait-for-recovery",
+          "index": {{ (p_restore_data_streams~p_snapshot_rename_suffix) | tojson }}
+        }
+      }
+      {% endfor %},
+      {
+        "name": "reset-recovery-settings-to-defaults",
+        "operation": {
+          "operation-type": "raw-request",
+          "method": "PUT",
+          "path": "/_cluster/settings",
+          "body": {
+            "transient": {
+              "indices.recovery.max_bytes_per_sec": null,
+              "cluster.routing.allocation.node_concurrent_recoveries": null
+            }
+          }
+        }
+      },
+      ,
+    {% endif %}
+    {
+      "operation": "discovery-search-request-size-100",
+      "clients": 1,
+      "warmup-iterations": 0,
+      "iterations": 50
+    },
+    {
+      "operation": "discovery-search-request-size-500",
+      "clients": 1,
+      "warmup-iterations": 0,
+      "iterations": 50
+    },
+
+    {
+      "operation": "discovery-search-request-size-1000",
+      "clients": 1,
+      "warmup-iterations": 0,
+      "iterations": 50
+    },
+    {
+      "name": "logging-queries",
+      "parallel": {
+        "time-period": {{ p_query_time_period }},
+        "warmup-time-period": {{ p_query_warmup_time_period }},
+        "tasks": [
+          {% for workflow in p_query_workflows %}
+            {
+              "name": {{workflow | tojson }},
+              "operation": {
+                "operation-type": "composite",
+                "param-source": "workflow-selector",
+                "workflow": {{workflow | tojson }},
+                "task-offset": {{ loop.index }},
+                "request-params": {{ p_query_request_params | tojson(indent=2) }}
+              },
+              "think-time-interval": {{ p_user_think_time }},
+              "workflow-interval": {{ p_user_workflow_time }},
+              "clients": {{ p_search_clients }},
+              "schedule": "workflow-scheduler"
+            }{{ ", " if not loop.last else "" }}
+          {% endfor %}
+        ]
+      }
+    }{%- if p_include_esql_queries %},
+    {
+      "operation": "esql_basic_count_group_0_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "limit0"]
+    },
+    {
+      "operation": "esql_basic_count_group_1_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "limit0"]
+    },
+    {
+      "operation": "esql_basic_count_group_2_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "limit0"]
+    },
+    {
+      "operation": "esql_basic_count_group_3_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "limit0"]
+    },
+    {
+      "operation": "esql_basic_count_group_4_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "limit0"]
+    },
+    {
+      "operation": "esql_time_range_and_date_histogram_two_groups_pre_filter_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "limit0"]
+    },
+    {
+      "operation": "esql_time_range_and_date_histogram_two_groups_post_filter_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "limit0"]
+    },
+    {
+      "operation": "esql_dissect_duration_and_stats_limit_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "limit0"]
+    },
+    {
+      "operation": "esql_basic_count_group_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "count"]
+    },
+    {
+      "operation": "esql_basic_count_group_1",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "count"]
+    },
+    {
+      "operation": "esql_basic_count_group_2",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 20,
+      "tags": ["esql", "count"]
+    },
+    {
+      "operation": "esql_basic_count_group_3",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 10,
+      "tags": ["esql", "count"]
+    },
+    {
+      "operation": "esql_basic_count_group_4",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 10,
+      "tags": ["esql", "count"]
+    },
+    {
+      "operation": "esql_time_range_and_date_histogram_two_groups_pre_filter",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 20,
+      "tags": ["esql", "date_histogram"]
+    },
+    {
+      "operation": "esql_time_range_and_date_histogram_two_groups_post_filter",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 20,
+      "tags": ["esql", "date_histogram"]
+    },
+    {
+      "operation": "esql_dissect_duration_and_stats",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 20,
+      "tags": ["esql", "dissect"]
+    }{%- if build_flavor != "serverless" or serverless_operator == true %},
+    {
+      "operation": "disable_query_cache",
+      "tags": ["esql", "settings"]
+    },
+    {
+      "operation": "search_basic_count_group_0",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "count", "search"]
+    },
+    {
+      "operation": "search_basic_count_group_1",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "count", "search"]
+    },
+    {
+      "operation": "search_basic_count_group_2",
+      "clients": 1,
+      "warmup-iterations": 2,
+      "iterations": 5,
+      "tags": ["esql", "count", "search"]
+    },
+    {
+      "operation": "search_basic_count_group_3",
+      "clients": 1,
+      "warmup-iterations": 1,
+      "iterations": 3,
+      "tags": ["esql", "count", "search"]
+    },
+    {
+      "operation": "search_basic_count_group_4",
+      "clients": 1,
+      "warmup-iterations": 1,
+      "iterations": 3,
+      "tags": ["esql", "count", "search"]
+    },
+    {
+      "operation": "enable_query_cache",
+      "tags": ["esql", "settings"]
+    }{%- endif %}
+    {%- endif %}
+  ]
+}

--- a/elastic/logs/challenges/large-logs-dataset.json
+++ b/elastic/logs/challenges/large-logs-dataset.json
@@ -104,42 +104,51 @@
         "name": "refresh-after-force-merge",
         "index": "logs-*",
         "operation": "refresh"
-      },
+      }
       {%- endif %}
-      {% for snapshot_restore_iter in range(p_snapshot_restore_counts) %}
+      {# non-serverless-index-statistics-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%},
       {
-        "name": "recover-snapshot-{{ p_snapshot_name }}-{{ snapshot_restore_iter }}",
+        "name": "compression-stats",
         "operation": {
-          "operation-type": "restore-snapshot",
-          "repository": {{ p_snapshot_repo_name | tojson }},
-          "snapshot": {{ p_snapshot_name | tojson }},
-          "wait-for-completion": true,
-          "body": {
-            "indices": {{ p_restore_data_streams | tojson }},
-            "ignore_unavailable": true,
-            "include_global_state": false,
-            "rename_pattern": "(.+)",
-            "rename_replacement": "$1{{ p_snapshot_rename_suffix }}-{{ snapshot_restore_iter }}"
-          }
+          "operation-type": "compression-statistics",
+          "param-source": "create-datastream-source"
         }
-      },
-      {% endfor %}
-      {
-        "name": "reset-recovery-settings-to-defaults",
-        "operation": {
-          "operation-type": "raw-request",
-          "method": "PUT",
-          "path": "/_cluster/settings",
-          "body": {
-            "transient": {
-              "indices.recovery.max_bytes_per_sec": null,
-              "cluster.routing.allocation.node_concurrent_recoveries": null
-            }
-          }
-        }
-      },
+      }
+      {%- endif -%}{# non-serverless-index-statistics-marker-end #}
       ,
     {% endif %}
+    {% for snapshot_restore_iter in range(p_snapshot_restore_counts) %}
+    {
+      "name": "recover-snapshot-{{ p_snapshot_name }}-{{ snapshot_restore_iter }}",
+      "operation": {
+        "operation-type": "restore-snapshot",
+        "repository": {{ p_snapshot_repo_name | tojson }},
+        "snapshot": {{ p_snapshot_name | tojson }},
+        "wait-for-completion": true,
+        "body": {
+          "indices": {{ p_restore_data_streams | tojson }},
+          "ignore_unavailable": true,
+          "include_global_state": false,
+          "rename_pattern": "(.+)",
+          "rename_replacement": "$1{{ p_snapshot_rename_suffix }}-{{ snapshot_restore_iter }}"
+        }
+      }
+    },
+    {% endfor %}
+    {
+      "name": "reset-recovery-settings-to-defaults",
+      "operation": {
+        "operation-type": "raw-request",
+        "method": "PUT",
+        "path": "/_cluster/settings",
+        "body": {
+          "transient": {
+            "indices.recovery.max_bytes_per_sec": null,
+            "cluster.routing.allocation.node_concurrent_recoveries": null
+          }
+        }
+      }
+    },
     {
       "operation": "discovery-search-request-size-100",
       "clients": 1,

--- a/elastic/logs/challenges/large-logs-dataset.json
+++ b/elastic/logs/challenges/large-logs-dataset.json
@@ -122,15 +122,9 @@
             "rename_replacement": "$1{{ p_snapshot_rename_suffix }}-{{ snapshot_restore_iter }}"
           }
         }
-      },
-      {
-        "name": "wait-for-snapshot-recovery-{{ p_snapshot_name }}",
-        "operation": {
-          "operation-type": "wait-for-recovery",
-          "index": {{ (p_restore_data_streams~p_snapshot_rename_suffix) | tojson }}
-        }
-      }
-      {% endfor %},
+      } {{ ", " if not loop.last else "" }}
+      {% endfor %}
+      ,
       {
         "name": "reset-recovery-settings-to-defaults",
         "operation": {

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -42,9 +42,10 @@
 {% set p_restore_data_streams = (restore_data_streams | default("logs-*")) %}
 {% set p_snapshot_metadata = (snapshot_metadata | default({}))%}
 {% set p_snapshot_rename_suffix = (snapshot_rename_suffix | default("") ) %}
+{% set p_snapshot_restore_counts = (snapshot_restore_counts | default(100) ) %}
 {% set p_dsl_poll_interval = (dsl_poll_interval | default(false) ) %}
 {% set p_dsl_default_rollover = (dsl_default_rollover | default(false) ) %}
-
+{% set p_skip_fleet_globals = (skip_fleet_globals | default(false) ) %}
 {% set p_worker_threads_enabled = (worker_threads_enabled | default(true))  %}
 
 {% set es_version = "7.13.2" %}
@@ -200,11 +201,13 @@
         "template-path": "component_template"
 
     },
+    {% if p_skip_fleet_globals == false %}
     {
         "name": ".fleet_globals-1",
         "template": "./templates/component/.fleet_globals-1.json",
         "template-path": "component_template"
     },
+    {% endif %}
     {
         "name": "logs-apache.access@package",
         "template": "./templates/component/logs-apache.access@package.json",


### PR DESCRIPTION
Introduce a new `large-logs-dataset` challenge to `elastic/logs` track which duplicates data indexed by restoring
a snapshot multiple times. The number of snapshot restore operations is controlled by the variable `snapshot_restore_counts` which by default has a value of `100`.

This would result in indexing `raw_data_volume_per_day` bytes multiplied by `snapshot_restore_counts`.
As an example if `raw_data_volume_per_day` is 50 GB then the index will have about 5 TB of raw data.
Note that the index, anyway, will include duplicated data.

This is meant to be used just as a fast way to increase the amount of data in an index skipping the expensive data
generation and indexing process.

Resolves #631 