### PR TITLE
Modify the default vector index type to int8_hnsw (#658)

### DIFF
--- a/dense_vector/README.md
+++ b/dense_vector/README.md
@@ -33,4 +33,4 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `number_of_replicas` (default: 0)
 * `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
-* `vector_index_type` (default: "hnsw"): The index kind for storing the vectors.
+* `vector_index_type` (default: "int8_hnsw"): The index kind for storing the vectors.

--- a/dense_vector/index.json
+++ b/dense_vector/index.json
@@ -19,7 +19,7 @@
         "index" : true,
         "similarity": "dot_product",
         "index_options": {
-          "type": {{ vector_index_type | default("hnsw") | tojson }},
+          "type": {{ vector_index_type | default("int8_hnsw") | tojson }},
           "m": 32,
           "ef_construction": 100
         }

--- a/so_vector/README.md
+++ b/so_vector/README.md
@@ -68,7 +68,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `max_num_segments` (default: 1)
 * `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
 * `include_force_merge` (default: true for non-serverless clusters, false for serverless clusters): Whether to include force merge operation.
-* `vector_index_type` (default: "hnsw"): The index kind for storing the vectors.
+* `vector_index_type` (default: "int8_hnsw"): The index kind for storing the vectors.
 
 ### License
 We use the same license for the data as the original data: [CC-SA-4.0](http://creativecommons.org/licenses/by-sa/4.0/).

--- a/so_vector/index.json
+++ b/so_vector/index.json
@@ -37,7 +37,7 @@
         "index" : true,
         "similarity": "dot_product",
         "index_options": {
-          "type": {{ vector_index_type | default("hnsw") | tojson }}
+          "type": {{ vector_index_type | default("int8_hnsw") | tojson }}
         }
       },
       "acceptedAnswerId": {


### PR DESCRIPTION
From ES v8.14 the default index type for dense_vectors is int8_hnsw. 
This modifies our rally tracks to reflect it.

Backport for #658