### PR TITLE
Remove `index.mode` gate on `copy_to`

### DIFF
--- a/elastic/security/README.md
+++ b/elastic/security/README.md
@@ -99,6 +99,7 @@ The following parameters are available:
 * `number_of_replicas` (default: 1) - The number of replicas to set per Data Stream. The same value is used for all Data Streams.
 * `bulk_indexing_clients` (default: 8) - The number of clients issuing indexing requests.
 * `bulk_size` (default: 50) - The number of documents to send per indexing request.
+* `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use. Only supported in `security-indexing-querying` track.
 
 ### Querying parameters
 

--- a/elastic/security/challenges/security-indexing-querying.json
+++ b/elastic/security/challenges/security-indexing-querying.json
@@ -18,6 +18,52 @@
       "clients": {{ p_bulk_indexing_clients }},
       "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
     },
+    {%- if force_merge_max_num_segments is defined %},
+    {
+      "name": "refresh-after-index",
+      "index": "logs-*",
+      "operation": "refresh"
+    },
+    {
+      "name": "wait-until-index-merges-fininshes",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "logs-*",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": false
+      }
+    },
+    {
+      "operation": {
+        "operation-type": "force-merge",
+        "index": "logs-*",
+        "request-timeout": 36000,
+        "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+      }
+    },
+    {
+      "name": "wait-until-merges-finish",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "logs-*",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": false
+      }
+    },
+    {
+      "name": "refresh-after-force-merge",
+      "index": "logs-*",
+      "operation": "refresh"
+    }
+    {%- endif %}
     {
       "name": "kibana-queries",
       "parallel": {

--- a/elastic/security/challenges/security-indexing-querying.json
+++ b/elastic/security/challenges/security-indexing-querying.json
@@ -21,35 +21,19 @@
     {%- if force_merge_max_num_segments is defined %}
     {
       "name": "refresh-after-index",
-      "index": "logs-*",
       "operation": "refresh"
-    },
-    {
-      "name": "wait-until-index-merges-fininshes",
-      "operation": {
-        "operation-type": "index-stats",
-        "index": "logs-*",
-        "condition": {
-          "path": "_all.total.merges.current",
-          "expected-value": 0
-        },
-        "retry-until-success": true,
-        "include-in-reporting": false
-      }
     },
     {
       "operation": {
         "operation-type": "force-merge",
-        "index": "logs-*",
         "request-timeout": 36000,
         "max-num-segments": {{ force_merge_max_num_segments | tojson }}
       }
     },
     {
-      "name": "wait-until-merges-finish",
+      "name": "wait-until-merge-finish",
       "operation": {
         "operation-type": "index-stats",
-        "index": "logs-*",
         "condition": {
           "path": "_all.total.merges.current",
           "expected-value": 0
@@ -60,7 +44,6 @@
     },
     {
       "name": "refresh-after-force-merge",
-      "index": "logs-*",
       "operation": "refresh"
     },
     {%- endif %}

--- a/elastic/security/challenges/security-indexing-querying.json
+++ b/elastic/security/challenges/security-indexing-querying.json
@@ -18,7 +18,7 @@
       "clients": {{ p_bulk_indexing_clients }},
       "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
     },
-    {%- if force_merge_max_num_segments is defined %},
+    {%- if force_merge_max_num_segments is defined %}
     {
       "name": "refresh-after-index",
       "index": "logs-*",
@@ -62,7 +62,7 @@
       "name": "refresh-after-force-merge",
       "index": "logs-*",
       "operation": "refresh"
-    }
+    },
     {%- endif %}
     {
       "name": "kibana-queries",

--- a/elastic/security/templates/component/logs-endpoint.events.file@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.file@package.json
@@ -320,7 +320,8 @@
             }
           },
           "message": {
-            "type": "text"
+            "type": "text",
+            "store": true
           },
           "@timestamp": {
             "type": "date"

--- a/elastic/security/templates/component/logs-endpoint.events.library@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.library@package.json
@@ -487,7 +487,8 @@
             }
           },
           "message": {
-            "type": "text"
+            "type": "text",
+            "store": true
           },
           "@timestamp": {
             "type": "date"

--- a/elastic/security/templates/component/logs-endpoint.events.network@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.network@package.json
@@ -434,7 +434,8 @@
             }
           },
           "message": {
-            "type": "text"
+            "type": "text",
+            "store": true
           },
           "network": {
             "properties": {

--- a/elastic/security/templates/component/logs-endpoint.events.process@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.process@package.json
@@ -1881,7 +1881,8 @@
             }
           },
           "message": {
-            "type": "text"
+            "type": "text",
+            "store": true
           },
           "@timestamp": {
             "type": "date"

--- a/elastic/security/templates/component/logs-endpoint.events.registry@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.registry@package.json
@@ -314,7 +314,8 @@
             }
           },
           "message": {
-            "type": "text"
+            "type": "text",
+            "store": true
           },
           "@timestamp": {
             "type": "date"

--- a/elastic/security/templates/component/logs-endpoint.events.security@package.json
+++ b/elastic/security/templates/component/logs-endpoint.events.security@package.json
@@ -389,7 +389,8 @@
             }
           },
           "message": {
-            "type": "text"
+            "type": "text",
+            "store": true
           },
           "event": {
             "properties": {

--- a/elastic/security/templates/composable/security-metricbeat.json
+++ b/elastic/security/templates/composable/security-metricbeat.json
@@ -14212,11 +14212,10 @@
                   }
                 },
                 "message" : {
-                  {% if index_mode != "logsdb" %}
                   "copy_to" : "message",
-                  {% endif %}
                   "norms" : false,
-                  "type" : "text"
+                  "type" : "text",
+                  "store": true
                 },
                 "type" : {
                   "ignore_above" : 1024,

--- a/elastic/security/workflows-logsdb/hosts/10.json
+++ b/elastic/security/workflows-logsdb/hosts/10.json
@@ -544,7 +544,7 @@
                 "include_unmapped": true
               },
               {
-                "field": "kubernetes.event.message",
+                "field": "message",
                 "include_unmapped": true
               },
               {

--- a/elastic/security/workflows-logsdb/hosts/8.json
+++ b/elastic/security/workflows-logsdb/hosts/8.json
@@ -446,7 +446,7 @@
                 "include_unmapped": true
               },
               {
-                "field": "kubernetes.event.message",
+                "field": "message",
                 "include_unmapped": true
               },
               {

--- a/elastic/security/workflows-logsdb/hosts/9.json
+++ b/elastic/security/workflows-logsdb/hosts/9.json
@@ -375,7 +375,7 @@
                 "include_unmapped": true
               },
               {
-                "field": "kubernetes.event.message",
+                "field": "message",
                 "include_unmapped": true
               },
               {

--- a/elastic/security/workflows-logsdb/network/11.json
+++ b/elastic/security/workflows-logsdb/network/11.json
@@ -582,7 +582,7 @@
                 "include_unmapped": true
               },
               {
-                "field": "kubernetes.event.message",
+                "field": "message",
                 "include_unmapped": true
               },
               {


### PR DESCRIPTION
This PR will be used to test an implementation of Elasrticsearch that supports copy_to for text fields. We make the field stored to mimic the actual copy_to implementation which will later use a stored field.