### PR TITLE
Add auto_expand_replicas to joins track

### DIFF
--- a/joins/README.md
+++ b/joins/README.md
@@ -45,6 +45,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `index_settings`: A list of index settings. Index settings defined elsewhere need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
+* `auto_expand_replicas` (default: "0-all"): Set the auto_expand_replicas behaviour for lookup indices.
 
 
 ### License

--- a/joins/index-lookup_idx_100000000_f10.json
+++ b/joins/index-lookup_idx_100000000_f10.json
@@ -2,7 +2,8 @@
 
 {
   "settings": {
-        "index.mode": "lookup"
+        "index.mode": "lookup",
+        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}

--- a/joins/index-lookup_idx_1000000_f10.json
+++ b/joins/index-lookup_idx_1000000_f10.json
@@ -2,7 +2,8 @@
 
 {
   "settings": {
-        "index.mode": "lookup"
+        "index.mode": "lookup",
+        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}

--- a/joins/index-lookup_idx_100000_f10.json
+++ b/joins/index-lookup_idx_100000_f10.json
@@ -2,7 +2,8 @@
 
 {
   "settings": {
-        "index.mode": "lookup"
+        "index.mode": "lookup",
+        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}

--- a/joins/index-lookup_idx_1000_f10.json
+++ b/joins/index-lookup_idx_1000_f10.json
@@ -2,7 +2,8 @@
 
 {
   "settings": {
-        "index.mode": "lookup"
+        "index.mode": "lookup",
+        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}

--- a/joins/index-lookup_idx_200000_f10.json
+++ b/joins/index-lookup_idx_200000_f10.json
@@ -2,7 +2,8 @@
 
 {
   "settings": {
-        "index.mode": "lookup"
+        "index.mode": "lookup",
+        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}

--- a/joins/index-lookup_idx_5000000_f10.json
+++ b/joins/index-lookup_idx_5000000_f10.json
@@ -2,7 +2,8 @@
 
 {
   "settings": {
-        "index.mode": "lookup"
+        "index.mode": "lookup",
+        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}

--- a/joins/index-lookup_idx_500000_f10.json
+++ b/joins/index-lookup_idx_500000_f10.json
@@ -2,7 +2,8 @@
 
 {
   "settings": {
-        "index.mode": "lookup"
+        "index.mode": "lookup",
+        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}


### PR DESCRIPTION
The behaviour of auto_expand_replicas has changed which means that even in IT tests, we default to having a single replica. This unblocks the IT tests and also adds a new option to control the auto_expand_replicas behaviour for lookup indices