### PR TITLE
Allow skipping delete of fleet component template

### DIFF
--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -44,6 +44,7 @@
 {% set p_snapshot_rename_suffix = (snapshot_rename_suffix | default("") ) %}
 {% set p_dsl_poll_interval = (dsl_poll_interval | default(false) ) %}
 {% set p_dsl_default_rollover = (dsl_default_rollover | default(false) ) %}
+{% set p_skip_fleet_globals = (skip_fleet_globals | default(false) ) %}
 
 {% set p_worker_threads_enabled = (worker_threads_enabled | default(true))  %}
 
@@ -200,11 +201,13 @@
         "template-path": "component_template"
 
     },
+    {% if p_skip_fleet_globals == false %}
     {
         "name": ".fleet_globals-1",
         "template": "./templates/component/.fleet_globals-1.json",
         "template-path": "component_template"
     },
+    {% endif %}
     {
         "name": "logs-apache.access@package",
         "template": "./templates/component/logs-apache.access@package.json",


### PR DESCRIPTION
The fleet component template is used when we try to delete it. Here we introduce a parameter that allows us to skip deletion of the component template. The default value is false, which means normally we attempt to delete it. Setting it explicitly to true we avoid deleting it. This prevents errors happening if we try to delete it and it is in use.


This needs to be backported to Elasticsearch 8.15.