### PR TITLE
Continue backport on error

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@v9.5.1
+        continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
When backport does not find a branch to backport to it returns with an error failing GH action step which in turn fails entire job (see example in https://github.com/elastic/rally-tracks/actions/runs/11019352166). This will happen frequently as not every PR will be labeled with `backport-to-*`.

The intention here is to prevent such error from failing entire job without repeating ourselves, i.e. including all possible `backport-to-*` labels in the `if` statement of the job. The list of backport-allowed branches is already defined in `targetBranchChoices` in `.backportrc.json`.