### PR TITLE
Configure routing on sort fields for logsdb for logs-k8-application

### DIFF
--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -25,6 +25,13 @@
         "default_pipeline": "logs-k8-app",
         {%- endif %}
         "refresh_interval": "5s"
+        {% if route_on_sort_fields | default(false) is true %}
+        "sort": {
+          "field": [ "host.name", "log.file.path", "@timestamp" ],
+          "order": [ "asc", "asc", "desc" ]
+        },
+        "logsdb.route_on_sort_fields": true,
+        {% endif %}
       }
     },
     "mappings": {


### PR DESCRIPTION
This was missed in #720.