### PR TITLE
Introduce a new `use_synthetic_source_recovery` track parameter

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -222,6 +222,7 @@ The following parameters are available:
 * `workflow-request-cache` (default: `true`) - Explicit control of request cache query parameter in searches executed in a workflow. This can be further overriden at an operation level with `request-cache` parameter.
 * `synthetic_source_keep` (default: unset) - Allows overriding the default synthetic source behaviour for all field types with the following values: `none` (equivalent to unset) - no source is stored, `arrays` - source stored as is only for multi-value (array) fields.
 * `source_mode` (default: unset) - Specifies the source mode to be used.
+* `use_synthetic_source_recovery` (default: unset): If `true` recovery will take place using synthetic source instead of using `_recovery_source`
 
 ### Data Download Parameters
 

--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -222,7 +222,7 @@ The following parameters are available:
 * `workflow-request-cache` (default: `true`) - Explicit control of request cache query parameter in searches executed in a workflow. This can be further overriden at an operation level with `request-cache` parameter.
 * `synthetic_source_keep` (default: unset) - Allows overriding the default synthetic source behaviour for all field types with the following values: `none` (equivalent to unset) - no source is stored, `arrays` - source stored as is only for multi-value (array) fields.
 * `source_mode` (default: unset) - Specifies the source mode to be used.
-* `use_synthetic_source_recovery` (default: unset): If `true` recovery will take place using synthetic source instead of using `_recovery_source`
+* `use_synthetic_source_recovery` (default: unset): Whether synthetic recovery source will be used.
 
 ### Data Download Parameters
 

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -5,7 +5,7 @@
         "index": {
             "mode": {{ index_mode | tojson }}
             {% if use_synthetic_source_recovery %}
-            ,"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}},
+            ,"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
             {% endif %}
             {% if synthetic_source_keep and synthetic_source_keep != 'none' %}
             ,"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -4,6 +4,9 @@
         {% if index_mode %}
         "index": {
             "mode": {{ index_mode | tojson }}
+            {% if use_synthetic_source_recovery %}
+            ,"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}},
+            {% endif %}
             {% if synthetic_source_keep and synthetic_source_keep != 'none' %}
             ,"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
             {% endif %}

--- a/elastic/security/README.md
+++ b/elastic/security/README.md
@@ -86,6 +86,7 @@ The following parameters are available:
 * `index_mode` (default: unset) - A parameter meant to be used internally which defines one of the available indexing modes, "standard", "logsdb" or "time_series". If not set, "standard" is used.
 * `synthetic_source_keep` (default: unset) - Allows overriding the default synthetic source behaviour for all field types with the following values: `none` (equivalent to unset) - no source is stored, `arrays` - source stored as is only for multi-value (array) fields.
 * `source_mode` (default: unset) - Specifies the source mode to be used.
+* `use_synthetic_source_recovery` (default: unset): If `true` recovery will take place using synthetic source instead of using `_recovery_source`
 
 ### Data Generation Parameters
 

--- a/elastic/security/README.md
+++ b/elastic/security/README.md
@@ -86,7 +86,7 @@ The following parameters are available:
 * `index_mode` (default: unset) - A parameter meant to be used internally which defines one of the available indexing modes, "standard", "logsdb" or "time_series". If not set, "standard" is used.
 * `synthetic_source_keep` (default: unset) - Allows overriding the default synthetic source behaviour for all field types with the following values: `none` (equivalent to unset) - no source is stored, `arrays` - source stored as is only for multi-value (array) fields.
 * `source_mode` (default: unset) - Specifies the source mode to be used.
-* `use_synthetic_source_recovery` (default: unset): If `true` recovery will take place using synthetic source instead of using `_recovery_source`
+* `use_synthetic_source_recovery` (default: unset): Whether synthetic recovery source will be used.
 
 ### Data Generation Parameters
 

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -5,7 +5,7 @@
         "index": {
             "mode": {{ index_mode | tojson }},
             {% if use_synthetic_source_recovery %}
-            "recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}},
+            "recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
             {% endif %}
             {% if synthetic_source_keep and synthetic_source_keep != 'none' %}
             "mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}},

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -4,6 +4,9 @@
         {% if index_mode %}
         "index": {
             "mode": {{ index_mode | tojson }},
+            {% if use_synthetic_source_recovery %}
+            "recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}},
+            {% endif %}
             {% if synthetic_source_keep and synthetic_source_keep != 'none' %}
             "mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}},
             {% endif %}

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -5,7 +5,7 @@
         "index": {
             "mode": {{ index_mode | tojson }},
             {% if use_synthetic_source_recovery %}
-            "recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
+            "recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}},
             {% endif %}
             {% if synthetic_source_keep and synthetic_source_keep != 'none' %}
             "mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}},

--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -204,6 +204,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
 * `document_ids`: documentd IDs to use for search, get and mget apis in the `low-latency` challenge. If empty, a default set of 4 values is used.
 * `synthetic_source_keep` (default: unset): If specified, configures the `index.mapping.synthetic_source_keep` index setting.
+* `use_synthetic_source_recovery` (default: unset): If `true` recovery will take place using synthetic source instead of using `_recovery_source`
 
 ### License
 

--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -204,7 +204,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
 * `document_ids`: documentd IDs to use for search, get and mget apis in the `low-latency` challenge. If empty, a default set of 4 values is used.
 * `synthetic_source_keep` (default: unset): If specified, configures the `index.mapping.synthetic_source_keep` index setting.
-* `use_synthetic_source_recovery` (default: unset): If `true` recovery will take place using synthetic source instead of using `_recovery_source`
+* `use_synthetic_source_recovery` (default: unset): Whether synthetic recovery source will be used.
 
 ### License
 

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -8,6 +8,9 @@
       "number_of_shards": {{number_of_shards | default(1)}},
       "number_of_replicas": {{number_of_replicas | default(0)}},
       "requests.cache.enable": false,
+      {% if use_synthetic_source_recovery %}
+      "recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}},
+      {% endif %}
       {%- endif -%}{# non-serverless-index-settings-marker-end #}
       "codec": "{{codec | default('default')}}",
       "mode": "{{index_mode | default('time_series')}}",


### PR DESCRIPTION
PR https://github.com/elastic/elasticsearch/pull/114618 in Elasticsearch introduced the ability
to do recovery using synthetic source instead of using the `_recovery_source` field.

We are updating three Rally tracks, `elastic/logs`, `elastic/security` and `tsdb` to include a new parameter, `use_synthetic_source_recovery`. This parameter will allow us to toggle the `index.mapping.use_synthetic_source`
setting in Rally nightly benchmarks. We will follow-up with another PR introducing new nightly Elasticsearch benchmarks
to provide a means of comparing the performance impact of enabling versus disabling this setting.