### PR TITLE
Also propagate synthetic_source_keep if set to none

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -220,7 +220,7 @@ The following parameters are available:
 * `corpora_uri_base` (default: `https://rally-tracks.elastic.co`) - Specify the base location of the datasets used by this track.
 * `lifecycle` (default: unset to fall back on Serverless detection) - Specifies the lifecycle management feature to use for data streams. Use `ilm` for index lifecycle management or `dlm` for data lifecycle management. By default, `dlm` will be used for benchmarking Serverless Elasticsearch.
 * `workflow-request-cache` (default: `true`) - Explicit control of request cache query parameter in searches executed in a workflow. This can be further overriden at an operation level with `request-cache` parameter.
-* `synthetic_source_keep` (default: unset) - Allows overriding the default synthetic source behaviour for all field types with the following values: `none` (equivalent to unset) - no source is stored, `arrays` - source stored as is only for multi-value (array) fields.
+* `synthetic_source_keep` (default: unset): If specified, configures the `index.mapping.synthetic_source_keep` index setting.
 * `source_mode` (default: unset) - Specifies the source mode to be used.
 
 ### Data Download Parameters

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -4,7 +4,7 @@
         {% if index_mode %}
         "index": {
             "mode": {{ index_mode | tojson }}
-            {% if synthetic_source_keep and synthetic_source_keep != 'none' %}
+            {% if synthetic_source_keep %}
             ,"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
             {% endif %}
         }

--- a/elastic/security/README.md
+++ b/elastic/security/README.md
@@ -84,7 +84,7 @@ The following parameters are available:
 * `wait_for_status` (default: `green`) - The track creates Data Streams prior to indexing. All created Data Streams must at least reach this status before indexing commences. Reduce to `yellow` for clusters where green isn't possible e.g. single node.
 * `corpora_uri_base` (default: `https://rally-tracks.elastic.co`) - Specify the base location of the datasets used by this track.
 * `index_mode` (default: unset) - A parameter meant to be used internally which defines one of the available indexing modes, "standard", "logsdb" or "time_series". If not set, "standard" is used.
-* `synthetic_source_keep` (default: unset) - Allows overriding the default synthetic source behaviour for all field types with the following values: `none` (equivalent to unset) - no source is stored, `arrays` - source stored as is only for multi-value (array) fields.
+* `synthetic_source_keep` (default: unset): If specified, configures the `index.mapping.synthetic_source_keep` index setting.
 * `source_mode` (default: unset) - Specifies the source mode to be used.
 
 ### Data Generation Parameters

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -4,7 +4,7 @@
         {% if index_mode %}
         "index": {
             "mode": {{ index_mode | tojson }},
-            {% if synthetic_source_keep and synthetic_source_keep != 'none' %}
+            {% if synthetic_source_keep %}
             "mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}},
             {% endif %}
             "sort.field": [ "host.id", "@timestamp" ],


### PR DESCRIPTION
In both elastic/logs and elastic/security tracks.