### PR TITLE
Disallow usage of ilm lifecycle for serverless

### DIFF
--- a/elastic/security/templates/component/logs-endpoint.events.file@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.file@package.json
@@ -5,19 +5,11 @@
       "settings": {
         "index": {
           {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
-              "settings": {
-                "index": {
-                  "lifecycle": {
-                    "name": "logs"
-                  }
-                }
-              }
+            "lifecycle": {
+              "name": "logs"
+            },
           {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
-          "settings": {
-            "index": {
-              "lifecycle": {}
-            }
-          },
+              "lifecycle": {},
           {%- endif -%}
           "codec": "best_compression",
           "mapping": {

--- a/elastic/security/templates/component/logs-endpoint.events.file@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.file@package.json
@@ -4,9 +4,21 @@
     "template": {
       "settings": {
         "index": {
-          "lifecycle": {
-            "name": "logs"
+          {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+              "settings": {
+                "index": {
+                  "lifecycle": {
+                    "name": "logs"
+                  }
+                }
+              }
+          {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+          "settings": {
+            "index": {
+              "lifecycle": {}
+            }
           },
+          {%- endif -%}
           "codec": "best_compression",
           "mapping": {
             "total_fields": {

--- a/elastic/security/templates/component/logs-endpoint.events.file@settings.json
+++ b/elastic/security/templates/component/logs-endpoint.events.file@settings.json
@@ -2,9 +2,13 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
+        {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          "lifecycle": {
+            "name": "logs"
+          },
+        {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+            "lifecycle": {},
+        {%- endif -%}
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/security/templates/component/logs-endpoint.events.library@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.library@package.json
@@ -4,7 +4,7 @@
     "template": {
       "settings": {
         "index": {
-          {{% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
             "lifecycle": {
               "name": "logs"
             },

--- a/elastic/security/templates/component/logs-endpoint.events.library@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.library@package.json
@@ -4,9 +4,13 @@
     "template": {
       "settings": {
         "index": {
-          "lifecycle": {
-            "name": "logs"
-          },
+          {{% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+            "lifecycle": {
+              "name": "logs"
+            },
+          {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+              "lifecycle": {},
+          {%- endif -%}
           "codec": "best_compression",
           "mapping": {
             "total_fields": {

--- a/elastic/security/templates/component/logs-endpoint.events.library@settings.json
+++ b/elastic/security/templates/component/logs-endpoint.events.library@settings.json
@@ -2,9 +2,13 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
+        {{% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          "lifecycle": {
+            "name": "logs"
+          },
+        {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+            "lifecycle": {},
+        {%- endif -%}
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/security/templates/component/logs-endpoint.events.library@settings.json
+++ b/elastic/security/templates/component/logs-endpoint.events.library@settings.json
@@ -2,7 +2,7 @@
   "template": {
     "settings": {
       "index": {
-        {{% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+        {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
           "lifecycle": {
             "name": "logs"
           },

--- a/elastic/security/templates/component/logs-endpoint.events.network@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.network@package.json
@@ -4,9 +4,13 @@
     "template": {
       "settings": {
         "index": {
-          "lifecycle": {
-            "name": "logs"
-          },
+          {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+            "lifecycle": {
+              "name": "logs"
+            },
+          {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+              "lifecycle": {},
+          {%- endif -%}
           "codec": "best_compression",
           "mapping": {
             "total_fields": {

--- a/elastic/security/templates/component/logs-endpoint.events.network@settings.json
+++ b/elastic/security/templates/component/logs-endpoint.events.network@settings.json
@@ -2,9 +2,13 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
+        {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          "lifecycle": {
+            "name": "logs"
+          },
+        {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+            "lifecycle": {},
+        {%- endif -%}
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/security/templates/component/logs-endpoint.events.process@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.process@package.json
@@ -4,9 +4,13 @@
     "template": {
       "settings": {
         "index": {
-          "lifecycle": {
-            "name": "logs"
-          },
+          {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+            "lifecycle": {
+              "name": "logs"
+            },
+          {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+              "lifecycle": {},
+          {%- endif -%}
           "codec": "best_compression",
           "mapping": {
             "total_fields": {

--- a/elastic/security/templates/component/logs-endpoint.events.process@settings.json
+++ b/elastic/security/templates/component/logs-endpoint.events.process@settings.json
@@ -2,9 +2,13 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
+        {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          "lifecycle": {
+            "name": "logs"
+          },
+        {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+            "lifecycle": {},
+        {%- endif -%}
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/security/templates/component/logs-endpoint.events.registry@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.registry@package.json
@@ -4,9 +4,13 @@
     "template": {
       "settings": {
         "index": {
-          "lifecycle": {
-            "name": "logs"
-          },
+          {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+            "lifecycle": {
+              "name": "logs"
+            },
+          {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+              "lifecycle": {},
+          {%- endif -%}
           "codec": "best_compression",
           "mapping": {
             "total_fields": {

--- a/elastic/security/templates/component/logs-endpoint.events.registry@settings.json
+++ b/elastic/security/templates/component/logs-endpoint.events.registry@settings.json
@@ -2,9 +2,13 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
+        {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          "lifecycle": {
+            "name": "logs"
+          },
+        {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+            "lifecycle": {},
+        {%- endif -%}
         "codec": "best_compression",
         "mapping": {
           "total_fields": {

--- a/elastic/security/templates/component/logs-endpoint.events.security@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.security@package.json
@@ -4,9 +4,13 @@
     "template": {
       "settings": {
         "index": {
-          "lifecycle": {
-            "name": "logs"
-          },
+          {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+            "lifecycle": {
+              "name": "logs"
+            },
+          {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+              "lifecycle": {},
+          {%- endif -%}
           "codec": "best_compression",
           "mapping": {
             "total_fields": {

--- a/elastic/security/templates/component/logs-endpoint.events.security@settings.json
+++ b/elastic/security/templates/component/logs-endpoint.events.security@settings.json
@@ -2,9 +2,13 @@
   "template": {
     "settings": {
       "index": {
-        "lifecycle": {
-          "name": "logs"
-        },
+        {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          "lifecycle": {
+            "name": "logs"
+          },
+        {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+            "lifecycle": {},
+        {%- endif -%}
         "codec": "best_compression",
         "mapping": {
           "total_fields": {


### PR DESCRIPTION
Serverless deployments miss ILM. As a result component templates should not use the lifecycle setting. Here we introduce a setting which allows us to exclude the lifecycle setting either using `lifecycle` parameter or a `build_flavor` parameter. This mimics what we do already for the elastic/logs track.

This needs backport to 8.15 branch.