### PR TITLE
Temporarily disable joins in IT

### DIFF
--- a/it/test_all_tracks_and_challenges.py
+++ b/it/test_all_tracks_and_challenges.py
@@ -21,7 +21,7 @@ pytest_rally = pytest.importorskip("pytest_rally")
 
 
 class TestTrackRepository:
-    skip_tracks = ["elastic/logs", "elastic/security", "k8s_metrics", "sql", "elser-ingest-speedtest", "msmarco-v2-vector"]
+    skip_tracks = ["elastic/logs", "elastic/security", "k8s_metrics", "sql", "elser-ingest-speedtest", "msmarco-v2-vector", "joins"]
     disable_assertions = {
         "http_logs": ["append-no-conflicts", "runtime-fields"],
         "nyc_taxis": ["update-aggs-only"],


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/120073 has meant that lookup indices in the joins track are left in yellow. Discussion is ongoing, but to unblock CI i suggest temporarily disabling joins for IT tests