### PR TITLE
Introduce a new synthetic source recovery challenge for LogsDB and TSDB

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -222,6 +222,12 @@ The following parameters are available:
 * `workflow-request-cache` (default: `true`) - Explicit control of request cache query parameter in searches executed in a workflow. This can be further overriden at an operation level with `request-cache` parameter.
 * `synthetic_source_keep` (default: unset) - Allows overriding the default synthetic source behaviour for all field types with the following values: `none` (equivalent to unset) - no source is stored, `arrays` - source stored as is only for multi-value (array) fields.
 * `source_mode` (default: unset) - Specifies the source mode to be used.
+* `use_synthetic_source_recovery` (default: unset): Whether synthetic recovery source will be used.
+* `recovery_target_index` (required) - The target index for fetching shard changes via the recovery API.
+* `recovery_from_seq_no` (default: `0`) - The sequence number from which to start fetching translog operations.
+* `recovery_poll_timeout` (default: `1m`) - The maximum time to wait for additional translog operations before returning an empty result.
+* `recovery_max_batch_size` (default: `32MB`) - The maximum estimated size for the batch of translog operations to return.
+* `recovery_max_operations_count` (default: `1048576`) - The maximum number of translog operations to return in a single batch.
 
 ### Data Download Parameters
 

--- a/elastic/logs/challenges/synthetic-source-recovery.json
+++ b/elastic/logs/challenges/synthetic-source-recovery.json
@@ -1,0 +1,41 @@
+{% import "rally.helpers" as rally %}
+{
+  "name": "synthetic-source-recovery",
+  "description": "Indexes logs for a specified time period and volume per day and then runs the recovery api fetching translog operations for a given tagre index.",
+  "default": false,
+  "schedule": [
+    {% include "tasks/index-setup.json" %},
+    {
+      "name": "bulk-index",
+      "operation": {
+        "operation-type": "raw-bulk",
+        "param-source": "processed-source",
+        "time-format": "milliseconds",
+        "profile": "fixed_interval",
+        "bulk-size": {{ p_bulk_size }},
+        "detailed-results": true
+      },
+      "clients": {{ p_bulk_indexing_clients }}{% if p_throttle_indexing %},
+      "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+      "schedule": "timestamp-throttler",
+      "max-delay-secs": 1
+      {% endif %}
+    },
+    {
+      "name": "shard-recovery",
+      "operation": {
+        "operation-type": "raw-request",
+        "path": {{ "/%s/ccr/shard_changes" | format(recovery_target_index) | tojson }},
+        "method": "GET",
+        "request-params": {
+          "from_seq_no": {{ p_recovery_from_seq_no | tojson }},
+          "max_batch_size": {{ p_recovery_max_batch_size | tojson }},
+          "poll_timeout": {{ p_recovery_poll_timeout | tojson }},
+          "max_operations_count": {{ p_recovery_max_operations_count | tojson }}
+        }
+      },
+      "warmup-iterations": 10,
+      "iterations": 100
+    }
+  ]
+}

--- a/elastic/logs/challenges/synthetic-source-recovery.json
+++ b/elastic/logs/challenges/synthetic-source-recovery.json
@@ -1,7 +1,7 @@
 {% import "rally.helpers" as rally %}
 {
   "name": "synthetic-source-recovery",
-  "description": "Indexes logs for a specified time period and volume per day and then runs the recovery api fetching translog operations for a given tagre index.",
+  "description": "Indexes logs for a specified time period and volume per day and then runs the recovery api fetching translog operations for a given target index.",
   "default": false,
   "schedule": [
     {% include "tasks/index-setup.json" %},

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -60,6 +60,11 @@
 {% set p_dsl_default_rollover = (dsl_default_rollover | default(false) ) %}
 {% set p_skip_fleet_globals = (skip_fleet_globals | default(false) ) %}
 
+{% set p_recovery_from_seq_no = (recovery_seq_no | default(0) ) %}
+{% set p_recovery_max_batch_size = (recovery_max_batch_size | default ("32MB") ) %}
+{% set p_recovery_poll_timeout = (recovery_poll_timeout | default("1m")) %}
+{% set_p_recovery_max_operations_count = (recovery_max_operations_count | default(1048576)) %}
+
 {% set p_worker_threads_enabled = (worker_threads_enabled | default(true))  %}
 
 {% set es_version = "7.13.2" %}

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -63,7 +63,7 @@
 {% set p_recovery_from_seq_no = (recovery_seq_no | default(0) ) %}
 {% set p_recovery_max_batch_size = (recovery_max_batch_size | default ("32MB") ) %}
 {% set p_recovery_poll_timeout = (recovery_poll_timeout | default("1m")) %}
-{% set_p_recovery_max_operations_count = (recovery_max_operations_count | default(1048576)) %}
+{% set p_recovery_max_operations_count = (recovery_max_operations_count | default(1048576)) %}
 
 {% set p_worker_threads_enabled = (worker_threads_enabled | default(true))  %}
 

--- a/elastic/security/README.md
+++ b/elastic/security/README.md
@@ -86,6 +86,12 @@ The following parameters are available:
 * `index_mode` (default: unset) - A parameter meant to be used internally which defines one of the available indexing modes, "standard", "logsdb" or "time_series". If not set, "standard" is used.
 * `synthetic_source_keep` (default: unset) - Allows overriding the default synthetic source behaviour for all field types with the following values: `none` (equivalent to unset) - no source is stored, `arrays` - source stored as is only for multi-value (array) fields.
 * `source_mode` (default: unset) - Specifies the source mode to be used.
+* `use_synthetic_source_recovery` (default: unset): Whether synthetic recovery source will be used.
+* `recovery_target_index` (required) - The target index for fetching shard changes via the recovery API.
+* `recovery_from_seq_no` (default: `0`) - The sequence number from which to start fetching translog operations.
+* `recovery_poll_timeout` (default: `1m`) - The maximum time to wait for additional translog operations before returning an empty result.
+* `recovery_max_batch_size` (default: `32MB`) - The maximum estimated size for the batch of translog operations to return.
+* `recovery_max_operations_count` (default: `1048576`) - The maximum number of translog operations to return in a single batch.
 
 ### Data Generation Parameters
 

--- a/elastic/security/challenges/synthetic-source-recovery.json
+++ b/elastic/security/challenges/synthetic-source-recovery.json
@@ -2,6 +2,7 @@
 {
   "name": "synthetic-source-recovery",
   "description": "Indexes security data for a specified time period and volume per day and then runs the recovery api fetching translog operations for a given target index.",
+  "default": false,
   "schedule": [
     {% include "tasks/index-setup.json" %},
     {

--- a/elastic/security/challenges/synthetic-source-recovery.json
+++ b/elastic/security/challenges/synthetic-source-recovery.json
@@ -1,0 +1,37 @@
+{% import "rally.helpers" as rally %}
+{
+  "name": "synthetic-source-recovery",
+  "description": "Indexes security data for a specified time period and volume per day and then runs the recovery api fetching translog operations for a given tagre index.",
+  "schedule": [
+    {% include "tasks/index-setup.json" %},
+    {
+      "name": "bulk-index",
+      "operation": {
+        "operation-type": "raw-bulk",
+        "param-source": "processed-source",
+        "time-format": "milliseconds",
+        "profile": "fixed_interval",
+        "detailed-results": true,
+        "bulk-size": {{ (bulk_size | default(50)) }}
+      },
+      "ingest-percentage": {{ ingest_percentage | default(100) }},
+      "clients": {{ p_bulk_indexing_clients }}
+    },
+    {
+      "name": "shard-recovery",
+      "operation": {
+        "operation-type": "raw-request",
+        "path": {{ "/%s/ccr/shard_changes" | format(recovery_target_index) | tojson }},
+        "method": "GET",
+        "request-params": {
+          "from_seq_no": {{ p_recovery_from_seq_no | tojson }},
+          "max_batch_size": {{ p_recovery_max_batch_size | tojson }},
+          "poll_timeout": {{ p_recovery_poll_timeout | tojson }},
+          "max_operations_count": {{ p_recovery_max_operations_count | tojson }}
+        }
+      },
+      "warmup-iterations": 10,
+      "iterations": 100
+    }
+  ]
+}

--- a/elastic/security/challenges/synthetic-source-recovery.json
+++ b/elastic/security/challenges/synthetic-source-recovery.json
@@ -1,7 +1,7 @@
 {% import "rally.helpers" as rally %}
 {
   "name": "synthetic-source-recovery",
-  "description": "Indexes security data for a specified time period and volume per day and then runs the recovery api fetching translog operations for a given tagre index.",
+  "description": "Indexes security data for a specified time period and volume per day and then runs the recovery api fetching translog operations for a given target index.",
   "schedule": [
     {% include "tasks/index-setup.json" %},
     {

--- a/elastic/security/track.json
+++ b/elastic/security/track.json
@@ -13,7 +13,7 @@
 {% set p_recovery_from_seq_no = (recovery_seq_no | default(0) ) %}
 {% set p_recovery_max_batch_size = (recovery_max_batch_size | default ("32MB") ) %}
 {% set p_recovery_poll_timeout = (recovery_poll_timeout | default("1m")) %}
-{% set_p_recovery_max_operations_count = (recovery_max_operations_count | default(1048576)) %}
+{% set p_recovery_max_operations_count = (recovery_max_operations_count | default(1048576)) %}
 {% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 {% set p_integration_ratios = (integration_ratios | default({
     "auditbeat": {

--- a/elastic/security/track.json
+++ b/elastic/security/track.json
@@ -10,6 +10,10 @@
 {% set p_number_of_replicas = (number_of_replicas | default(1)) %}
 {% set p_skip_delete_component_template = (skip_delete_component_template | default(false) ) %}
 {% set p_logs_endpoint_from_kibana = (logs_endpoint_from_kibana | default(false) ) %}
+{% set p_recovery_from_seq_no = (recovery_seq_no | default(0) ) %}
+{% set p_recovery_max_batch_size = (recovery_max_batch_size | default ("32MB") ) %}
+{% set p_recovery_poll_timeout = (recovery_poll_timeout | default("1m")) %}
+{% set_p_recovery_max_operations_count = (recovery_max_operations_count | default(1048576)) %}
 {% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 {% set p_integration_ratios = (integration_ratios | default({
     "auditbeat": {

--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -204,6 +204,12 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
 * `document_ids`: documentd IDs to use for search, get and mget apis in the `low-latency` challenge. If empty, a default set of 4 values is used.
 * `synthetic_source_keep` (default: unset): If specified, configures the `index.mapping.synthetic_source_keep` index setting.
+* `use_synthetic_source_recovery` (default: unset): Whether synthetic recovery source will be used.
+* `recovery_target_index` (required) - The target index for fetching shard changes via the recovery API.
+* `recovery_from_seq_no` (default: `0`) - The sequence number from which to start fetching translog operations.
+* `recovery_poll_timeout` (default: `1m`) - The maximum time to wait for additional translog operations before returning an empty result.
+* `recovery_max_batch_size` (default: `32MB`) - The maximum estimated size for the batch of translog operations to return.
+* `recovery_max_operations_count` (default: `1048576`) - The maximum number of translog operations to return in a single batch.
 
 ### License
 

--- a/tsdb/challenges/synthetic-source-recovery.json
+++ b/tsdb/challenges/synthetic-source-recovery.json
@@ -1,5 +1,5 @@
 {
-  "name": "append-no-conflicts",
+  "name": "synthetic-source-recovery",
   "description": "Indexes the whole document corpus and then runs the recovery api fetching translog operations for a given target index.",
   "default": false,
   "schedule": [

--- a/tsdb/challenges/synthetic-source-recovery.json
+++ b/tsdb/challenges/synthetic-source-recovery.json
@@ -1,7 +1,7 @@
 {
   "name": "append-no-conflicts",
   "description": "Indexes the whole document corpus and then runs the recovery api fetching translog operations for a given target index.",
-  "default": true,
+  "default": false,
   "schedule": [
     {# non-serverless-cluster-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     {

--- a/tsdb/challenges/synthetic-source-recovery.json
+++ b/tsdb/challenges/synthetic-source-recovery.json
@@ -1,0 +1,128 @@
+{
+  "name": "append-no-conflicts",
+  "description": "Indexes the whole document corpus.",
+  "default": true,
+  "schedule": [
+    {# non-serverless-cluster-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {
+      "name":"increase-max_buckets_setting",
+      "tags": ["setup"],
+      "operation": {
+        "operation-type": "raw-request",
+        "method": "PUT",
+        "path": "/_cluster/settings",
+        "body": {
+          "transient": {
+            "search.max_buckets" : 300000
+          }
+        },
+        "include-in-reporting": false
+      }
+    },
+    {%- endif -%}{# non-serverless-cluster-settings-marker-end #}
+    {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
+    {
+      "name": "create-all-templates",
+      "operation": {
+        "operation-type": "create-composable-template",
+        "request-params": {
+          "create": "true"
+        }
+      }
+    },
+    {
+      "name": "check-cluster-health",
+      "operation": {
+        "operation-type": "cluster-health",
+        "request-params": {
+          "wait_for_status": "{{cluster_health | default('green')}}",
+          "wait_for_no_relocating_shards": "true"
+        },
+        "retry-until-success": true
+      }
+    },
+    {%- else %}
+    {
+      "operation": "delete-index"
+    },
+    {
+      "operation": {
+        "operation-type": "create-index",
+        "settings": {{index_settings | default({}) | tojson}}
+      }
+    },
+    {
+      "name": "check-cluster-health",
+      "operation": {
+        "operation-type": "cluster-health",
+        "index": "tsdb",
+        "request-params": {
+          "wait_for_status": "{{cluster_health | default('green')}}",
+          "wait_for_no_relocating_shards": "true"
+        },
+        "retry-until-success": true
+      }
+    },
+    {%- endif %}
+    {
+      "operation": "index",
+      "warmup-time-period": 240,
+      "clients": {{bulk_indexing_clients | default(8)}},
+      "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+    },
+    {
+      "name": "refresh-after-index",
+      "operation": "refresh"
+    },
+    {
+      "operation": {
+        "operation-type": "force-merge",
+        "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
+        "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+        {%- endif %}
+      }
+    },
+    {
+      "name": "wait-until-merges-finish",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "_all",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": false
+      }
+    },
+    {
+      "name": "refresh-after-force-merge",
+      "operation": "refresh"
+    },
+    {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+    {
+      "name": "post-ingest-sleep",
+      "operation": {
+        "operation-type": "sleep",
+        "duration": {{ post_ingest_sleep_duration|default(30) }}
+      }
+    },
+    {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
+    {
+      "name": "shard-recovery",
+      "operation": {
+        "operation-type": "raw-request",
+        "path": {{ "/%s/ccr/shard_changes" | format(recovery_target_index) | tojson }},
+        "method": "GET",
+        "request-params": {
+          "from_seq_no": {{ p_recovery_from_seq_no | tojson }},
+          "max_batch_size": {{ p_recovery_max_batch_size | tojson }},
+          "poll_timeout": {{ p_recovery_poll_timeout | tojson }},
+          "max_operations_count": {{ p_recovery_max_operations_count | tojson }}
+        }
+      },
+      "warmup-iterations": 10,
+      "iterations": 100
+    }
+  ]
+}

--- a/tsdb/challenges/synthetic-source-recovery.json
+++ b/tsdb/challenges/synthetic-source-recovery.json
@@ -1,6 +1,6 @@
 {
   "name": "append-no-conflicts",
-  "description": "Indexes the whole document corpus.",
+  "description": "Indexes the whole document corpus and then runs the recovery api fetching translog operations for a given target index.",
   "default": true,
   "schedule": [
     {# non-serverless-cluster-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}

--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -3,7 +3,7 @@
 {% set p_recovery_from_seq_no = (recovery_seq_no | default(0) ) %}
 {% set p_recovery_max_batch_size = (recovery_max_batch_size | default ("32MB") ) %}
 {% set p_recovery_poll_timeout = (recovery_poll_timeout | default("1m")) %}
-{% set_p_recovery_max_operations_count = (recovery_max_operations_count | default(1048576)) %}
+{% set p_recovery_max_operations_count = (recovery_max_operations_count | default(1048576)) %}
 
 {
   "version": 2,

--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -1,5 +1,10 @@
 {% import "rally.helpers" as rally with context %}
 
+{% set p_recovery_from_seq_no = (recovery_seq_no | default(0) ) %}
+{% set p_recovery_max_batch_size = (recovery_max_batch_size | default ("32MB") ) %}
+{% set p_recovery_poll_timeout = (recovery_poll_timeout | default("1m")) %}
+{% set_p_recovery_max_operations_count = (recovery_max_operations_count | default(1048576)) %}
+
 {
   "version": 2,
   "description": "metricbeat information for elastic-app k8s cluster",


### PR DESCRIPTION
After exposing the shard changes api as a rest api in snapshot builds we introduce a new
challenge to exercise the recovery functionality. We do that using a `raw-request` hitting the
`/{index}/ccr/shard_changes` endpoint, with a configurable (required) target index.
When synthetic source is enabled (write) operations in the Translog will use a source filed whose
value is reconstructed using synthetic source, as opposed to using the `_recovery_source` field.
This challenge will provide us with a way to benchmark recovery latency over time
allowing us to spot possible regressions. The challenge is added to `elastic/logs`, `elastic/security`
and `tsdb` tracks which, as of today, make use of synthetic source, as a result of using TSDB
and LogsDB.

A followup PR will introduce nightly benchmarks which will target measuring recovery latency in
all three scenarios.