### PR TITLE
Updated query_warmup_time_period and workflow_time_interval

### DIFF
--- a/elastic/it/query-tests/discover.json
+++ b/elastic/it/query-tests/discover.json
@@ -27,9 +27,9 @@
   "query_workflows": ["discover/search", "discover/visualize"],
   "query_min_date":"2021-01-01T00:30:00Z",
   "query_max_date":"2021-01-01T23:30:00Z",
-  "query_warmup_time_period":60,
+  "query_warmup_time_period":120,
   "query_time_period":360,
-  "workflow_time_interval":10,
+  "workflow_time_interval":30,
   "think_time_interval":10,
   "detailed_results":true
 }

--- a/elastic/it/query-tests/mysql.json
+++ b/elastic/it/query-tests/mysql.json
@@ -19,9 +19,9 @@
   "query_workflows": ["mysql/dashboard"],
   "query_min_date":"2021-01-01T00:30:00Z",
   "query_max_date":"2021-01-01T23:30:00Z",
-  "query_warmup_time_period":60,
+  "query_warmup_time_period":120,
   "query_time_period":200,
-  "workflow_time_interval":10,
+  "workflow_time_interval":30,
   "think_time_interval":10,
   "detailed_results":true
 }


### PR DESCRIPTION
With this PR we update `query_warmup_time_period` from 60 to 120 and `workflow_time_interval` from 10 to 30 for workflows: "discover/search", "discover/visualize" and "mysql/dashboard".
This change is needed in order to give more to the selected workflows time to warmup and execute.