### PR TITLE
[8.15] Add logsdb support to http_logs track

### DIFF
--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -49,6 +49,8 @@ node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 * `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
+* `enable_logsdb` (default: false) Determines whether the logsdb index mode gets used. If set then index sorting is configured to only use `@timestamp` field and the `source_enabled` parameter will have no effect.
+* `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 
 ### License
 

--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -44,7 +44,9 @@
         {
           "operation": {
             "operation-type": "force-merge",
-            "request-timeout": 7200
+            "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
+            "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+            {%- endif %}
           }
         },
         {

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -5,12 +5,21 @@
     "index.number_of_replicas": {{ number_of_replicas | default(0) }},
     "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
+    {%- if enable_logsdb %},
+    "index.mode": "logsdb",
+    "index.mapping.synthetic_source_keep": "arrays",
+    "index.sort.field": ["@timestamp"],
+    "index.sort.order":["desc"]
+    {%- endif %}
   },
   "mappings": {
     "dynamic": "strict",
+    {%- if enable_logsdb %}
+    {%- else %}
     "_source": {
       "enabled": {{ source_enabled | default(true) | tojson }}
     },
+    {%- endif %}
     "properties": {
       "@timestamp": {
         {%- if ingest_pipeline is defined and ingest_pipeline == "grok" %}


### PR DESCRIPTION
This back ports #672 to 8.15 branch.

* `enable_logsdb` (default: false) Determines whether the logsdb index mode gets used. If set then index sorting is configured to only use `@timestamp` field and the `source_enabled` parameter will have no effect.
* `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.