### PR TITLE
[8.15] Bump versions after 3.8 deprecation (#729)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os:
           - macos-13
           - ubuntu-latest
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.12"]
 
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.15`:
 - [Bump versions after 3.8 deprecation (#729)](https://github.com/elastic/rally-tracks/pull/729)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Gareth Ellis","email":"gareth.ellis@elastic.co"},"sourceCommit":{"committedDate":"2025-01-17T15:25:55Z","message":"Bump versions after 3.8 deprecation (#729)","sha":"17cc2023637360264201f38fa9577c1a87471817","branchLabelMapping":{"^backport-to-(.+)$":"$1"}},"sourcePullRequest":{"labels":["backport-to-8.15"],"title":"Bump versions after 3.8 deprecation","number":729,"url":"https://github.com/elastic/rally-tracks/pull/729","mergeCommit":{"message":"Bump versions after 3.8 deprecation (#729)","sha":"17cc2023637360264201f38fa9577c1a87471817"}},"sourceBranch":"master","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"8.15","label":"backport-to-8.15","branchLabelMappingKey":"^backport-to-(.+)$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->