### PR TITLE
Include ability to force merge segments in `elastic/security`

### DIFF
--- a/elastic/security/README.md
+++ b/elastic/security/README.md
@@ -99,6 +99,7 @@ The following parameters are available:
 * `number_of_replicas` (default: 1) - The number of replicas to set per Data Stream. The same value is used for all Data Streams.
 * `bulk_indexing_clients` (default: 8) - The number of clients issuing indexing requests.
 * `bulk_size` (default: 50) - The number of documents to send per indexing request.
+* `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use. Only supported in `security-indexing-querying` track.
 
 ### Querying parameters
 

--- a/elastic/security/challenges/security-indexing-querying.json
+++ b/elastic/security/challenges/security-indexing-querying.json
@@ -18,6 +18,52 @@
       "clients": {{ p_bulk_indexing_clients }},
       "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
     },
+    {%- if force_merge_max_num_segments is defined %},
+    {
+      "name": "refresh-after-index",
+      "index": "logs-*",
+      "operation": "refresh"
+    },
+    {
+      "name": "wait-until-index-merges-fininshes",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "logs-*",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": false
+      }
+    },
+    {
+      "operation": {
+        "operation-type": "force-merge",
+        "index": "logs-*",
+        "request-timeout": 36000,
+        "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+      }
+    },
+    {
+      "name": "wait-until-merges-finish",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "logs-*",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": false
+      }
+    },
+    {
+      "name": "refresh-after-force-merge",
+      "index": "logs-*",
+      "operation": "refresh"
+    }
+    {%- endif %}
     {
       "name": "kibana-queries",
       "parallel": {

--- a/elastic/security/challenges/security-indexing-querying.json
+++ b/elastic/security/challenges/security-indexing-querying.json
@@ -21,35 +21,19 @@
     {%- if force_merge_max_num_segments is defined %}
     {
       "name": "refresh-after-index",
-      "index": "logs-*",
       "operation": "refresh"
-    },
-    {
-      "name": "wait-until-index-merges-fininshes",
-      "operation": {
-        "operation-type": "index-stats",
-        "index": "logs-*",
-        "condition": {
-          "path": "_all.total.merges.current",
-          "expected-value": 0
-        },
-        "retry-until-success": true,
-        "include-in-reporting": false
-      }
     },
     {
       "operation": {
         "operation-type": "force-merge",
-        "index": "logs-*",
         "request-timeout": 36000,
         "max-num-segments": {{ force_merge_max_num_segments | tojson }}
       }
     },
     {
-      "name": "wait-until-merges-finish",
+      "name": "wait-until-merge-finish",
       "operation": {
         "operation-type": "index-stats",
-        "index": "logs-*",
         "condition": {
           "path": "_all.total.merges.current",
           "expected-value": 0
@@ -60,7 +44,6 @@
     },
     {
       "name": "refresh-after-force-merge",
-      "index": "logs-*",
       "operation": "refresh"
     },
     {%- endif %}

--- a/elastic/security/challenges/security-indexing-querying.json
+++ b/elastic/security/challenges/security-indexing-querying.json
@@ -18,7 +18,7 @@
       "clients": {{ p_bulk_indexing_clients }},
       "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
     },
-    {%- if force_merge_max_num_segments is defined %},
+    {%- if force_merge_max_num_segments is defined %}
     {
       "name": "refresh-after-index",
       "index": "logs-*",
@@ -62,7 +62,7 @@
       "name": "refresh-after-force-merge",
       "index": "logs-*",
       "operation": "refresh"
-    }
+    },
     {%- endif %}
     {
       "name": "kibana-queries",


### PR DESCRIPTION
Force merging allows us to compare segment size and overall storage size reasoning about
storage saving. The security track is missing a way to force merge.

We are not going to set this parameter in nightlies but we still would like to have it for ad-hoc runs, since it makes reasoning about storage footprint easier.

This needs back-porting to Rally `8.15` branch.