### PR TITLE
Introduce an `index_mode` param into the `elastic/security` Rally track

### DIFF
--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -1,0 +1,11 @@
+{
+  "template": {
+    "settings": {
+      {% if index_mode %}
+      "index": {
+          "mode": {{ index_mode | tojson }}
+      }
+      {% endif %}
+    }
+  }
+}

--- a/elastic/security/templates/composable/.logs-endpoint.action.responses.json
+++ b/elastic/security/templates/composable/.logs-endpoint.action.responses.json
@@ -24,7 +24,8 @@
       ".logs-endpoint.action.responses@package",
       ".logs-endpoint.action.responses@custom",
       ".fleet_globals-1",
-      ".fleet_agent_id_verification-1"
+      ".fleet_agent_id_verification-1",
+      "track-shared-logsdb-mode"
     ],
     "priority": 200,
     "_meta": {

--- a/elastic/security/templates/composable/.logs-endpoint.actions.json
+++ b/elastic/security/templates/composable/.logs-endpoint.actions.json
@@ -24,7 +24,8 @@
       ".logs-endpoint.actions@package",
       ".logs-endpoint.actions@custom",
       ".fleet_globals-1",
-      ".fleet_agent_id_verification-1"
+      ".fleet_agent_id_verification-1",
+      "track-shared-logsdb-mode"
     ],
     "priority": 200,
     "_meta": {

--- a/elastic/security/templates/composable/.logs-endpoint.diagnostic.collection.json
+++ b/elastic/security/templates/composable/.logs-endpoint.diagnostic.collection.json
@@ -24,7 +24,8 @@
       ".logs-endpoint.diagnostic.collection@package",
       ".logs-endpoint.diagnostic.collection@custom",
       ".fleet_globals-1",
-      ".fleet_agent_id_verification-1"
+      ".fleet_agent_id_verification-1",
+      "track-shared-logsdb-mode"
     ],
     "priority": 200,
     "_meta": {

--- a/elastic/security/templates/composable/logs-endpoint.alerts.json
+++ b/elastic/security/templates/composable/logs-endpoint.alerts.json
@@ -24,7 +24,8 @@
       "logs-endpoint.alerts@package",
       "logs-endpoint.alerts@custom",
       ".fleet_globals-1",
-      ".fleet_agent_id_verification-1"
+      ".fleet_agent_id_verification-1",
+      "track-shared-logsdb-mode"
     ],
     "priority": 200,
     "_meta": {

--- a/elastic/security/templates/composable/logs-endpoint.events.file.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.file.json
@@ -24,7 +24,8 @@
       "logs-endpoint.events.file@package",
       "logs-endpoint.events.file@custom",
       ".fleet_globals-1",
-      ".fleet_agent_id_verification-1"
+      ".fleet_agent_id_verification-1",
+      "track-shared-logsdb-mode"
     ],
     "priority": 200,
     "_meta": {

--- a/elastic/security/templates/composable/logs-endpoint.events.library.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.library.json
@@ -24,7 +24,8 @@
       "logs-endpoint.events.library@package",
       "logs-endpoint.events.library@custom",
       ".fleet_globals-1",
-      ".fleet_agent_id_verification-1"
+      ".fleet_agent_id_verification-1",
+      "track-shared-logsdb-mode"
     ],
     "priority": 200,
     "_meta": {

--- a/elastic/security/templates/composable/logs-endpoint.events.network.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.network.json
@@ -24,7 +24,8 @@
       "logs-endpoint.events.network@package",
       "logs-endpoint.events.network@custom",
       ".fleet_globals-1",
-      ".fleet_agent_id_verification-1"
+      ".fleet_agent_id_verification-1",
+      "track-shared-logsdb-mode"
     ],
     "priority": 200,
     "_meta": {

--- a/elastic/security/templates/composable/logs-endpoint.events.process.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.process.json
@@ -24,7 +24,8 @@
       "logs-endpoint.events.process@package",
       "logs-endpoint.events.process@custom",
       ".fleet_globals-1",
-      ".fleet_agent_id_verification-1"
+      ".fleet_agent_id_verification-1",
+      "track-shared-logsdb-mode"
     ],
     "priority": 200,
     "_meta": {

--- a/elastic/security/templates/composable/logs-endpoint.events.registry.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.registry.json
@@ -24,7 +24,8 @@
       "logs-endpoint.events.registry@package",
       "logs-endpoint.events.registry@custom",
       ".fleet_globals-1",
-      ".fleet_agent_id_verification-1"
+      ".fleet_agent_id_verification-1",
+      "track-shared-logsdb-mode"
     ],
     "priority": 200,
     "_meta": {

--- a/elastic/security/templates/composable/logs-endpoint.events.security.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.security.json
@@ -24,7 +24,8 @@
       "logs-endpoint.events.security@package",
       "logs-endpoint.events.security@custom",
       ".fleet_globals-1",
-      ".fleet_agent_id_verification-1"
+      ".fleet_agent_id_verification-1",
+      "track-shared-logsdb-mode"
     ],
     "priority": 200,
     "_meta": {

--- a/elastic/security/templates/composable/security-auditbeat.json
+++ b/elastic/security/templates/composable/security-auditbeat.json
@@ -8106,7 +8106,7 @@
       }
     }
   },
-  "composed_of" : ["track-custom-mappings"],
+  "composed_of" : ["track-custom-mappings", "track-shared-logsdb-mode"],
   "priority" : 150,
   "data_stream" : { }
 }

--- a/elastic/security/templates/composable/security-filebeat.json
+++ b/elastic/security/templates/composable/security-filebeat.json
@@ -29071,7 +29071,7 @@
       }
     }
   },
-  "composed_of" : ["track-custom-mappings"],
+  "composed_of" : ["track-custom-mappings", "track-shared-logsdb-mode"],
   "priority" : 150,
   "data_stream" : { }
 }

--- a/elastic/security/templates/composable/security-metricbeat.json
+++ b/elastic/security/templates/composable/security-metricbeat.json
@@ -29619,7 +29619,7 @@
       "date_detection" : false
     }
   },
-  "composed_of" : ["track-custom-mappings"],
+  "composed_of" : ["track-custom-mappings", "track-shared-logsdb-mode"],
   "priority" : 150,
   "data_stream" : { }
 }

--- a/elastic/security/templates/composable/security-packetbeat.json
+++ b/elastic/security/templates/composable/security-packetbeat.json
@@ -8973,7 +8973,7 @@
       }
     }
   },
-  "composed_of" : ["track-custom-mappings"],
+  "composed_of" : ["track-custom-mappings", "track-shared-logsdb-mode"],
   "priority" : 150,
   "data_stream" : { }
 }

--- a/elastic/security/templates/composable/security-winlogbeat.json
+++ b/elastic/security/templates/composable/security-winlogbeat.json
@@ -7317,7 +7317,7 @@
       }
     }
   },
-  "composed_of" : ["track-custom-mappings"],
+  "composed_of" : ["track-custom-mappings", "track-shared-logsdb-mode"],
   "priority" : 150,
   "data_stream" : { }
 }

--- a/elastic/security/track.json
+++ b/elastic/security/track.json
@@ -93,6 +93,10 @@
   ],
   "component-templates": [
     {
+      "name": "track-shared-logsdb-mode",
+      "template": "./templates/component/track-shared-logsdb-mode.json"
+    },
+    {
       "name": "track-custom-mappings",
       "template": "./templates/component/track-custom-mappings.json"
     },


### PR DESCRIPTION
The `index_mode` parameter will be used to run Rally benchmarks comparing
indexing using `standard` and `logsdb` mode for the `elastic/security` track.

Enabling LogsDB is done by means of a component template which is added and
later used if the `index_mode` is provided. In case it is missing no index mode
will be used which will default to `standard`.