### PR TITLE
Synthetic source does not still support `copy_to`

### DIFF
--- a/elastic/security/templates/composable/security-metricbeat.json
+++ b/elastic/security/templates/composable/security-metricbeat.json
@@ -14208,7 +14208,9 @@
                   }
                 },
                 "message" : {
+                  {% if index_mode != "logsdb" %}
                   "copy_to" : "message",
+                  {% endif %}
                   "norms" : false,
                   "type" : "text"
                 },


### PR DESCRIPTION
This causes the `elastic/security` track to fail execution when `index_mode` is set to
`logsdb`. This is happening because LogsDB uses synthetic source which, in turn, does
not support `copy_to`. Supporting `copy_to` is expected to come in Elasticsearch 8.16.
In the meanwhile we just exclude the `copy_to` setting from the mapping so to avoid
triggering the error.