### PR TITLE
Add standard component templates to security track composable templates

### DIFF
--- a/elastic/security/templates/composable/.logs-endpoint.action.responses.json
+++ b/elastic/security/templates/composable/.logs-endpoint.action.responses.json
@@ -21,6 +21,9 @@
       }
     },
     "composed_of": [
+      "logs@mappings",
+      "logs@settings",
+      "ecs@mappings",
       ".logs-endpoint.action.responses@package",
       ".logs-endpoint.action.responses@custom",
       ".fleet_globals-1",

--- a/elastic/security/templates/composable/.logs-endpoint.actions.json
+++ b/elastic/security/templates/composable/.logs-endpoint.actions.json
@@ -21,6 +21,9 @@
       }
     },
     "composed_of": [
+      "logs@mappings",
+      "logs@settings",
+      "ecs@mappings",
       ".logs-endpoint.actions@package",
       ".logs-endpoint.actions@custom",
       ".fleet_globals-1",

--- a/elastic/security/templates/composable/.logs-endpoint.diagnostic.collection.json
+++ b/elastic/security/templates/composable/.logs-endpoint.diagnostic.collection.json
@@ -21,6 +21,9 @@
       }
     },
     "composed_of": [
+      "logs@mappings",
+      "logs@settings",
+      "ecs@mappings",
       ".logs-endpoint.diagnostic.collection@package",
       ".logs-endpoint.diagnostic.collection@custom",
       ".fleet_globals-1",

--- a/elastic/security/templates/composable/logs-endpoint.alerts.json
+++ b/elastic/security/templates/composable/logs-endpoint.alerts.json
@@ -21,6 +21,9 @@
       }
     },
     "composed_of": [
+      "logs@mappings",
+      "logs@settings",
+      "ecs@mappings",
       "logs-endpoint.alerts@package",
       "logs-endpoint.alerts@custom",
       ".fleet_globals-1",

--- a/elastic/security/templates/composable/logs-endpoint.events.file.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.file.json
@@ -21,6 +21,9 @@
       }
     },
     "composed_of": [
+      "logs@mappings",
+      "logs@settings",
+      "ecs@mappings",
       "logs-endpoint.events.file@package",
       "logs-endpoint.events.file@custom",
       ".fleet_globals-1",

--- a/elastic/security/templates/composable/logs-endpoint.events.library.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.library.json
@@ -21,6 +21,9 @@
       }
     },
     "composed_of": [
+      "logs@mappings",
+      "logs@settings",
+      "ecs@mappings",
       "logs-endpoint.events.library@package",
       "logs-endpoint.events.library@custom",
       ".fleet_globals-1",

--- a/elastic/security/templates/composable/logs-endpoint.events.network.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.network.json
@@ -21,6 +21,9 @@
       }
     },
     "composed_of": [
+      "logs@mappings",
+      "logs@settings",
+      "ecs@mappings",
       "logs-endpoint.events.network@package",
       "logs-endpoint.events.network@custom",
       ".fleet_globals-1",

--- a/elastic/security/templates/composable/logs-endpoint.events.process.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.process.json
@@ -21,6 +21,9 @@
       }
     },
     "composed_of": [
+      "logs@mappings",
+      "logs@settings",
+      "ecs@mappings",
       "logs-endpoint.events.process@package",
       "logs-endpoint.events.process@custom",
       ".fleet_globals-1",

--- a/elastic/security/templates/composable/logs-endpoint.events.registry.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.registry.json
@@ -21,6 +21,9 @@
       }
     },
     "composed_of": [
+      "logs@mappings",
+      "logs@settings",
+      "ecs@mappings",
       "logs-endpoint.events.registry@package",
       "logs-endpoint.events.registry@custom",
       ".fleet_globals-1",

--- a/elastic/security/templates/composable/logs-endpoint.events.security.json
+++ b/elastic/security/templates/composable/logs-endpoint.events.security.json
@@ -21,6 +21,9 @@
       }
     },
     "composed_of": [
+      "logs@mappings",
+      "logs@settings",
+      "ecs@mappings",
       "logs-endpoint.events.security@package",
       "logs-endpoint.events.security@custom",
       ".fleet_globals-1",


### PR DESCRIPTION
Adding logs@settings, logs@mappings, ecs@mappings to the composable templates of the endpoint indices in the security track.