### PR TITLE
Add exclude to query ruleset benchmarks

### DIFF
--- a/wikipedia/ids.txt
+++ b/wikipedia/ids.txt
@@ -1,0 +1,1000 @@
+AccessibleComputing
+Anarchism
+AfghanistanHistory
+AfghanistanGeography
+AfghanistanPeople
+AfghanistanCommunications
+AfghanistanTransportations
+AfghanistanMilitary
+AfghanistanTransnationalIssues
+AssistiveTechnology
+AmoeboidTaxa
+Autism
+AlbaniaHistory
+AlbaniaPeople
+AsWeMayThink
+AlbaniaGovernment
+AlbaniaEconomy
+Albedo
+AfroAsiaticLanguages
+ArtificalLanguages
+AbacuS
+AbalonE
+ʿAbbādid
+AbbesS
+AbbevilleFrance
+AbbeY
+AbboT
+Abbreviations
+AtlasShrugged
+ArtificialLanguages
+AtlasShruggedCharacters
+AtlasShruggedCompanies
+AyersMusicPublishingCompany
+AfricanAmericanPeople
+AdolfHitler
+AbeceDarians
+AbeL
+AbensbergGermany
+AberdeenSouthDakota
+ArthurKoestler
+AynRand
+AlexanderTheGreat
+AnchorageAlaska
+ArgumentForms
+ArgumentsForTheExistenceOfGod
+AnarchY
+AsciiArt
+AcademyAwards
+AcademyAwards/BestPicture
+AustriaLanguage
+AcademicElitism
+AxiomOfChoice
+AmericanFootball
+AmericA
+AnnaKournikova
+AndorrA
+AustroAsiaticLanguages
+ActresseS
+A
+AnarchoCapitalism
+AnarchoCapitalists
+ActressesS
+AnAmericanInParis
+AutoMorphism
+ActionFilm
+Alabama
+AfricA
+Achilles
+AppliedStatistics
+Abraham Lincoln
+Aristotle
+An American in Paris
+Academy Award for Best Production Design
+Academy Awards
+Action Film
+Actrius
+Animalia (book)
+International Atomic Time
+Altruism
+AutoRacing
+Ayn Rand
+Alain Connes
+Allan Dwan
+Algeria/People
+Algeria/Transnational Issues
+Algeria
+List of Atlas Shrugged characters
+Topics of note in Atlas Shrugged
+Anthropology
+Agricultural science
+Alchemy
+Alien
+Astronomer
+Ameboid stage
+ASCII
+Ashmore And Cartier Islands
+Austin (disambiguation)
+Animation
+Apollo
+Andre Agassi
+Artificial languages
+Austroasiatic languages
+Afro-asiatic languages
+Afroasiatic languages
+Andorra
+Andorra/Transnational issues
+Arithmetic mean
+American Football Conference
+Albert Gore
+AnEnquiryConcerningHumanUnderstanding
+Animal Farm
+Amphibian
+Albert Arnold Gore/Criticisms
+Alaska
+Auteur Theory Film
+Agriculture
+Aldous Huxley
+Abstract Algebra
+Ada
+Aberdeen (disambiguation)
+Algae
+Analysis of variance
+ANOVA
+Alkane
+Appellate procedure in the United States
+Answer (law)
+Appellate court
+Arithmetic and logic unit
+Actress
+Arraignment
+America the Beautiful
+Assistive technology
+Accessible computing
+Abacus
+Acid
+Bitumen
+American National Standards Institute
+Argument (disambiguation)
+Apollo 11
+Apollo 8
+Astronaut
+A Modest Proposal
+Alkali metal
+Argument form
+Allotrope
+Alphabet
+Atomic number
+Anatomy
+Affirming the consequent
+Andrei Tarkovsky
+Ambiguity
+Abel
+Animal (disambiguation)
+Aardvark
+Aardwolf
+Adobe
+Adventure
+Amaltheia
+Analysis of Variance
+Asia
+Aruba
+Articles of Confederation
+Archaeology/Broch
+Asia Minor (disambiguation)
+Aa River
+Atlantic Ocean
+Arthur Schopenhauer
+Angola
+Demographics of Angola
+Politics of Angola
+Economy of Angola
+Transport in Angola
+Angolan Armed Forces
+Foreign relations of Angola
+Albert Sidney Johnston
+Android (robot)
+Alberta
+Wikipedia:Adding Wikipedia articles to Nupedia
+Astronomy/History
+List of anthropologists
+Astronomy and Astrophysics/History
+Actinopterygii
+Al Gore/Criticisms
+Albert Einstein
+Afghanistan
+Albania
+Allah
+Algorithms (journal)
+Antigua And Barbuda
+Azerbaijan
+Amateur astronomy
+Astronomers and Astrophysicists
+Aikido
+Art
+Albania/History
+Albania/Transnational Issues
+Albania/People
+Albania/Foreign relations
+Agnostida
+Abortion
+Abstract (law)
+A.E. van Vogt
+American Revolutionary War
+Ampere
+Algorithm
+Annual plant
+Anthophyta
+Atlas (disambiguation)
+Mouthwash
+Alexander the Great
+Alfred Korzybski
+Asteroids (video game)
+Asparagales
+Alismatales
+Apiales
+Asterales
+Asteroid
+Allocution
+Affidavit
+Aries (constellation)
+Aquarius (constellation)
+Anime
+Asterism
+Ankara
+Arabic
+AlbaniaCommunications
+Alfred Hitchcock
+Anaconda
+Afghanistan/History
+Afghanistan/Geography
+Afghanistan/Government
+Afghanistan/People
+Afghanistan/Economy
+Afghanistan/Communications
+Afghanistan/Military
+Afghanistan/Transnational Issues
+Afghanistan (1911 Encyclopedia)
+Altaic languages
+Austrian German
+Austria/Transnational issues
+Anglican Church
+Axiom of choice
+Attila
+Aegean Sea
+A Clockwork Orange (novel)
+Amsterdam
+Museum of Work
+Audi
+Aircraft
+Alfred Nobel
+Alexander Graham Bell
+Anatolia
+Abiotic factors
+Apple Inc.
+Aberdeenshire
+AU
+Aztlan Underground
+Aland
+American Civil War
+Andy Warhol
+Alp Arslan
+American Film Institute
+Akira Kurosawa
+Ancient civilization
+Ancient Egypt
+Analog Brothers
+Motor neuron diseases
+Abjad
+Abugida
+ABBA
+Allegiance
+Absolute majority
+Altenberg
+MessagePad
+A. E. van Vogt
+Anna Kournikova
+Accountancy
+Alfons Maria Jakob
+Agnosticism
+Argon
+Arsenic
+Antimony
+Actinium
+Americium
+Astatine
+Atom
+Arable land
+Aluminium
+Advanced Chemistry
+Awk
+AgoraNomic
+Anglican Communion
+Arne Kaijser
+Archipelago
+Author
+Andrey Markov
+Anti-semitism
+Anti-semitic
+Angst
+Anxiety
+A.A. Milne
+A. A. Milne
+Asociación Alumni
+Alumna
+Axiom
+Alpha
+Alvin Toffler
+The Amazing Spider-Man
+AM
+Automated Alice/XII
+Automated Alice/XI
+Automated Alice/X
+Automated Alice/IX
+Automated Alice/VIII
+Automated Alice/VI
+Automated Alice/VII
+Automated Alice/V
+Automated Alice/IV
+Automated Alice/II
+Automated Alice/I
+Automated Alice/III
+Antigua and Barbuda
+Azincourt
+Albert Speer
+Asteraceae
+Apiaceae
+Axon
+Agma
+Aramaic alphabet
+Arguments for the existence of God
+American shot
+Acute disseminated encephalomyelitis
+Ataxia
+AmbientCalculusOnline
+Abdul Alhazred
+A priori and a posterior knowledge
+Ada Lovelace
+AmbientCalculiOnline
+August Derleth
+Alps
+A priori and a posteriori knowledge
+Albert Camus
+Agatha Christie
+The Plague (novel)
+Applied ethics
+Absolute value
+Analog signal
+Arecales
+Hercule Poirot
+Miss Marple
+April
+August
+Aaron
+April 6
+April 12
+April 15
+April 30
+August 22
+August 27
+Alcohol (chemistry)
+Achill Island
+Allen Ginsberg
+Algebraically closed field
+August 6
+Anatoly Karpov
+Aspect ratio
+Auto racing
+Anarcho-capitalism
+Anarcho-capitalists
+August 9
+Aristophanes
+Albert Schweitzer
+Austrian school of economics
+Abscess
+Aal
+Aalborg Municipality
+Aarhus
+Northern cavefish
+Abatement
+Amateur
+Alexis Carrel
+All Souls' Day
+Anatole France
+André Gide
+Applied statistics
+Analysis of variance/Random effects models
+Analysis of variance/Degrees of freedom
+Algorithms for calculating variance
+Almond
+Demographics of Antigua and Barbuda
+Politics of Antigua and Barbuda
+Telecommunications in Antigua and Barbuda
+Antigua and Barbuda Defence Force
+Antigua and Barbuda/Transnational issues
+Antisemitism
+Economy of Azerbaijan
+Geography of Azerbaijan
+Azerbaijan/People
+Azerbaijan/Communications
+Foreign relations of Azerbaijan
+Azerbaijani Armed Forces
+Azerbaijan/Foreign relations
+Geography of Armenia
+Demographics of Armenia
+Politics of Armenia
+Economy of Armenia
+Transport in Armenia
+Armed Forces of Armenia
+Foreign relations of Armenia
+Argentina/Transnational issues
+Argentina/Foreign relations
+Geography of American Samoa
+Demographics of American Samoa
+Politics of American Samoa
+Economy of American Samoa
+Transportation in American Samoa
+American Samoa/Military
+Australia/Transnational issues
+August 13
+Avicenna
+The Ashes
+Analysis
+Abner Doubleday
+America's National Game
+Amplitude modulation
+Augustin-Jean Fresnel
+Abbot
+Ardipithecus
+Assembly line
+Adelaide
+AK47
+Alan Garner
+Amhrann na bhFiann
+August 2
+Atlantic (disambiguation)
+Algebraic number
+Automorphism
+Accordion
+Artificial intelligence
+Afro Celt Sound System
+Ancient philosophy
+Anaximander
+APL
+Architect
+Abbreviation
+Aphrodite
+April 1
+Antisymmetric relation
+Aleister Crowley
+Afterlife
+Astrometry
+Athena
+Amber Diceless Roleplaying Game
+Athene (disambiguation)
+AphexTwin
+Alloy
+Articles of Faith
+Alternative history
+Artistic revolution
+Agrarianism
+Atomic
+Allotropes
+Angle
+Asa
+Acoustics
+Angle tribe
+Atomic physics
+American Sign Language
+Applet
+Alternate history
+Atomic orbitals
+Atomic orbital
+Amino acid
+Alan Turing
+Area
+Astronomical unit
+Artist
+Actaeon
+Anglicanism
+Athens
+Anguilla
+Anguilla/Transnational issues
+Anguilla/Military
+Telecommunications in Anguilla
+Ashmore and Cartier Islands
+Ashmore and Cartier Islands/Geography
+Ashmore and Cartier Islands/People
+Ashmore and Cartier Islands/Government
+Ashmore and Cartier Islands/Transportation
+Ashmore and Cartier Islands/Economy
+Ashmore and Cartier Islands/Military
+Acoustic theory
+Alexander Mackenzie (politician)
+Atomic bomb
+Ashoka
+American (word)
+Ada (programming language)
+Alpha ray
+Alfonso Aráu
+Alfonso Cuarón
+Arianism
+August 1
+Astronomical Units
+Antoninus Pius
+August 3
+Advanced Encryption Standard
+April 26
+Argot
+Anisotropy
+Alpha decay
+AI
+Extreme poverty
+Analytical engine
+Augustus
+Geography of Antarctica
+Economy of Antarctica
+Government of Antarctica
+Transport in Antarctica
+Military of Antarctica
+Geography of Alabama
+List of governors of Alabama
+Apocrypha
+Antartic Treaty
+Antarctic Treaty System
+Algernon Swinburne
+Alfred Lawson
+ALCS
+Apocrypha/Tanakh
+Ames, Iowa
+Abbadides
+Abalone
+Abbess
+Human abdomen
+Abdominal surgery
+Abduction
+Abensberg
+Arminianism
+The Alan Parsons Project
+Almost all
+Ada Byron's notes on the analytical engine
+Augustine
+Aromatic compound
+Abbey
+Annales school
+Antimatter
+Antonio Gaudi/Sagrada Familia
+Casa Batlló
+Park Güell
+Casa Milà
+Antiparticle
+A.D.
+Arabian Prince
+August 7
+August 8
+April 16
+Associative property
+The Apache Software Foundation
+Americans with Disabilities Act of 1990
+Americans with Disabilities Act of 1990/Findings and Purposes
+Americans with Disabilities Act of 1990/Definitions
+Americans with Disabilities Act of 1990/Title III
+A.D
+Apple I
+Apache webserver
+Apatosaurus
+Allosaurus
+AK-47
+Atanasoff–Berry computer
+Andes
+Anderida
+Ancylopoda
+Anchor
+Anbar (town)
+Anazarbus
+Anagram
+Anadyr (river)
+André-Marie Ampère
+Ammonia
+Amethyst
+Albertosaurus
+Assembly language
+Ambrosia
+Ambrose
+Ambracia
+Amber
+Amalaric
+Alphorn
+Army
+Alligatoridae
+Alder
+Amos Bronson Alcott
+Arachnophobia
+Alabaster
+Ahab
+ASIC (disambiguation)
+Dasyproctidae
+Algol
+Amazing Grace
+AOL
+ADHD
+Anno Domini
+AV
+Amino group
+Antony van Leeuwenhook
+Alcuin
+Angilbert
+Antony van Leeuwenhoek
+Amine
+Adrian I
+April 29
+August 14
+Absolute zero
+Adiabatic process
+Amide
+Animism
+Antonio Vivaldi
+Adrian II
+Adrian
+Adrian IV
+Aare
+Abgar
+Abbotsford, Scottish Borders
+Abraham
+Abraxas
+Absalom
+Abydos
+Abydos, Egypt
+Abydos (Hellespont)
+August 15
+Acacia sensu lato
+Acapulco
+August 16
+Alan Kay
+APL (programming language)
+ALGOL
+AWK
+Alzheimers disease
+Ascorbic Acid
+Asgard
+Apollo program
+Assault
+Australian Prime Ministers
+Álfheimr
+Ask and Embla
+Alabama River
+Alain de Lille
+Alemanni
+NYSE American
+August 17
+August 12
+Alfred Russel Wallace
+Australian Labor Party
+August 18
+August 19
+August 21
+Dodo (Alice's Adventures in Wonderland)
+Lory (disambiguation)
+Eaglet (Alice's Adventures in Wonderland)
+Albert
+Albert I
+Albert II
+Albert III
+Albert Alcibiades, Margrave of Brandenburg-Kulmbach
+Albert the Bear
+Albert I of Hapsburg
+Albert of Brandenburg
+Albert, Duke of Prussia
+Albert III, Elector of Saxony
+Albert the Degenerate
+Albert Of Aix
+August 25
+Aachen
+Agate
+Aspirin
+Abner
+Ahmed I
+Ahmed II
+Ahmed III
+Ainu people
+Aix-la-Chapelle
+Acorn (fruit of the oak tree)
+Acropolis
+Acupuncture
+Adder (disambiguation)
+Adirondacks
+Aeneas
+April 13
+Amaranth
+Agapanthus africanus
+Agamemnon
+Aga Khan I
+Aga Khan III
+Agasias
+Alexander Agassiz
+Agathon
+Agesilaus II
+Agis
+Antonio Agliardi
+Agnes of Merania
+Agrippina the Elder
+Agrippina the Younger
+American Chinese cuisine
+Ahenobarbus
+Ahmad Shah Durrani
+Aidan of Dalriada
+Arthur Aikin
+Ailanthus
+Aimoin
+Akkadian Empire
+Ajax the Lesser
+Ajax the Great
+Ajax
+Alaric I
+Alaric II
+Albategnius
+Albertus Magnus
+Alboin
+Afonso de Albuquerque
+Alcaeus of Mytilene
+Alcamenes
+Alcmene
+Alcidamas
+Aldine Press
+Ealdred (archbishop of York)
+Alexander I of Epirus
+Alexander Balas
+Alexander of Pherae
+Alexander II of Epirus
+Alexander Jagiellon
+Alexander III of Russia
+Alexander I of Scotland
+Alexander II of Scotland
+Alexander I of Serbia
+Alexander III of Scotland
+Alexander of Greece (disambiguation)
+Alexander of Aphrodisias
+Severus Alexander
+Alexander
+Alexander I
+Alexander II
+Alexander III
+Alexander Aetolus
+Alexander Jannaeus
+Alexander IV
+Alexander V
+Alexander VI
+Alexander VII
+Alexander VIII
+Alexandrists
+Alexios I Komnenos
+Alexis (poet)
+Alexios II Komnenos
+Alexios III Angelos
+Alexios V Doukas
+Alexei Petrovich, Tsarevich of Russia
+Andrew Jackson
+Andrew Johnson
+Aleksandr Solzhenitsyn
+Aleksandr Isaevich Solzhenitsyn
+Aberdeen
+August 23
+August 24
+Antipope
+Aquaculture
+Kolmogorov complexity
+Antoine de Saint-Exupery
+Hymn to Proserpine
+The Triumph of Time
+April 28
+Alfred the Great
+Alfred Ernest Albert
+Alessandro Algardi
+Alger of Liège
+Algiers
+Ibn al-Haytham
+Alessandro Allori
+Almoravid dynasty
+Aloe
+Alured of Berkeley
+Alyattes
+Age of consent
+Alypius of Antioch
+Amalasuintha
+Amalric of Bena
+Afonso I of Portugal
+Afonso II of Portugal
+Afonso III of Portugal
+Afonso IV of Portugal
+Afonso V of Portugal
+Afonso VI of Portugal
+Alphonso I of Spain
+Alfonso II of Asturias
+Amarasimha
+Alphonso VIII of Spain
+Alfonso IX of Spain
+Alfonso XII
+Alfonso XIII
+Alphonsus a Sancta Maria
+Alfonso the Battler
+Amaryllis
+Amasis I
+Alfonso III of Aragon
+Alfonso IV of Aragon
+Amasis II
+Alfonso V of Aragon
+Amathus
+Alphons
+Alfonso I
+Amati
+Alfonso II
+Alfonso III
+Alfonso IV
+Amazons
+Alfonso V
+Ambergris
+Ambiorix
+Alfonso VI
+August Wilhelm Ambros
+Amazon River
+Alfred of Beverley
+Alphonso VII
+Alphonso VIII
+Alphonso IX
+Alphonso X
+Alphonso XI
+Alphonso XII
+Alphonso XIII
+April 22
+August 31
+Autpert Ambrose
+Abu Bakr
+Ambrose Traversari
+Ambrosians
+Ambrosiaster
+Ambrosius Aurelianus
+Ammon
+Ammonius Hermiae
+Ammonius Saccas
+Book of Amos
+Amphipolis
+Amram
+Amyntas I of Macedon
+Amyntas III of Macedon
+Anacharsis
+Anacreon (poet)
+Anah
+Ānanda
+Anaxagoras
+Anaxarchus
+Ancyra (planthopper)
+Anastasius I
+Anastasius II
+Anastasius III
+Anastasius IV
+Anaximenes of Lampsacus
+Anastasius
+Anaximenes of Miletus
+Ancus Marcius
+Andaman Islands
+Alexander Anderson (mathematician)
+Andocides
+Andrea Andreani
+Andrew II of Hungary
+An Enquiry Concerning Human Understanding
+André de Longjumeau
+Andriscus
+Andronikos III Palaiologos
+Andronikos II Palaiologos
+Andronikos I Komnenos
+Andronicus of Cyrrhus
+Andronicus of Rhodes
+Andronicus
+Asteroid Belt
+Ammianus Marcellinus
+ALICE
+An Enquiry Concerning Human Understanding/Text
+Apollo 13
+Apollo Program
+Arthritus
+Apollo 7
+Apollo 9
+Applied discrete math
+Arthritis
+April 2
+Acetylene
+Alfred
+August 28
+Arabic numerals
+April 9
+ABM
+Apuleius
+Alexander Selkirk
+Anti-ballistic missile
+August 29
+August 30
+Acre
+ATP
+Adenosine triphosphate
+Ægir
+Antibiotic
+Arnold Schwarzenegger
+ASA
+Aquinas
+Actium
+Amide hydrolysis
+Amway
+Adam Smith
+Antoine Laurent Lavoisier
+Antoine Lavoisier
+A roll
+Hermann Kolbe
+April 18
+April 23
+Amitabh Bachchan
+Air Pollution
+Antarctic-Environmental Protocol
+Allomorph
+American bias
+Allophone
+Affix
+Allegory
+Amazon river
+Allotropy
+Agathocles of Syracuse
+Economy of Alberta
+Augustin-Louis Cauchy
+Archimedes
+Alternative medicine
+Archimedean solid
+Antiprism
+Ancient Greeks
+Natural history of Africa
+Geography of Africa
+Africa/History
+Approval voting
+Aromatic hydrocarbon
+Arizona State University
+April 14
+Astoria, Oregon
+Alarums and Excursions
+Alfred Jarry
+Amalric
+Amalric of Jerusalem
+Aimery of Cyprus
+Anthemius of Tralles
+Absalon
+Adhemar of Le Puy
+Adhemar de Chabannes
+Albigenses
+Alphonse, Count of Poitiers
+Alfonso Jordan
+Ambroise
+Art Deco
+ASCII art
+Autoerotic asphyxiation
+Alexius
+Ban on assault rifles
+American English
+Albert Spalding
+Africa Alphabet
+Acquire
+Australian English
+American Airlines Flight 77
+American Airlines flight 77
+American Airlines flight 11
+Ambush
+Astronomical aberration
+Abzyme
+Adaptive radiation
+Agarose gel electrophoresis
+Allele
+Ampicillin
+Annealing
+Antimicrobial resistance
+Antigen
+Autosome
+Antwerp (disambiguation)
+Aquila
+Al-Qaeda
+Alessandro Volta
+Argo Navis
+Andromeda (mythology)
+Antlia
+Ara (constellation)
+Auriga
+Arkansas
+Atmosphere (disambiguation)
+Apus
+Abadan, Iran
+Attorney
+Astronomical Unit
+Alexander Fleming
+Andrew Carnegie
+Approximant
+Astronomer Royal
+Aeon
+Airline
+Australian Democrats
+Australian Capital Territory
+Unit of alcohol

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -197,7 +197,7 @@ class PinnedSearchParamSource(QueryIteratorParamSource):
                     "query": {
                         "pinned": {
                             "organic": {"query_string": {"query": query, "default_field": self._params["search-fields"]}},
-                            "ids": [self.ids],
+                            "ids": [random.choice(self.ids)],
                         }
                     },
                     "size": self._params["size"],

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -32,7 +32,7 @@ def query_samples(k: int, random_seed: int = None) -> List[str]:
 
 
 # ids file was created with the following command: grep _index pages-1k.json | jq .index._id | tr -d '"' | grep -v null > ids.txt
-def ids_samples() -> list[str]:
+def ids_samples() -> List[str]:
     with open(SAMPLE_IDS_FILENAME, "r") as file:
         ids = {line.strip() for line in file}
     for i in range(100):

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -29,10 +29,11 @@ def query_samples(k: int, random_seed: int = None) -> List[str]:
         random.seed(random_seed)
 
         return random.choices(queries, weights=probabilities, k=k)
-    
+
+
 # ids file was created with the following command: grep _index pages-1k.json | jq .index._id | tr -d '"' | grep -v null > ids.txt
 def ids_samples() -> list[str]:
-    with open(SAMPLE_IDS_FILENAME, 'r') as file:
+    with open(SAMPLE_IDS_FILENAME, "r") as file:
         ids = {line.strip() for line in file}
     for i in range(100):
         ids.add(f"missing-id-{i}")
@@ -151,7 +152,7 @@ class CreateQueryRulesetParamSource(ParamSource):
             rules.append(rule)
 
         return {"method": "PUT", "path": f"{QUERY_RULES_ENDPOINT}/{self.query_ruleset_params.ruleset_id}", "body": {"rules": rules}}
-    
+
 
 class QueryRulesSearchParamSource(QueryIteratorParamSource):
     def __init__(self, track, params, **kwargs):

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -10,6 +10,7 @@ from esrally.track.params import ParamSource
 
 QUERIES_DIRNAME: str = dirname(__file__)
 QUERIES_FILENAME: str = f"{QUERIES_DIRNAME}/queries.csv"
+SAMPLE_IDS_FILENAME: str = f"{QUERIES_DIRNAME}/ids.txt"
 
 SEARCH_APPLICATION_ROOT_ENDPOINT: str = "/_application/search_application"
 QUERY_RULES_ENDPOINT: str = "/_query_rules"
@@ -28,6 +29,14 @@ def query_samples(k: int, random_seed: int = None) -> List[str]:
         random.seed(random_seed)
 
         return random.choices(queries, weights=probabilities, k=k)
+    
+# ids file was created with the following command: grep _index pages-1k.json | jq .index._id | tr -d '"' | grep -v null > ids.txt
+def ids_samples() -> list[str]:
+    with open(SAMPLE_IDS_FILENAME, 'r') as file:
+        ids = {line.strip() for line in file}
+    for i in range(100):
+        ids.add(f"missing-id-{i}")
+    return list(ids)
 
 
 class SearchApplicationParams:
@@ -130,19 +139,19 @@ class CreateQueryRulesetParamSource(ParamSource):
         return self
 
     def params(self):
+        ids = ids_samples()
         rules = []
         for i in range(self.query_ruleset_params.ruleset_size):
-            # Note: `AccessibleComputing` is one of the _ids indexed in the dataset
             rule = {
                 "rule_id": "rule_{{i}}",
-                "type": "pinned",
+                "type": random.choice(["pinned", "exclude"]),
                 "criteria": [{"type": "exact", "metadata": "rule_key", "values": [random.choice(["match", "no-match"])]}],
-                "actions": {"ids": [random.choice(["AccessibleComputing", "pinned-miss"])]},
+                "actions": {"ids": [random.choice(ids)]},
             }
             rules.append(rule)
 
         return {"method": "PUT", "path": f"{QUERY_RULES_ENDPOINT}/{self.query_ruleset_params.ruleset_id}", "body": {"rules": rules}}
-
+    
 
 class QueryRulesSearchParamSource(QueryIteratorParamSource):
     def __init__(self, track, params, **kwargs):
@@ -152,7 +161,6 @@ class QueryRulesSearchParamSource(QueryIteratorParamSource):
     def params(self):
         try:
             query = next(self._queries_iterator)
-            # TODO Update this to use current syntax with 8.15.0+
             return {
                 "method": "POST",
                 "path": "/_search",
@@ -176,6 +184,7 @@ class PinnedSearchParamSource(QueryIteratorParamSource):
     def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)
         self.query_ruleset_params = QueryRulesetParams(track, params)
+        self.ids = ids_samples()
 
     def params(self):
         try:
@@ -187,7 +196,7 @@ class PinnedSearchParamSource(QueryIteratorParamSource):
                     "query": {
                         "pinned": {
                             "organic": {"query_string": {"query": query, "default_field": self._params["search-fields"]}},
-                            "ids": [random.choice(["AccessibleComputing", "pinned-miss"])],
+                            "ids": [self.ids],
                         }
                     },
                     "size": self._params["size"],


### PR DESCRIPTION
Adds `exclude` query rules to our query ruleset benchmarking, and loads additional random IDs to include in rulesets for query building. 

Note: Requires `8.16.0-SNAPSHOT` or later. 

Sample command to run this: 
```
esrally race --kill-running-processes --preserve-install --track-path=wikipedia --on-error=abort --car="4gheap,trial-license"  --test-mode
```