### PR TITLE
ES|QL JOIN: non existing keys and duplicate keys

### DIFF
--- a/joins/challenges/default.json
+++ b/joins/challenges/default.json
@@ -125,6 +125,14 @@
 {% endfor %}
 
         {
+          "operation": "esql_lookup_join_100k_keys_x10_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 50
+        },
+
+        {
           "operation": "esql_lookup_join_1k_keys_where_no_match",
           "tags": ["lookup", "join"],
           "clients": 1,

--- a/joins/challenges/default.json
+++ b/joins/challenges/default.json
@@ -114,6 +114,16 @@
         },
 {% endfor %}
 
+{% for i in range(2, 7) %}
+        {
+          "operation": "esql_lookup_join_100k_to_{{idx_suffix[i]}}",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+{% endfor %}
+
         {
           "operation": "esql_lookup_join_1k_keys_where_no_match",
           "tags": ["lookup", "join"],
@@ -129,7 +139,6 @@
           "warmup-iterations": 10,
           "iterations": 50
         }
-
 
       ]
     }

--- a/joins/challenges/large.json
+++ b/joins/challenges/large.json
@@ -1,6 +1,6 @@
     {
-      "name": "esql-small",
-      "description": "Performance benchmarks for internal R&D on query languages. Only running smaller indexes",
+      "name": "esql-large",
+      "description": "Performance benchmarks for internal R&D on query languages. This is work in progress",
       "default": false,
       "schedule": [
         {
@@ -58,13 +58,18 @@
           "tags": ["setup"]
         },
         {
+          "operation": "index-lookup-100m",
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "tags": ["setup"]
+        },
+        {
           "name": "refresh-after-index",
           "operation": "refresh",
           "tags": ["setup"]
         },
 
 
-{% for i in range(idx_suffix|length - 1) %}
+{% for i in range(idx_suffix|length) %}
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit1",
           "tags": ["lookup", "join", "limit1"],
@@ -94,6 +99,20 @@
           "iterations": 50
         },
         {
+          "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_no_match",
+          "tags": ["lookup", "join"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
           "clients": 1,
@@ -102,7 +121,7 @@
         },
 {% endfor %}
 
-{% for i in range(2, 6) %}
+{% for i in range(2, 7) %}
         {
           "operation": "esql_lookup_join_100k_to_{{idx_suffix[i]}}",
           "tags": ["lookup", "join", "limit1000"],
@@ -111,22 +130,6 @@
           "iterations": 50
         },
 {% endfor %}
-
-        {
-          "operation": "esql_lookup_join_1k_keys_sort_limit10000",
-          "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
-          "warmup-iterations": 5,
-          "iterations": 20
-        },
-
-        {
-          "operation": "esql_lookup_join_1k_keys_where_no_match",
-          "tags": ["lookup", "join"],
-          "clients": 1,
-          "warmup-iterations": 5,
-          "iterations": 20
-        },
 
         {
           "operation": "esql_lookup_join_1k_100k_200k_500k",

--- a/joins/challenges/large.json
+++ b/joins/challenges/large.json
@@ -132,6 +132,14 @@
 {% endfor %}
 
         {
+          "operation": "esql_lookup_join_100k_keys_x10_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 50
+        },
+
+        {
           "operation": "esql_lookup_join_1k_100k_200k_500k",
           "tags": ["lookup", "join", "limit1000"],
           "clients": 1,

--- a/joins/challenges/small.json
+++ b/joins/challenges/small.json
@@ -113,6 +113,14 @@
 {% endfor %}
 
         {
+          "operation": "esql_lookup_join_100k_keys_x10_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 50
+        },
+
+        {
           "operation": "esql_lookup_join_1k_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
           "clients": 1,

--- a/joins/index-lookup_idx_100000_f10_x10.json
+++ b/joins/index-lookup_idx_100000_f10_x10.json
@@ -1,0 +1,21 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+
+{
+  "settings": {
+        "index.mode": "lookup",
+        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+    {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    , "index.requests.cache.enable": false
+    {%- endif -%}{# non-serverless-index-settings-marker-end #}
+  },
+  "mappings": {
+    "_source": {
+      "mode": {{ source_mode | default("stored") | tojson }}
+    },
+    "properties": {
+      "key_100000": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/joins/operations/default.json
+++ b/joins/operations/default.json
@@ -20,6 +20,13 @@
       "ingest-percentage": 100
     },
     {
+      "name": "index-lookup-100k_x10",
+      "operation-type": "bulk",
+      "indices": ["lookup_idx_100000_f10_x10"],
+      "bulk-size": {{bulk_size | default(10000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}}
+    },
+    {
       "name": "index-lookup-1m",
       "operation-type": "bulk",
       "indices": ["lookup_idx_1000000_f10"],
@@ -92,6 +99,11 @@
     },
 {% endfor %}
 
+    {
+      "name": "esql_lookup_join_100k_keys_x10_limit1000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_100000_f10_x10 on key_100000 | limit 1000"
+    },
     {
       "name": "esql_lookup_join_1k_100k_200k_500k",
       "operation-type": "esql",

--- a/joins/operations/default.json
+++ b/joins/operations/default.json
@@ -84,13 +84,16 @@
 {% endfor %}
 
 
+{% for i in range(2, 7) %}
     {
-    "name": "esql_lookup_join_1k_100k_200k_500k",
-    "operation-type": "esql",
-    "query": "FROM join_base_idx | lookup join lookup_idx_1000_f10 on key_1000 | rename lookup_keyword_0 as lk_1k | lookup join lookup_idx_100000_f10 on key_100000 | rename lookup_keyword_0 as lk_100k | lookup join lookup_idx_200000_f10 on key_200000 | rename lookup_keyword_0 as lk_200k | lookup join lookup_idx_500000_f10 on key_500000 | rename lookup_keyword_0 as lk_500k | keep id, key_1000, key_100000, key_200000, key_500000, lk_1k, lk_100k, lk_200k, lk_500k | limit 1000"
+      "name": "esql_lookup_join_100k_to_{{idx_suffix[i]}}",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | rename key_100000 as key_{{key_suffix[i]}}| lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1000"
+    },
+{% endfor %}
+
+    {
+      "name": "esql_lookup_join_1k_100k_200k_500k",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_1000_f10 on key_1000 | rename lookup_keyword_0 as lk_1k | lookup join lookup_idx_100000_f10 on key_100000 | rename lookup_keyword_0 as lk_100k | lookup join lookup_idx_200000_f10 on key_200000 | rename lookup_keyword_0 as lk_200k | lookup join lookup_idx_500000_f10 on key_500000 | rename lookup_keyword_0 as lk_500k | keep id, key_1000, key_100000, key_200000, key_500000, lk_1k, lk_100k, lk_200k, lk_500k | limit 1000"
     }
-
-
-
-
-

--- a/joins/track.json
+++ b/joins/track.json
@@ -17,6 +17,10 @@
       "body": "index-lookup_idx_100000_f10.json"
     },
     {
+      "name": "lookup_idx_100000_f10_x10",
+      "body": "index-lookup_idx_100000_f10_x10.json"
+    },
+    {
       "name": "lookup_idx_200000_f10",
       "body": "index-lookup_idx_200000_f10.json"
     },
@@ -63,6 +67,20 @@
           "document-count": 100000,
           "compressed-bytes": 2248693,
           "uncompressed-bytes": 41277790
+        }
+      ]
+    },
+    {
+      "name": "lookup_idx_100000_f10_x10",
+      "base-url": "https://rally-tracks.elastic.co/joins",
+      "documents": [
+        {
+          "target-index": "lookup_idx_100000_f10_x10",
+          "source-file": "lookup_idx_100000_f10_x10.json.bz2",
+          "#COMMENT": "Lookup index with 1M documents and 100k distinct keys (keyworks, \"0\"..\"99999\")",
+          "document-count": 1000000,
+          "compressed-bytes": 22483295,
+          "uncompressed-bytes": 412777900
         }
       ]
     },


### PR DESCRIPTION
Adding queries for
- queries where some join keys are missing in the lookup index.
- duplicate keys, ie. the lookup index contains 10 records per join key 
- a "large" track that runs expensive queries for all the cardinalities
