### PR TITLE
Update msmarco-passage-ranking track to use sparse_vector instead of weighted_tokens

### DIFF
--- a/msmarco-passage-ranking/msmarco-passage-ranking-collection.json
+++ b/msmarco-passage-ranking/msmarco-passage-ranking-collection.json
@@ -8,10 +8,10 @@
                 "type": "text"
             },
             "text_expansion_elser": {
-                "type": "rank_features"
+                "type": "sparse_vector"
             },
             "text_expansion_splade": {
-                "type": "rank_features"
+                "type": "sparse_vector"
             }
         }
     },

--- a/msmarco-passage-ranking/track.py
+++ b/msmarco-passage-ranking/track.py
@@ -81,43 +81,24 @@ def generate_combine_bm25_weighted_terms_query(
 
 
 def generate_pruned_query(field, query_expansion, boost=1.0):
-    return {
-        "query": {
-            "weighted_tokens": {
-                f"{field}": {
-                    "tokens": query_expansion,
-                    "pruning_config": {"tokens_freq_ratio_threshold": 5, "tokens_weight_threshold": 0.4, "only_score_pruned_tokens": False},
-                    "boost": boost,
-                }
-            }
-        }
-    }
+    return {"query": {"sparse_vector": {"field": field, "query_vector": query_expansion, "prune": True, "boost": boost}}}
 
 
 def generate_rescored_pruned_query(field, query_expansion, num_candidates, boost=1.0):
     return {
-        "query": {
-            "weighted_tokens": {
-                f"{field}": {
-                    "tokens": query_expansion,
-                    "pruning_config": {"tokens_freq_ratio_threshold": 5, "tokens_weight_threshold": 0.4, "only_score_pruned_tokens": False},
-                    "boost": boost,
-                }
-            }
-        },
+        "query": {"sparse_vector": {"field": field, "query_vector": query_expansion, "prune": True, "boost": boost}},
         "rescore": {
             "window_size": num_candidates,
             "query": {
                 "rescore_query": {
-                    "weighted_tokens": {
-                        f"{field}": {
-                            "tokens": query_expansion,
-                            "pruning_config": {
-                                "tokens_freq_ratio_threshold": 5,
-                                "tokens_weight_threshold": 0.4,
-                                "only_score_pruned_tokens": True,
-                            },
-                        }
+                    "sparse_vector": {
+                        "field": field,
+                        "query_vector": query_expansion,
+                        "prune": True,
+                        "pruning_config": {
+                            "only_score_pruned_tokens": True,
+                        },
+                        "boost": boost,
                     }
                 }
             },


### PR DESCRIPTION
Example command to test: 
```
esrally race --kill-running-processes --preserve-install --track-path=msmarco-passage-ranking --on-error=abort  --test-mode
```
Requires 8.15.0 or higher