### PR TITLE
Two more benchmarks for partial sorting with ESQL

### DIFF
--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -279,20 +279,14 @@
         },
         {
           "operation": "distanceFilterCount200x300",
-          "warmup-iterations": 200,
-          "iterations": 200,
+          "warmup-iterations": 50,
+          "iterations": 50,
           "tags": ["distance", "esql"]
         },
         {
-          "operation": "distanceFilterCount200x300-must_not",
-          "warmup-iterations": 200,
-          "iterations": 200,
-          "tags": ["distance", "esql"]
-        },
-        {
-          "operation": "distanceFilterCount200x300-filter",
-          "warmup-iterations": 200,
-          "iterations": 200,
+          "operation": "distanceFilterCount200x300-alt",
+          "warmup-iterations": 50,
+          "iterations": 50,
           "tags": ["distance", "esql"]
         },
         {

--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -279,14 +279,20 @@
         },
         {
           "operation": "distanceFilterCount200x300",
-          "warmup-iterations": 50,
-          "iterations": 50,
+          "warmup-iterations": 200,
+          "iterations": 200,
           "tags": ["distance", "esql"]
         },
         {
-          "operation": "distanceFilterCount200x300-alt",
-          "warmup-iterations": 50,
-          "iterations": 50,
+          "operation": "distanceFilterCount200x300-must_not",
+          "warmup-iterations": 200,
+          "iterations": 200,
+          "tags": ["distance", "esql"]
+        },
+        {
+          "operation": "distanceFilterCount200x300-filter",
+          "warmup-iterations": 200,
+          "iterations": 200,
           "tags": ["distance", "esql"]
         },
         {
@@ -338,6 +344,12 @@
           "tags": ["distance", "esql", "sort"]
         },
         {
+          "operation": "distanceSort-esql-partial",
+          "warmup-iterations": 50,
+          "iterations": 50,
+          "tags": ["distance", "esql", "sort"]
+        },
+        {
           "operation": "distanceFilterSort",
           "warmup-iterations": 200,
           "iterations": 100,
@@ -345,6 +357,12 @@
         },
         {
           "operation": "distanceFilterSort-esql",
+          "warmup-iterations": 200,
+          "iterations": 100,
+          "tags": ["distance", "esql", "sort"]
+        },
+        {
+          "operation": "distanceFilterSort-esql-partial",
           "warmup-iterations": 200,
           "iterations": 100,
           "tags": ["distance", "esql", "sort"]

--- a/geopoint/operations/default.json
+++ b/geopoint/operations/default.json
@@ -454,7 +454,7 @@
       }
     },
     {
-      "name": "distanceFilterCount200x300-alt",
+      "name": "distanceFilterCount200x300-must_not",
       "operation-type": "search",
       "body": {
         "query": {
@@ -480,6 +480,41 @@
                       }
                     }
                   ]
+                }
+              }
+            ]
+          }
+        },
+        "aggs": {
+          "count": {
+            "value_count": {
+              "field": "location"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "distanceFilterCount200x300-filter",
+      "operation-type": "search",
+      "body": {
+        "query": {
+          "bool": {
+            "filter": [
+              {
+              "geo_shape": {
+                "location": {
+                    "shape": { "type": "circle", "radius": "300km", "coordinates": [7, 55] },
+                    "relation": "intersects"
+                  }
+                }
+              },
+              {
+                "geo_shape": {
+                  "location": {
+                    "shape": { "type": "circle", "radius": "200km", "coordinates": [7, 55] },
+                    "relation": "disjoint"
+                  }
                 }
               }
             ]
@@ -592,6 +627,11 @@
       "query": "FROM osmgeopoints | EVAL distance = ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) | SORT distance ASC | LIMIT 10"
     },
     {
+      "name": "distanceSort-esql-partial",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints | EVAL distance = ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")), loc = location::string | SORT distance ASC, loc ASC | LIMIT 10"
+    },
+    {
       "name": "distanceFilterSort",
       "operation-type": "search",
       "body": {
@@ -619,6 +659,11 @@
       "name": "distanceFilterSort-esql",
       "operation-type": "esql",
       "query": "FROM osmgeopoints  | EVAL distance = ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")) | WHERE distance <= 400000 | SORT distance ASC | LIMIT 10"
+    },
+    {
+      "name": "distanceFilterSort-esql-partial",
+      "operation-type": "esql",
+      "query": "FROM osmgeopoints  | EVAL distance = ST_Distance(location, TO_GEOPOINT(\"POINT(7.0 55.0)\")), loc = location::string | WHERE distance <= 400000 | SORT distance ASC, loc ASC | LIMIT 10"
     },
     {
       "name": "distanceRange",

--- a/geopoint/operations/default.json
+++ b/geopoint/operations/default.json
@@ -454,7 +454,7 @@
       }
     },
     {
-      "name": "distanceFilterCount200x300-must_not",
+      "name": "distanceFilterCount200x300-alt",
       "operation-type": "search",
       "body": {
         "query": {
@@ -480,41 +480,6 @@
                       }
                     }
                   ]
-                }
-              }
-            ]
-          }
-        },
-        "aggs": {
-          "count": {
-            "value_count": {
-              "field": "location"
-            }
-          }
-        }
-      }
-    },
-    {
-      "name": "distanceFilterCount200x300-filter",
-      "operation-type": "search",
-      "body": {
-        "query": {
-          "bool": {
-            "filter": [
-              {
-              "geo_shape": {
-                "location": {
-                    "shape": { "type": "circle", "radius": "300km", "coordinates": [7, 55] },
-                    "relation": "intersects"
-                  }
-                }
-              },
-              {
-                "geo_shape": {
-                  "location": {
-                    "shape": { "type": "circle", "radius": "200km", "coordinates": [7, 55] },
-                    "relation": "disjoint"
-                  }
                 }
               }
             ]


### PR DESCRIPTION
These cannot be replicated in _search since that only supports what can be pushed down to lucene, and this feature explicitly only pushes down part of the sort, and then does the other part in the compute engine.