### PR TITLE
Add a retriever test with optional rerank

### DIFF
--- a/wikipedia/challenges/default.json
+++ b/wikipedia/challenges/default.json
@@ -149,6 +149,20 @@
           }
         ]
       }
+    },
+    {
+      "name": "standalone-retriever-search",
+      "operation": "retriever-search",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "standalone-retriever-search-with-rerank",
+      "operation": "retriever-search-with-rerank",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
     }
   ]
 }

--- a/wikipedia/operations/default.json
+++ b/wikipedia/operations/default.json
@@ -146,4 +146,20 @@
   "param-source": "query-string-search",
   "size" : {{ query_string_search_page_size | default(20) | int }},
   "search-fields" : "{{ query_string_search_fields | default("*") }}"
+},
+{
+  "name": "retriever-search",
+  "operation-type": "raw-request",
+  "param-source": "retriever-search",
+  "size" : {{ retriever_search_page_size | default(20) | int }},
+  "search-fields" : "{{ retriever_search_fields | default("*") }}"
+},
+{
+  "name": "retriever-search-with-rerank",
+  "operation-type": "raw-request",
+  "param-source": "retriever-search",
+  "size" : {{ retriever_search_page_size | default(20) | int }},
+  "search-fields" : "{{ retriever_search_fields | default("*") }}",
+  "rerank": "True",
+  "reranker": "random_reranker"
 }

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -206,7 +206,8 @@ class PinnedSearchParamSource(QueryIteratorParamSource):
         except StopIteration:
             self._queries_iterator = iter(self._sample_queries)
             return self.params()
-        
+
+
 class RetrieverParamSource(QueryIteratorParamSource):
     def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)
@@ -217,35 +218,23 @@ class RetrieverParamSource(QueryIteratorParamSource):
     def params(self):
 
         standard_retriever = {
-            "standard": {
-                "query": {
-                    "query_string": {
-                        "query": next(self._queries_iterator), "default_field": self._params["search-fields"]
-                    }
-                }
-            }
+            "standard": {"query": {"query_string": {"query": next(self._queries_iterator), "default_field": self._params["search-fields"]}}}
         }
-        
+
         retriever = standard_retriever
-        if (self._rerank):
-            retriever = {
-                self._reranker: {
-                    "retriever": standard_retriever
-                }
-            }
-        
+        if self._rerank:
+            retriever = {self._reranker: {"retriever": standard_retriever}}
+
         try:
             return {
                 "method": "POST",
                 "path": f"/{self._index_name}/_search",
-                "body": {
-                    "retriever": retriever,
-                    "size": self._params["size"]
-                },
+                "body": {"retriever": retriever, "size": self._params["size"]},
             }
         except StopIteration:
             self._queries_iterator = iter(self._sample_queries)
             return self.params()
+
 
 def register(registry):
     registry.register_param_source("query-string-search", QueryParamSource)

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -223,7 +223,7 @@ class RetrieverParamSource(QueryIteratorParamSource):
 
         retriever = standard_retriever
         if self._rerank:
-            retriever = {self._reranker: {"retriever": standard_retriever}}
+            retriever = {self._reranker: {"retriever": standard_retriever, "field": self._params["search-fields"]}}
 
         try:
             return {

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -218,7 +218,6 @@ class RetrieverParamSource(QueryIteratorParamSource):
         self._size = params.get("size", 20)
 
     def params(self):
-
         standard_retriever = {
             "standard": {"query": {"query_string": {"query": next(self._queries_iterator), "default_field": self._search_fields}}}
         }


### PR DESCRIPTION
Adds retriever and retriever with rerank challenges to the Wikipedia track in Rally. 

Sample output running `esbench` against 8.16.0-SNAPSHOT: 

```
    ______     __                    __  
   / ____/____/ /_  ___  ____  _____/ /_ 
  / __/ / ___/ __ \/ _ \/ __ \/ ___/ __ \
 / /___(__  ) /_/ /  __/ / / / /__/ / / /
/_____/____/_.___/\___/_/ /_/\___/_/ /_/ 
                                         

ssh esbench@44.211.77.207 -o StrictHostKeyChecking=accept-new -tt
Welcome to Ubuntu 18.04.6 LTS (GNU/Linux 5.4.0-1103-aws aarch64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Wed Aug 21 12:35:52 UTC 2024

  System load:  0.0                Processes:              253
  Usage of /:   1.9% of 193.63GB   Users logged in:        1
  Memory usage: 1%                 IP address for ens5:    10.10.27.180
  Swap usage:   0%                 IP address for docker0: 172.17.0.1


Expanded Security Maintenance for Infrastructure is not enabled.

10 updates can be applied immediately.
3 of these updates are standard security updates.
To see these additional updates run: apt list --upgradable

127 additional security updates can be applied with ESM Infra.
Learn more about enabling ESM Infra service for Ubuntu 18.04 at
https://ubuntu.com/18-04

New release '20.04.6 LTS' available.
Run 'do-release-upgrade' to upgrade to it.


Last login: Wed Aug 21 00:06:51 2024 from 10.10.27.180
esbench@rally-0:~$ tail -n200 ~/.rally/logs/rally.log 
|                                           Heap used for points |                                                 |      0           |     MB |
|                                    Heap used for stored fields |                                                 |      0           |     MB |
|                                                  Segment count |                                                 |     86           |        |
|                                    Total Ingest Pipeline count |                                                 |      0           |        |
|                                     Total Ingest Pipeline time |                                                 |      0           |      s |
|                                   Total Ingest Pipeline failed |                                                 |      0           |        |
|                                                 Min Throughput |                      initial-documents-indexing |   1646.2         | docs/s |
|                                                Mean Throughput |                      initial-documents-indexing |   2220.22        | docs/s |
|                                              Median Throughput |                      initial-documents-indexing |   2251.9         | docs/s |
|                                                 Max Throughput |                      initial-documents-indexing |   2498.88        | docs/s |
|                                        50th percentile latency |                      initial-documents-indexing |    294.203       |     ms |
|                                        90th percentile latency |                      initial-documents-indexing |    595.675       |     ms |
|                                        99th percentile latency |                      initial-documents-indexing |   8146.32        |     ms |
|                                      99.9th percentile latency |                      initial-documents-indexing |  10833.5         |     ms |
|                                     99.99th percentile latency |                      initial-documents-indexing |  10996.3         |     ms |
|                                       100th percentile latency |                      initial-documents-indexing |  11001.4         |     ms |
|                                   50th percentile service time |                      initial-documents-indexing |    294.59        |     ms |
|                                   90th percentile service time |                      initial-documents-indexing |    592.841       |     ms |
|                                   99th percentile service time |                      initial-documents-indexing |   8290.09        |     ms |
|                                 99.9th percentile service time |                      initial-documents-indexing |  10834.6         |     ms |
|                                99.99th percentile service time |                      initial-documents-indexing |  10996.3         |     ms |
|                                  100th percentile service time |                      initial-documents-indexing |  11001.4         |     ms |
|                                                     error rate |                      initial-documents-indexing |      0.57        |      % |
|                                                 Min Throughput |                  standalone-query-string-search |     61.31        |  ops/s |
|                                                Mean Throughput |                  standalone-query-string-search |   1862.98        |  ops/s |
|                                              Median Throughput |                  standalone-query-string-search |   2228.32        |  ops/s |
|                                                 Max Throughput |                  standalone-query-string-search |   3250.88        |  ops/s |
|                                        50th percentile latency |                  standalone-query-string-search |      3.04031     |     ms |
|                                        90th percentile latency |                  standalone-query-string-search |      4.44581     |     ms |
|                                        99th percentile latency |                  standalone-query-string-search |     85.2975      |     ms |
|                                      99.9th percentile latency |                  standalone-query-string-search |    231.233       |     ms |
|                                     99.99th percentile latency |                  standalone-query-string-search |    358.489       |     ms |
|                                       100th percentile latency |                  standalone-query-string-search |    945.597       |     ms |
|                                   50th percentile service time |                  standalone-query-string-search |      3.03987     |     ms |
|                                   90th percentile service time |                  standalone-query-string-search |      4.38636     |     ms |
|                                   99th percentile service time |                  standalone-query-string-search |     87.1011      |     ms |
|                                 99.9th percentile service time |                  standalone-query-string-search |    230.682       |     ms |
|                                99.99th percentile service time |                  standalone-query-string-search |    360.386       |     ms |
|                                  100th percentile service time |                  standalone-query-string-search |    945.597       |     ms |
|                                                     error rate |                  standalone-query-string-search |      0           |      % |
|                                                 Min Throughput |               default-search-application-search |    137.45        |  ops/s |
|                                                Mean Throughput |               default-search-application-search |    161.48        |  ops/s |
|                                              Median Throughput |               default-search-application-search |    163.01        |  ops/s |
|                                                 Max Throughput |               default-search-application-search |    164.45        |  ops/s |
|                                        50th percentile latency |               default-search-application-search |    108.322       |     ms |
|                                        90th percentile latency |               default-search-application-search |    195.045       |     ms |
|                                        99th percentile latency |               default-search-application-search |    314.58        |     ms |
|                                      99.9th percentile latency |               default-search-application-search |    438.146       |     ms |
|                                     99.99th percentile latency |               default-search-application-search |    652.144       |     ms |
|                                       100th percentile latency |               default-search-application-search |   1007.09        |     ms |
|                                   50th percentile service time |               default-search-application-search |    108.411       |     ms |
|                                   90th percentile service time |               default-search-application-search |    195.577       |     ms |
|                                   99th percentile service time |               default-search-application-search |    314.761       |     ms |
|                                 99.9th percentile service time |               default-search-application-search |    440.644       |     ms |
|                                99.99th percentile service time |               default-search-application-search |    658.12        |     ms |
|                                  100th percentile service time |               default-search-application-search |   1007.09        |     ms |
|                                                     error rate |               default-search-application-search |      0           |      % |
|                                                 Min Throughput |                            query-rules-search-1 |    142.27        |  ops/s |
|                                                Mean Throughput |                            query-rules-search-1 |    144.73        |  ops/s |
|                                              Median Throughput |                            query-rules-search-1 |    144.69        |  ops/s |
|                                                 Max Throughput |                            query-rules-search-1 |    145.56        |  ops/s |
|                                        50th percentile latency |                            query-rules-search-1 |    124.316       |     ms |
|                                        90th percentile latency |                            query-rules-search-1 |    222.599       |     ms |
|                                        99th percentile latency |                            query-rules-search-1 |    364.919       |     ms |
|                                      99.9th percentile latency |                            query-rules-search-1 |    486.245       |     ms |
|                                     99.99th percentile latency |                            query-rules-search-1 |    661.321       |     ms |
|                                       100th percentile latency |                            query-rules-search-1 |   1108.4         |     ms |
|                                   50th percentile service time |                            query-rules-search-1 |    123.92        |     ms |
|                                   90th percentile service time |                            query-rules-search-1 |    222.395       |     ms |
|                                   99th percentile service time |                            query-rules-search-1 |    365.27        |     ms |
|                                 99.9th percentile service time |                            query-rules-search-1 |    487.082       |     ms |
|                                99.99th percentile service time |                            query-rules-search-1 |    661.321       |     ms |
|                                  100th percentile service time |                            query-rules-search-1 |   1108.4         |     ms |
|                                                     error rate |                            query-rules-search-1 |      0           |      % |
|                                                 Min Throughput |                           query-rules-search-10 |     19.43        |  ops/s |
|                                                Mean Throughput |                           query-rules-search-10 |     20.1         |  ops/s |
|                                              Median Throughput |                           query-rules-search-10 |     20.08        |  ops/s |
|                                                 Max Throughput |                           query-rules-search-10 |     21.52        |  ops/s |
|                                        50th percentile latency |                           query-rules-search-10 |    794.379       |     ms |
|                                        90th percentile latency |                           query-rules-search-10 |   1940.71        |     ms |
|                                        99th percentile latency |                           query-rules-search-10 |   3269.15        |     ms |
|                                      99.9th percentile latency |                           query-rules-search-10 |   4239.27        |     ms |
|                                       100th percentile latency |                           query-rules-search-10 |   5185.12        |     ms |
|                                   50th percentile service time |                           query-rules-search-10 |    794.738       |     ms |
|                                   90th percentile service time |                           query-rules-search-10 |   1939.43        |     ms |
|                                   99th percentile service time |                           query-rules-search-10 |   3272.92        |     ms |
|                                 99.9th percentile service time |                           query-rules-search-10 |   4239.27        |     ms |
|                                  100th percentile service time |                           query-rules-search-10 |   5185.12        |     ms |
|                                                     error rate |                           query-rules-search-10 |      0           |      % |
|                                                 Min Throughput |                          query-rules-search-100 |     19.95        |  ops/s |
|                                                Mean Throughput |                          query-rules-search-100 |     20.7         |  ops/s |
|                                              Median Throughput |                          query-rules-search-100 |     20.61        |  ops/s |
|                                                 Max Throughput |                          query-rules-search-100 |     22.9         |  ops/s |
|                                        50th percentile latency |                          query-rules-search-100 |    790.969       |     ms |
|                                        90th percentile latency |                          query-rules-search-100 |   1892.36        |     ms |
|                                        99th percentile latency |                          query-rules-search-100 |   3069.36        |     ms |
|                                      99.9th percentile latency |                          query-rules-search-100 |   3944.23        |     ms |
|                                       100th percentile latency |                          query-rules-search-100 |   4395.49        |     ms |
|                                   50th percentile service time |                          query-rules-search-100 |    790.803       |     ms |
|                                   90th percentile service time |                          query-rules-search-100 |   1893.48        |     ms |
|                                   99th percentile service time |                          query-rules-search-100 |   3078.39        |     ms |
|                                 99.9th percentile service time |                          query-rules-search-100 |   3944.23        |     ms |
|                                  100th percentile service time |                          query-rules-search-100 |   4395.49        |     ms |
|                                                     error rate |                          query-rules-search-100 |      0           |      % |
|                                                 Min Throughput |                         query-rules-search-1000 |     19.75        |  ops/s |
|                                                Mean Throughput |                         query-rules-search-1000 |     20.22        |  ops/s |
|                                              Median Throughput |                         query-rules-search-1000 |     20.19        |  ops/s |
|                                                 Max Throughput |                         query-rules-search-1000 |     21.04        |  ops/s |
|                                        50th percentile latency |                         query-rules-search-1000 |    804.434       |     ms |
|                                        90th percentile latency |                         query-rules-search-1000 |   1893.42        |     ms |
|                                        99th percentile latency |                         query-rules-search-1000 |   3195.78        |     ms |
|                                      99.9th percentile latency |                         query-rules-search-1000 |   4045.85        |     ms |
|                                       100th percentile latency |                         query-rules-search-1000 |   4330.54        |     ms |
|                                   50th percentile service time |                         query-rules-search-1000 |    803.229       |     ms |
|                                   90th percentile service time |                         query-rules-search-1000 |   1891.12        |     ms |
|                                   99th percentile service time |                         query-rules-search-1000 |   3192.89        |     ms |
|                                 99.9th percentile service time |                         query-rules-search-1000 |   4045.85        |     ms |
|                                  100th percentile service time |                         query-rules-search-1000 |   4330.54        |     ms |
|                                                     error rate |                         query-rules-search-1000 |      0           |      % |
|                                                 Min Throughput |                                   pinned-search |     19.4         |  ops/s |
|                                                Mean Throughput |                                   pinned-search |     20.06        |  ops/s |
|                                              Median Throughput |                                   pinned-search |     19.94        |  ops/s |
|                                                 Max Throughput |                                   pinned-search |     23.88        |  ops/s |
|                                        50th percentile latency |                                   pinned-search |    812.227       |     ms |
|                                        90th percentile latency |                                   pinned-search |   1978.88        |     ms |
|                                        99th percentile latency |                                   pinned-search |   3251.95        |     ms |
|                                      99.9th percentile latency |                                   pinned-search |   4673.84        |     ms |
|                                       100th percentile latency |                                   pinned-search |   6430.52        |     ms |
|                                   50th percentile service time |                                   pinned-search |    811.855       |     ms |
|                                   90th percentile service time |                                   pinned-search |   1983.66        |     ms |
|                                   99th percentile service time |                                   pinned-search |   3253.93        |     ms |
|                                 99.9th percentile service time |                                   pinned-search |   4673.84        |     ms |
|                                  100th percentile service time |                                   pinned-search |   6430.52        |     ms |
|                                                     error rate |                                   pinned-search |      0           |      % |
|                                                 Min Throughput |                parallel-documents-indexing-bulk |     67.79        | docs/s |
|                                                Mean Throughput |                parallel-documents-indexing-bulk |     69.76        | docs/s |
|                                              Median Throughput |                parallel-documents-indexing-bulk |     68.69        | docs/s |
|                                                 Max Throughput |                parallel-documents-indexing-bulk |     77.33        | docs/s |
|                                        50th percentile latency |                parallel-documents-indexing-bulk | 117896           |     ms |
|                                        90th percentile latency |                parallel-documents-indexing-bulk | 204823           |     ms |
|                                       100th percentile latency |                parallel-documents-indexing-bulk | 227418           |     ms |
|                                   50th percentile service time |                parallel-documents-indexing-bulk |   3753.16        |     ms |
|                                   90th percentile service time |                parallel-documents-indexing-bulk |   4415.66        |     ms |
|                                  100th percentile service time |                parallel-documents-indexing-bulk |   4694.95        |     ms |
|                                                     error rate |                parallel-documents-indexing-bulk |      0           |      % |
|                                                 Min Throughput | parallel-documents-indexing-query-string-search |    164.83        |  ops/s |
|                                                Mean Throughput | parallel-documents-indexing-query-string-search |    201.16        |  ops/s |
|                                              Median Throughput | parallel-documents-indexing-query-string-search |    175.89        |  ops/s |
|                                                 Max Throughput | parallel-documents-indexing-query-string-search |    566.08        |  ops/s |
|                                        50th percentile latency | parallel-documents-indexing-query-string-search |    121.806       |     ms |
|                                        90th percentile latency | parallel-documents-indexing-query-string-search |    227.53        |     ms |
|                                        99th percentile latency | parallel-documents-indexing-query-string-search |    375.323       |     ms |
|                                      99.9th percentile latency | parallel-documents-indexing-query-string-search |    532.528       |     ms |
|                                     99.99th percentile latency | parallel-documents-indexing-query-string-search |    974.269       |     ms |
|                                       100th percentile latency | parallel-documents-indexing-query-string-search |   1194.42        |     ms |
|                                   50th percentile service time | parallel-documents-indexing-query-string-search |    121.444       |     ms |
|                                   90th percentile service time | parallel-documents-indexing-query-string-search |    226.695       |     ms |
|                                   99th percentile service time | parallel-documents-indexing-query-string-search |    375.811       |     ms |
|                                 99.9th percentile service time | parallel-documents-indexing-query-string-search |    532.504       |     ms |
|                                99.99th percentile service time | parallel-documents-indexing-query-string-search |    974.308       |     ms |
|                                  100th percentile service time | parallel-documents-indexing-query-string-search |   1194.42        |     ms |
|                                                     error rate | parallel-documents-indexing-query-string-search |      0           |      % |
|                                                 Min Throughput |                     standalone-retriever-search |    136.99        |  ops/s |
|                                                Mean Throughput |                     standalone-retriever-search |    144.12        |  ops/s |
|                                              Median Throughput |                     standalone-retriever-search |    144.5         |  ops/s |
|                                                 Max Throughput |                     standalone-retriever-search |    144.96        |  ops/s |
|                                        50th percentile latency |                     standalone-retriever-search |    124.825       |     ms |
|                                        90th percentile latency |                     standalone-retriever-search |    222.576       |     ms |
|                                        99th percentile latency |                     standalone-retriever-search |    360.666       |     ms |
|                                      99.9th percentile latency |                     standalone-retriever-search |    491.335       |     ms |
|                                     99.99th percentile latency |                     standalone-retriever-search |    647.179       |     ms |
|                                       100th percentile latency |                     standalone-retriever-search |    966.833       |     ms |
|                                   50th percentile service time |                     standalone-retriever-search |    124.682       |     ms |
|                                   90th percentile service time |                     standalone-retriever-search |    222.176       |     ms |
|                                   99th percentile service time |                     standalone-retriever-search |    360.822       |     ms |
|                                 99.9th percentile service time |                     standalone-retriever-search |    492.939       |     ms |
|                                99.99th percentile service time |                     standalone-retriever-search |    647.179       |     ms |
|                                  100th percentile service time |                     standalone-retriever-search |    966.833       |     ms |
|                                                     error rate |                     standalone-retriever-search |      0           |      % |
|                                                 Min Throughput |         standalone-retriever-search-with-rerank |    133.41        |  ops/s |
|                                                Mean Throughput |         standalone-retriever-search-with-rerank |    138.19        |  ops/s |
|                                              Median Throughput |         standalone-retriever-search-with-rerank |    138.15        |  ops/s |
|                                                 Max Throughput |         standalone-retriever-search-with-rerank |    139.48        |  ops/s |
|                                        50th percentile latency |         standalone-retriever-search-with-rerank |    130.448       |     ms |
|                                        90th percentile latency |         standalone-retriever-search-with-rerank |    233.096       |     ms |
|                                        99th percentile latency |         standalone-retriever-search-with-rerank |    376.354       |     ms |
|                                      99.9th percentile latency |         standalone-retriever-search-with-rerank |    507.779       |     ms |
|                                     99.99th percentile latency |         standalone-retriever-search-with-rerank |    705.915       |     ms |
|                                       100th percentile latency |         standalone-retriever-search-with-rerank |    795.822       |     ms |
|                                   50th percentile service time |         standalone-retriever-search-with-rerank |    130.079       |     ms |
|                                   90th percentile service time |         standalone-retriever-search-with-rerank |    234.015       |     ms |
|                                   99th percentile service time |         standalone-retriever-search-with-rerank |    376.128       |     ms |
|                                 99.9th percentile service time |         standalone-retriever-search-with-rerank |    508.115       |     ms |
|                                99.99th percentile service time |         standalone-retriever-search-with-rerank |    705.915       |     ms |
|                                  100th percentile service time |         standalone-retriever-search-with-rerank |    795.822       |     ms |
|                                                     error rate |         standalone-retriever-search-with-rerank |      0           |      % |

```