### PR TITLE
ES|QL join: add SORT and KEEP queries and SMALL challenge

### DIFF
--- a/joins/challenges/default.json
+++ b/joins/challenges/default.json
@@ -1,7 +1,7 @@
     {
       "name": "esql",
       "description": "Performance benchmarks for internal R&D on query languages. This is work in progress",
-      "default": false,
+      "default": true,
       "schedule": [
         {
           "operation": "delete-index",

--- a/joins/challenges/default.json
+++ b/joins/challenges/default.json
@@ -101,8 +101,8 @@
           "operation": "esql_lookup_join_1k_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         },
         {
           "operation": "esql_lookup_join_1k_keys_where_limit1000",
@@ -115,8 +115,8 @@
           "operation": "esql_lookup_join_1k_keys_where_no_match",
           "tags": ["lookup", "join"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         },
 
 
@@ -152,8 +152,8 @@
           "operation": "esql_lookup_join_100k_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         },
         {
           "operation": "esql_lookup_join_100k_keys_where_limit1000",
@@ -166,8 +166,8 @@
           "operation": "esql_lookup_join_100k_keys_where_no_match",
           "tags": ["lookup", "join"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         #}
 
 
@@ -203,8 +203,8 @@
           "operation": "esql_lookup_join_200k_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         },
         {
           "operation": "esql_lookup_join_200k_keys_where_limit1000",
@@ -217,8 +217,8 @@
           "operation": "esql_lookup_join_200k_keys_where_no_match",
           "tags": ["lookup", "join"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         #}
 
 
@@ -254,8 +254,8 @@
           "operation": "esql_lookup_join_500k_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         },
         {
           "operation": "esql_lookup_join_500k_keys_where_limit1000",
@@ -268,8 +268,8 @@
           "operation": "esql_lookup_join_500k_keys_where_no_match",
           "tags": ["lookup", "join"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         #}
 
 
@@ -305,8 +305,8 @@
           "operation": "esql_lookup_join_1M_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         },
         {
           "operation": "esql_lookup_join_1M_keys_where_limit1000",
@@ -319,8 +319,8 @@
           "operation": "esql_lookup_join_1M_keys_where_no_match",
           "tags": ["lookup", "join"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         #}
 
 
@@ -356,8 +356,8 @@
           "operation": "esql_lookup_join_5M_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         },
         {
           "operation": "esql_lookup_join_5M_keys_where_limit1000",
@@ -370,8 +370,8 @@
           "operation": "esql_lookup_join_5M_keys_where_no_match",
           "tags": ["lookup", "join"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         #}
 
 
@@ -407,8 +407,8 @@
           "operation": "esql_lookup_join_100M_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         },
         {
           "operation": "esql_lookup_join_100M_keys_where_limit1000",
@@ -421,8 +421,8 @@
           "operation": "esql_lookup_join_100M_keys_where_no_match",
           "tags": ["lookup", "join"],
           "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
+          "warmup-iterations": 5,
+          "iterations": 20
         #}
 
 

--- a/joins/challenges/default.json
+++ b/joins/challenges/default.json
@@ -91,6 +91,20 @@
           "iterations": 50
         },
         {
+          "operation": "esql_lookup_join_1k_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
           "operation": "esql_lookup_join_1k_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
           "clients": 1,
@@ -122,6 +136,20 @@
         },
         {
           "operation": "esql_lookup_join_100k_keys_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
           "clients": 1,
           "warmup-iterations": 10,
@@ -165,6 +193,20 @@
           "iterations": 50
         },
         {
+          "operation": "esql_lookup_join_200k_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_200k_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
           "operation": "esql_lookup_join_200k_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
           "clients": 1,
@@ -196,6 +238,20 @@
         },
         {
           "operation": "esql_lookup_join_500k_keys_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_500k_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_500k_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
           "clients": 1,
           "warmup-iterations": 10,
@@ -239,6 +295,20 @@
           "iterations": 50
         },
         {
+          "operation": "esql_lookup_join_1M_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_1M_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
           "operation": "esql_lookup_join_1M_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
           "clients": 1,
@@ -276,6 +346,20 @@
           "iterations": 50
         },
         {
+          "operation": "esql_lookup_join_5M_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_5M_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
           "operation": "esql_lookup_join_5M_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
           "clients": 1,
@@ -307,6 +391,20 @@
         },
         {
           "operation": "esql_lookup_join_100M_keys_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100M_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100M_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
           "clients": 1,
           "warmup-iterations": 10,

--- a/joins/challenges/small.json
+++ b/joins/challenges/small.json
@@ -1,0 +1,382 @@
+    {
+      "name": "esql-small",
+      "description": "Performance benchmarks for internal R&D on query languages. Only running smaller indexes",
+      "default": false,
+      "schedule": [
+        {
+          "operation": "delete-index",
+          "tags": ["setup"]
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
+              {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+                {% if p_include_non_serverless_index_settings %}
+              "index.translog.flush_threshold_size": "4g",
+                {% endif %}
+              {%- endif -%}{# non-serverless-index-settings-marker-end #}
+              "index.codec": "best_compression",
+              "index.refresh_interval": "30s"
+            }{%- endif %}
+          },
+          "tags": ["setup"]
+        },
+
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "join_base_idx",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            },
+            "retry-until-success": true
+          },
+          "tags": ["setup"]
+        },
+
+        {
+          "operation": "index-base",
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "tags": ["setup"]
+        },
+        {
+          "operation": "index-small-lookup-indices",
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "tags": ["setup"]
+        },
+        {
+          "operation": "index-lookup-1m",
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "tags": ["setup"]
+        },
+        {
+          "operation": "index-lookup-5m",
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "tags": ["setup"]
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "tags": ["setup"]
+        },
+
+
+        {
+          "operation": "esql_lookup_join_1k_keys_limit1",
+          "tags": ["lookup", "join", "limit1"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_no_match",
+          "tags": ["lookup", "join"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+
+
+        {
+          "operation": "esql_lookup_join_100k_keys_limit1",
+          "tags": ["lookup", "join", "limit1"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_where_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {#
+          "operation": "esql_lookup_join_100k_keys_where_no_match",
+          "tags": ["lookup", "join"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        #}
+
+
+        {
+          "operation": "esql_lookup_join_200k_keys_limit1",
+          "tags": ["lookup", "join", "limit1"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_200k_keys_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_200k_keys_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_200k_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_200k_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_200k_keys_where_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {#
+          "operation": "esql_lookup_join_200k_keys_where_no_match",
+          "tags": ["lookup", "join"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        #}
+
+
+        {
+          "operation": "esql_lookup_join_500k_keys_limit1",
+          "tags": ["lookup", "join", "limit1"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_500k_keys_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_500k_keys_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_500k_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_500k_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_500k_keys_where_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {#
+          "operation": "esql_lookup_join_500k_keys_where_no_match",
+          "tags": ["lookup", "join"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        #}
+
+
+        {
+          "operation": "esql_lookup_join_1M_keys_limit1",
+          "tags": ["lookup", "join", "limit1"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_1M_keys_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_1M_keys_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_1M_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_1M_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1M_keys_where_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {#
+          "operation": "esql_lookup_join_1M_keys_where_no_match",
+          "tags": ["lookup", "join"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        #}
+
+
+        {
+          "operation": "esql_lookup_join_5M_keys_limit1",
+          "tags": ["lookup", "join", "limit1"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_5M_keys_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_5M_keys_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_5M_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_5M_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_5M_keys_where_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {#
+          "operation": "esql_lookup_join_5M_keys_where_no_match",
+          "tags": ["lookup", "join"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        #}
+
+        {
+          "operation": "esql_lookup_join_1k_100k_200k_500k",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        }
+
+
+      ]
+    }

--- a/joins/challenges/small.json
+++ b/joins/challenges/small.json
@@ -144,13 +144,6 @@
           "iterations": 50
         },
         {
-          "operation": "esql_lookup_join_100k_keys_sort_limit10000",
-          "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
-          "warmup-iterations": 5,
-          "iterations": 20
-        },
-        {
           "operation": "esql_lookup_join_100k_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
           "clients": 1,
@@ -193,13 +186,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
-        },
-        {
-          "operation": "esql_lookup_join_200k_keys_sort_limit10000",
-          "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
-          "warmup-iterations": 5,
-          "iterations": 20
         },
         {
           "operation": "esql_lookup_join_200k_keys_where_limit1000",
@@ -246,13 +232,6 @@
           "iterations": 50
         },
         {
-          "operation": "esql_lookup_join_500k_keys_sort_limit10000",
-          "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
-          "warmup-iterations": 5,
-          "iterations": 20
-        },
-        {
           "operation": "esql_lookup_join_500k_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
           "clients": 1,
@@ -297,13 +276,6 @@
           "iterations": 50
         },
         {
-          "operation": "esql_lookup_join_1M_keys_sort_limit10000",
-          "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
-          "warmup-iterations": 5,
-          "iterations": 20
-        },
-        {
           "operation": "esql_lookup_join_1M_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
           "clients": 1,
@@ -346,13 +318,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
-        },
-        {
-          "operation": "esql_lookup_join_5M_keys_sort_limit10000",
-          "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
-          "warmup-iterations": 5,
-          "iterations": 20
         },
         {
           "operation": "esql_lookup_join_5M_keys_where_limit1000",

--- a/joins/operations/default.json
+++ b/joins/operations/default.json
@@ -57,6 +57,16 @@
       "query": "FROM join_base_idx | lookup join lookup_idx_1000_f10 on key_1000 | limit 10000"
     },
     {
+      "name": "esql_lookup_join_1k_keys_keep_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_1000_f10 on key_1000 | keep @timestamp, lookup_keyword_0 | limit 10000"
+    },
+    {
+      "name": "esql_lookup_join_1k_keys_sort_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_1000_f10 on key_1000 | sort lookup_keyword_0 asc | limit 10000"
+    },
+    {
       "name": "esql_lookup_join_1k_keys_where_limit1000",
       "operation-type": "esql",
       "query": "FROM join_base_idx | lookup join lookup_idx_1000_f10 on key_1000 | where lookup_keyword_0 like \"val 1*\" | limit 1000"
@@ -82,6 +92,16 @@
       "name": "esql_lookup_join_100k_keys_limit10000",
       "operation-type": "esql",
       "query": "FROM join_base_idx | lookup join lookup_idx_100000_f10 on key_100000 | limit 10000"
+    },
+    {
+      "name": "esql_lookup_join_100k_keys_keep_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_100000_f10 on key_100000 | keep @timestamp, lookup_keyword_0 | limit 10000"
+    },
+    {
+      "name": "esql_lookup_join_100k_keys_sort_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_100000_f10 on key_100000 | sort lookup_keyword_0 asc | limit 10000"
     },
     {
       "name": "esql_lookup_join_100k_keys_where_limit1000",
@@ -111,6 +131,16 @@
       "query": "FROM join_base_idx | lookup join lookup_idx_200000_f10 on key_200000 | limit 10000"
     },
     {
+      "name": "esql_lookup_join_200k_keys_keep_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_200000_f10 on key_200000 | keep @timestamp, lookup_keyword_0 | limit 10000"
+    },
+    {
+      "name": "esql_lookup_join_200k_keys_sort_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_200000_f10 on key_200000 | sort lookup_keyword_0 asc | limit 10000"
+    },
+    {
       "name": "esql_lookup_join_200k_keys_where_limit1000",
       "operation-type": "esql",
       "query": "FROM join_base_idx | lookup join lookup_idx_200000_f10 on key_200000 | where lookup_keyword_0 like \"val 1*\" | limit 1000"
@@ -136,6 +166,16 @@
       "name": "esql_lookup_join_500k_keys_limit10000",
       "operation-type": "esql",
       "query": "FROM join_base_idx | lookup join lookup_idx_500000_f10 on key_500000 | limit 10000"
+    },
+    {
+      "name": "esql_lookup_join_500k_keys_keep_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_500000_f10 on key_500000 | keep @timestamp, lookup_keyword_0 | limit 10000"
+    },
+    {
+    "name": "esql_lookup_join_500k_keys_sort_limit10000",
+    "operation-type": "esql",
+    "query": "FROM join_base_idx | lookup join lookup_idx_500000_f10 on key_500000 | sort lookup_keyword_0 asc | limit 10000"
     },
     {
       "name": "esql_lookup_join_500k_keys_where_limit1000",
@@ -165,6 +205,16 @@
       "query": "FROM join_base_idx | lookup join lookup_idx_1000000_f10 on key_1000000 | limit 10000"
     },
     {
+      "name": "esql_lookup_join_1M_keys_keep_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_1000000_f10 on key_1000000 | keep @timestamp, lookup_keyword_0 | limit 10000"
+    },
+    {
+      "name": "esql_lookup_join_1M_keys_sort_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_1000000_f10 on key_1000000 | sort lookup_keyword_0 | limit 10000"
+    },
+    {
       "name": "esql_lookup_join_1M_keys_where_limit1000",
       "operation-type": "esql",
       "query": "FROM join_base_idx | lookup join lookup_idx_1000000_f10 on key_1000000 | where lookup_keyword_0 like \"val 1*\" | limit 1000"
@@ -192,6 +242,16 @@
       "query": "FROM join_base_idx | lookup join lookup_idx_5000000_f10 on key_5000000 | limit 10000"
     },
     {
+      "name": "esql_lookup_join_5M_keys_keep_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_5000000_f10 on key_5000000 | keep @timestamp, lookup_keyword_0 | limit 10000"
+    },
+    {
+      "name": "esql_lookup_join_5M_keys_sort_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_5000000_f10 on key_5000000 | sort lookup_keyword_0 | limit 10000"
+    },
+    {
       "name": "esql_lookup_join_5M_keys_where_limit1000",
       "operation-type": "esql",
       "query": "FROM join_base_idx | lookup join lookup_idx_5000000_f10 on key_5000000 | where lookup_keyword_0 like \"val 1*\" | limit 1000"
@@ -217,6 +277,16 @@
       "name": "esql_lookup_join_100M_keys_limit10000",
       "operation-type": "esql",
       "query": "FROM join_base_idx | lookup join lookup_idx_100000000_f10 on key_100000000 | limit 10000"
+    },
+    {
+      "name": "esql_lookup_join_100M_keys_keep_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_100000000_f10 on key_100000000 | keep @timestamp, lookup_keyword_0 | limit 10000"
+    },
+    {
+      "name": "esql_lookup_join_100M_keys_sort_limit10000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_100000000_f10 on key_100000000 | sort lookup_keyword_0 | limit 10000"
     },
     {
       "name": "esql_lookup_join_100M_keys_where_limit1000",


### PR DESCRIPTION
- Adding queries with SORT and KEEP together with JOIN.
- Reducing the iterations for some queries that are particularly expensive
- Adding an `esql-small` challenge that doesn't use the biggest lookup index (100M records)
