### PR TITLE
`host.name` is empty we need to use `host.hostname`

### DIFF
--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -1,17 +1,14 @@
 {
-  "template": {
-    "settings": {
-      {% if index_mode %}
-      "index": {
-          "mode": {{ index_mode | tojson }},
-          "sort": {
-          "order": [
-            { "host.hostname": "desc" },
-            { "@timestamp": "desc" }
-          ]
+    "template": {
+      "settings": {
+        {% if index_mode %}
+        "index": {
+            "mode": {{ index_mode | tojson }},
+            "sort.field": [ "host.hostname", "@timestamp" ],
+            "sort.order": [ "asc", "desc" ],
+            "sort.missing": ["_first", "_last"]
         }
+        {% endif %}
       }
-      {% endif %}
     }
   }
-}

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -3,7 +3,13 @@
     "settings": {
       {% if index_mode %}
       "index": {
-          "mode": {{ index_mode | tojson }}
+          "mode": {{ index_mode | tojson }},
+          "sort": {
+          "order": [
+            { "host.hostname": "desc" },
+            { "@timestamp": "desc" }
+          ]
+        }
       }
       {% endif %}
     }


### PR DESCRIPTION
If the `host.name` field does not exists, indices created as backing indices of a data stream
are injected with empty values of `host.name`. Sorting on `host.name` and `@timestamp`
results in sorting just on `@timestamp`. Looking at some mappings I see a `host.hostname`
exists. Also a cardinality aggregation results in hundreds of distinct values which suggests
the filed is not empty.

We would like to test using a meaningful combination of fields to sort on. Ideally we expect
better benchmark results despite being possible that other, more effective, combinations of
fields might exist. We are interested, anyway, in changes over time **given a valid set of fields
to sort on**.

This needs backporting to `8.15`