### PR TITLE
Add synthetic_source_keep param to tsdb and http_logs tracks

### DIFF
--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -3,9 +3,9 @@
       "settings": {
         {% if index_mode %}
         "index": {
-            "mode": {{ index_mode | tojson }},
+            "mode": {{ index_mode | tojson }}
             {% if synthetic_source_keep and synthetic_source_keep != 'none' %}
-            "mapping": {
+            ,"mapping": {
                 "synthetic_source_keep": "{{ synthetic_source_keep }}"
             }
             {% endif %}

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -51,6 +51,7 @@ node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
 * `enable_logsdb` (default: false) Determines whether the logsdb index mode gets used. If set then index sorting is configured to only use `@timestamp` field and the `source_enabled` parameter will have no effect.
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
+* `synthetic_source_keep` (default: unset): If specified, configures the `index.mapping.synthetic_source_keep` index setting.
 
 ### License
 

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -7,7 +7,9 @@
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
     {%- if enable_logsdb %},
     "index.mode": "logsdb",
-    "index.mapping.synthetic_source_keep": "arrays",
+    {% if synthetic_source_keep %}
+    "index.mapping.synthetic_source_keep": "{{synthetic_source_keep}}",
+    {% endif %}
     "index.sort.field": ["@timestamp"],
     "index.sort.order":["desc"]
     {%- endif %}

--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -203,6 +203,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
 * `document_ids`: documentd IDs to use for search, get and mget apis in the `low-latency` challenge. If empty, a default set of 4 values is used.
+* `synthetic_source_keep` (default: unset): If specified, configures the `index.mapping.synthetic_source_keep` index setting.
 
 ### License
 

--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -31,7 +31,12 @@
           "end_time": "2021-05-01T00:00:00.000Z"
         },
         {% endif %}
-        "mapping.total_fields.limit": 10000
+        "mapping": {
+          {% if synthetic_source_keep %}
+          "synthetic_source_keep": "{{synthetic_source_keep}}",
+          {% endif %}
+          "total_fields.limit": 10000
+        }
       }
     },
     "mappings": {

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -28,7 +28,12 @@
         "end_time": "9999-01-01T00:00:00.000Z"
       },
       {% endif %}
-      "mapping.total_fields.limit": 10000
+      "mapping": {
+        {% if synthetic_source_keep %}
+        "synthetic_source_keep": "{{synthetic_source_keep}}",
+        {% endif %}
+        "total_fields.limit": 10000
+      }
     }
   },
   "mappings": {


### PR DESCRIPTION
The addition of the `index.mapping.synthetic_source_keep` to tsdb is new. To http_logs is not and before the `index.mapping.synthetic_source_keep` setting was hard coded to `arrays`. I will open a separate PR that adds the `source_keep` track param to nightly configs.

Having the `source_keep` makes comparing benchmark results between the different source keep options easier.