### PR TITLE
Use `host.id` for sorting security data

### DIFF
--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -9,7 +9,7 @@
                 "synthetic_source_keep": "{{ synthetic_source_keep }}"
             },
             {% endif %}
-            "sort.field": [ "host.hostname", "@timestamp" ],
+            "sort.field": [ "host.id", "@timestamp" ],
             "sort.order": [ "asc", "desc" ],
             "sort.missing": ["_first", "_last"]
         }


### PR DESCRIPTION
`host.hostname` has cardinality 100 while `host.id` has cardinality 50. This happen because in the dataset there is a host per each couple of hostnames, like a single `host.id` and for each of them two host names like 'dustin.windows' and 'dustin.linux'. This is probably an artifact of the data generation script.

Lower cardinality fields might:
* reduce sorting overhead due to less comparisons, which might improve ingestion throughput
* improve compression due to better data clustering, which might reduce disk storage (index size)

This change should at least allow us to see if there is any benefit in choosing a lower cardinality field
like `host.id` versus `host.hostname`.

Right now benchmarks run with version `9.0` of Elasticsearch and it looks like we still don't have
the corresponding branch in Rally. As a result, Rally is checked out from master. For this reason
back-porting is not strictly required. We do the backport to `8.15` in case we need to do some
comparison later on, comparing Elasticsearch `8.16` versus `8.15`.