### PR TITLE
Exclude msmarco from IT tests

### DIFF
--- a/it/test_all_tracks_and_challenges.py
+++ b/it/test_all_tracks_and_challenges.py
@@ -21,7 +21,7 @@ pytest_rally = pytest.importorskip("pytest_rally")
 
 
 class TestTrackRepository:
-    skip_tracks = ["elastic/logs", "elastic/security", "k8s_metrics", "sql", "elser-ingest-speedtest"]
+    skip_tracks = ["elastic/logs", "elastic/security", "k8s_metrics", "sql", "elser-ingest-speedtest", "msmarco-v2-vector"]
     disable_assertions = {
         "http_logs": ["append-no-conflicts", "runtime-fields"],
         "nyc_taxis": ["update-aggs-only"],

--- a/it_serverless/test_selected_tracks_and_challenges.py
+++ b/it_serverless/test_selected_tracks_and_challenges.py
@@ -35,7 +35,7 @@ class TestTrackRepository:
         "github_archive",
         "http_logs",
         # "k8s_metrics", (slow)
-        "msmarco-v2-vector",
+        # "msmarco-v2-vector", (slow for test mode)
         "nested",
         "noaa",
         "nyc_taxis",


### PR DESCRIPTION
Whilst checking the output from another PR, i spotted that msmarco-v2-vector takes around 50 minutes to run even in test-mode.
Checking track.py there's a very suspicious loop where we read 12000 lines from a file, which we decompress on the fly. This is run many times during the track, as we load it for each operation. I ran on a very large instance I had running and it took 25 minutes to run, the machines we're using for CI are obviously a lot slower...

It would be good if we could get the test-mode config down to the paramsource etc, and then consider doing something different for this track (or others), but it doesnt seem thats too simple right now. I'll create a ticket in rally to address, but in the meantime I think this track should be excluded from system tests. 

It would be nice if we could add a comment we could make that would run a specific test (e.g when making changes to some tracks that are excluded).