### PR TITLE
Keep array source in logsdb mode

### DIFF
--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -3,7 +3,10 @@
       "settings": {
         {% if index_mode %}
         "index": {
-            "mode": {{ index_mode | tojson }}
+            "mode": {{ index_mode | tojson }},
+            "mapping": {
+                "synthetic_source_keep": "arrays"
+            }
         }
         {% endif %}
       }


### PR DESCRIPTION
Test this change in nightlies, to decide whether to enable it by default.

Related to https://github.com/elastic/elasticsearch/issues/112354