### PR TITLE
Configure routing on sort fields for logsdb

### DIFF
--- a/elastic/logs/templates/component/auditbeat-mappings.json
+++ b/elastic/logs/templates/component/auditbeat-mappings.json
@@ -8,6 +8,13 @@
           }
         },
         "refresh_interval": "30s",
+        {% if route_on_sort_fields | default(false) is true %}
+        "sort": {
+           "field": [ "host.name", "kubernetes.pod.uid", "log.logger", "@timestamp" ],
+           "order": [ "asc", "asc", "asc", "desc" ]
+        },
+        "logsdb.route_on_sort_fields": true,
+        {% endif %}
         {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         "max_docvalue_fields_search": 200,
         "number_of_shards": 1,

--- a/elastic/logs/templates/component/logs-apache.access@package.json
+++ b/elastic/logs/templates/component/logs-apache.access@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-apache.access-1.18.0",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "user_agent.name", "log.file.path", "@timestamp" ],
+            "order": [ "asc", "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"

--- a/elastic/logs/templates/component/logs-apache.error@package.json
+++ b/elastic/logs/templates/component/logs-apache.error@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-apache.error-1.18.0",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "user_agent.name", "log.file.path", "@timestamp" ],
+            "order": [ "asc", "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"

--- a/elastic/logs/templates/component/logs-kafka.log@package.json
+++ b/elastic/logs/templates/component/logs-kafka.log@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-kafka.log-1.13.0",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "event.type", "kafka.log.component", "@timestamp" ],
+            "order": [ "asc", "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"

--- a/elastic/logs/templates/component/logs-mysql.error@package.json
+++ b/elastic/logs/templates/component/logs-mysql.error@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-mysql.error-1.19.0",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "event.type", "log.file.path", "@timestamp" ],
+            "order": [ "asc", "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"

--- a/elastic/logs/templates/component/logs-mysql.slowlog@package.json
+++ b/elastic/logs/templates/component/logs-mysql.slowlog@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-mysql.slowlog-1.19.0",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "user.name", "log.file.path", "@timestamp" ],
+            "order": [ "asc", "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"

--- a/elastic/logs/templates/component/logs-nginx.access@package.json
+++ b/elastic/logs/templates/component/logs-nginx.access@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-nginx.access-1.20.0",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "user_agent.name", "log.file.path", "@timestamp" ],
+            "order": [ "asc", "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"

--- a/elastic/logs/templates/component/logs-nginx.error@package.json
+++ b/elastic/logs/templates/component/logs-nginx.error@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-nginx.error-1.20.0",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "input.type", "log.file.path", "@timestamp" ],
+            "order": [ "asc", "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"

--- a/elastic/logs/templates/component/logs-postgresql.log@package.json
+++ b/elastic/logs/templates/component/logs-postgresql.log@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-postgresql.log-1.20.0",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "error.code", "event.code", "@timestamp" ],
+            "order": [ "asc", "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"

--- a/elastic/logs/templates/component/logs-redis.log@package.json
+++ b/elastic/logs/templates/component/logs-redis.log@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-redis.log-1.15.0",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "redis.log.role", "log.level", "@timestamp" ],
+            "order": [ "asc", "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"

--- a/elastic/logs/templates/component/logs-redis.slowlog@package.json
+++ b/elastic/logs/templates/component/logs-redis.slowlog@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-redis.slowlog-1.15.0",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "redis.slowlog.key", "@timestamp" ],
+            "order": [ "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"

--- a/elastic/logs/templates/component/logs-system.auth@package.json
+++ b/elastic/logs/templates/component/logs-system.auth@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-system.auth-1.58.1",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "event.code", "log.file.path", "@timestamp" ],
+            "order": [ "asc", "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"

--- a/elastic/logs/templates/component/logs-system.syslog@package.json
+++ b/elastic/logs/templates/component/logs-system.syslog@package.json
@@ -7,6 +7,13 @@
           {%- if disable_pipelines is not true %}
           "default_pipeline": "logs-system.syslog-1.58.1",
           {%- endif %}
+          {% if route_on_sort_fields | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "event.code", "log.file.path", "@timestamp" ],
+            "order": [ "asc", "asc", "asc", "desc" ]
+          },
+          "logsdb.route_on_sort_fields": true,
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"


### PR DESCRIPTION
Introduce param `route_on_sort_fields` to (a) add per-index sort config and (b) set `logsdb.route_on_sort_fields`. The plan is to set up separate reporting in nightlies to observe the impact of this configuration to dataset size and indexing performance, along with the default configuration.

Demo: 
```
esrally compare --baseline=896d854d-e9bd-4d13-906f-e3c8ab6debb7   --contender=b28e997e-26c1-4f35-b098-b7603a13fee0  --config esbench
```