### PR TITLE
[8.15] Keep array source in logsdb mode

### DIFF
--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -4,6 +4,9 @@
         {% if index_mode %}
         "index": {
             "mode": {{ index_mode | tojson }},
+            "mapping": {
+                "synthetic_source_keep": "arrays"
+            },
             "sort.field": [ "host.name", "@timestamp" ],
             "sort.order": [ "asc", "desc" ],
             "sort.missing": ["_first", "_last"]


### PR DESCRIPTION
Backport to 8.15:

- Keep array source in logsdb mode (655)