### PR TITLE
Don't index rally.* fields in elastic/logs track

### DIFF
--- a/elastic/logs/templates/component/track-custom-mappings.json
+++ b/elastic/logs/templates/component/track-custom-mappings.json
@@ -17,10 +17,12 @@
         "rally": {
           "properties" : {
             "doc_size": {
-              "type": "long"
+              "type": "long",
+              "index": false
             },
             "message_size": {
-              "type": "long"
+              "type": "long",
+              "index": false
             }
           }
         }

--- a/elastic/logs/templates/component/track-custom-mappings.json
+++ b/elastic/logs/templates/component/track-custom-mappings.json
@@ -1,6 +1,15 @@
 {
   "template" : {
     "mappings" : {
+      {% if index_mode | default('standard') is equalto 'standard' %}
+      "runtime": {
+        "rally.doc_size": {
+          "type": "long"
+        },
+        "rally.message_size": {
+          "type": "long"
+        }
+      },{% endif %}
       "properties" : {
         "event": {
           "properties": {
@@ -13,7 +22,7 @@
               "format": "strict_date_optional_time"
             }
           }
-        },
+        }{% if index_mode | default('standard') is equalto 'logsdb' %},
         "rally": {
           "properties" : {
             "doc_size": {
@@ -25,7 +34,7 @@
               "index": false
             }
           }
-        }
+        }{% endif %}
       }
     }
   },


### PR DESCRIPTION
and in case of none logsdb fallback to runtime fields that rely on source. The latter is to reduce noice seen elastic/logs standard runs.

The rally.* fields don't need to be indexed, and just need to be stored as doc values in case logsdb mode. Before this fields were stored in _ignored_source but now both indexed and doc values enabled. With this change we just keeps doc doc values.