### PR TITLE
Prevent usage of ilm lifecycle in serverless

### DIFF
--- a/elastic/security/templates/composable/security-auditbeat.json
+++ b/elastic/security/templates/composable/security-auditbeat.json
@@ -5,9 +5,13 @@
   "template" : {
     "settings" : {
       "index" : {
-        "lifecycle" : {
-          "name" : "security"
-        },
+        {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          "lifecycle": {
+            "name": "security"
+          },
+        {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+            "lifecycle": {},
+        {%- endif -%}
         "mapping" : {
           "total_fields" : {
             "limit" : "10000"

--- a/elastic/security/templates/composable/security-filebeat.json
+++ b/elastic/security/templates/composable/security-filebeat.json
@@ -5,9 +5,13 @@
   "template" : {
     "settings" : {
       "index" : {
-        "lifecycle" : {
-          "name" : "security"
-        },
+        {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          "lifecycle": {
+            "name": "security"
+          },
+        {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+            "lifecycle": {},
+        {%- endif -%}
         "mapping" : {
           "total_fields" : {
             "limit" : "10000"

--- a/elastic/security/templates/composable/security-metricbeat.json
+++ b/elastic/security/templates/composable/security-metricbeat.json
@@ -5,9 +5,13 @@
   "template" : {
     "settings" : {
       "index" : {
-        "lifecycle" : {
-          "name" : "security"
-        },
+        {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          "lifecycle": {
+            "name": "security"
+          },
+        {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+            "lifecycle": {},
+        {%- endif -%}
         "codec" : "best_compression",
         "mapping" : {
           "total_fields" : {

--- a/elastic/security/templates/composable/security-packetbeat.json
+++ b/elastic/security/templates/composable/security-packetbeat.json
@@ -5,9 +5,13 @@
   "template" : {
     "settings" : {
       "index" : {
-        "lifecycle" : {
-          "name" : "security"
-        },
+        {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          "lifecycle": {
+            "name": "security"
+          },
+        {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+            "lifecycle": {},
+        {%- endif -%}
         "mapping" : {
           "total_fields" : {
             "limit" : "10000"

--- a/elastic/security/templates/composable/security-winlogbeat.json
+++ b/elastic/security/templates/composable/security-winlogbeat.json
@@ -5,9 +5,13 @@
   "template" : {
     "settings" : {
       "index" : {
-        "lifecycle" : {
-          "name" : "security"
-        },
+        {% if lifecycle == "ilm" or (not lifecycle and build_flavor == "default") %}
+          "lifecycle": {
+            "name": "security"
+          },
+        {%- elif lifecycle == "dlm" or (not lifecycle and build_flavor == "serverless") %}
+            "lifecycle": {},
+        {%- endif -%}
         "mapping" : {
           "total_fields" : {
             "limit" : "10000"


### PR DESCRIPTION
There are still some places where ILM lifecycle policies are used without gating
their usage for serverless. Serverless uses DLM, not ILM. Here we just
conditionally include the `index.lifecycle.name` only for stateful deployments.