### PR TITLE
Add support index.mapping.source.mode setting to various tracks

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -221,6 +221,7 @@ The following parameters are available:
 * `lifecycle` (default: unset to fall back on Serverless detection) - Specifies the lifecycle management feature to use for data streams. Use `ilm` for index lifecycle management or `dlm` for data lifecycle management. By default, `dlm` will be used for benchmarking Serverless Elasticsearch.
 * `workflow-request-cache` (default: `true`) - Explicit control of request cache query parameter in searches executed in a workflow. This can be further overriden at an operation level with `request-cache` parameter.
 * `synthetic_source_keep` (default: unset) - Allows overriding the default synthetic source behaviour for all field types with the following values: `none` (equivalent to unset) - no source is stored, `arrays` - source stored as is only for multi-value (array) fields.
+* `source_mode` (default: unset) - Specified the source mode to be used.
 
 ### Data Download Parameters
 

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -5,9 +5,10 @@
         "index": {
             "mode": {{ index_mode | tojson }}
             {% if synthetic_source_keep and synthetic_source_keep != 'none' %}
-            ,"mapping": {
-                "synthetic_source_keep": "{{ synthetic_source_keep }}"
-            }
+            ,"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
+            {% endif %}
+            {% if source_mode %}
+            ,"mapping.source.mode": {{ source_mode | tojson }}
             {% endif %}
         }
         {% endif %}

--- a/elastic/security/README.md
+++ b/elastic/security/README.md
@@ -85,6 +85,7 @@ The following parameters are available:
 * `corpora_uri_base` (default: `https://rally-tracks.elastic.co`) - Specify the base location of the datasets used by this track.
 * `index_mode` (default: unset) - A parameter meant to be used internally which defines one of the available indexing modes, "standard", "logsdb" or "time_series". If not set, "standard" is used.
 * `synthetic_source_keep` (default: unset) - Allows overriding the default synthetic source behaviour for all field types with the following values: `none` (equivalent to unset) - no source is stored, `arrays` - source stored as is only for multi-value (array) fields.
+* `source_mode` (default: unset) - Specified the source mode to be used.
 
 ### Data Generation Parameters
 

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -5,9 +5,10 @@
         "index": {
             "mode": {{ index_mode | tojson }},
             {% if synthetic_source_keep and synthetic_source_keep != 'none' %}
-            "mapping": {
-                "synthetic_source_keep": "{{ synthetic_source_keep }}"
-            },
+            "mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}},
+            {% endif %}
+            {% if source_mode %}
+            "mapping.source.mode": {{ source_mode | tojson }},
             {% endif %}
             "sort.field": [ "host.id", "@timestamp" ],
             "sort.order": [ "asc", "desc" ],

--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -52,6 +52,7 @@ node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'
 * `enable_logsdb` (default: false) Determines whether the logsdb index mode gets used. If set then index sorting is configured to only use `@timestamp` field and the `source_enabled` parameter will have no effect.
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
 * `synthetic_source_keep` (default: unset): If specified, configures the `index.mapping.synthetic_source_keep` index setting.
+* `source_mode` (default: unset) - Specified the source mode to be used.
 
 ### License
 

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -10,6 +10,9 @@
     {% if synthetic_source_keep %}
     "index.mapping.synthetic_source_keep": "{{synthetic_source_keep}}",
     {% endif %}
+    {% if source_mode %}
+    "index.mapping.source.mode": {{ source_mode | tojson }},
+    {% endif %}
     "index.sort.field": ["@timestamp"],
     "index.sort.order":["desc"]
     {%- endif %}

--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -35,6 +35,9 @@
           {% if synthetic_source_keep %}
           "synthetic_source_keep": "{{synthetic_source_keep}}",
           {% endif %}
+          {% if p_source_mode %}
+          "source.mode": {{ p_source_mode | tojson }},
+          {% endif %}
           "total_fields.limit": 10000
         }
       }
@@ -43,9 +46,6 @@
       "_meta": {
         "beat": "metricbeat",
         "version": "7.6.2"
-      },
-      "_source": {
-        "mode": {{ p_source_mode | tojson }}
       },
       "dynamic_templates": [
         {

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -32,6 +32,9 @@
         {% if synthetic_source_keep %}
         "synthetic_source_keep": "{{synthetic_source_keep}}",
         {% endif %}
+        {% if p_source_mode %}
+        "source.mode": {{ p_source_mode | tojson }},
+        {% endif %}
         "total_fields.limit": 10000
       }
     }
@@ -40,9 +43,6 @@
     "_meta": {
       "beat": "metricbeat",
       "version": "7.6.2"
-    },
-    "_source": {
-      "mode": {{ p_source_mode | tojson }}
     },
     "dynamic_templates": [
       {


### PR DESCRIPTION
Add support index.mapping.source.mode setting to elastic/logs, elastic/security, http_logs and tsdb tracks.