### PR TITLE
Bump versions after 3.8 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os:
           - macos-13
           - ubuntu-latest
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.12"]
 
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
Now rally needs 3.9 or later, we need to bump versions in rally-tracks system tests