### PR TITLE
Update to use JDK 21 for build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: pyproject.toml
-      - uses: actions/setup-java@v4.3
+      - uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "21"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: pyproject.toml
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4.3
         with:
           distribution: "temurin"
-          java-version: "17"
-      - run: echo "JAVA17_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
+          java-version: "21"
+      - run: echo "JAVA21_HOME=$JAVA_HOME_21_X64" >> $GITHUB_ENV
       - run: echo "JAVA11_HOME=$JAVA_HOME_11_X64" >> $GITHUB_ENV
       - name: "Install dependencies"
         run: python -m pip install .[develop]


### PR DESCRIPTION
This updates the build JDK to 21, since Elasticsearch@main now requires 21 to build. I bumped the github action versions too at the same time