### PR TITLE
[8.15] `host.name` is empty we need to use `host.hostname` (#678)

### DIFF
--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -1,11 +1,14 @@
 {
-  "template": {
-    "settings": {
-      {% if index_mode %}
-      "index": {
-          "mode": {{ index_mode | tojson }}
+    "template": {
+      "settings": {
+        {% if index_mode %}
+        "index": {
+            "mode": {{ index_mode | tojson }},
+            "sort.field": [ "host.hostname", "@timestamp" ],
+            "sort.order": [ "asc", "desc" ],
+            "sort.missing": ["_first", "_last"]
+        }
+        {% endif %}
       }
-      {% endif %}
     }
   }
-}


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.15` of:
 - #678

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)