### PR TITLE
Bump Wikipedia export version

### DIFF
--- a/wikipedia/_tools/parse_documents.py
+++ b/wikipedia/_tools/parse_documents.py
@@ -5,7 +5,7 @@ from xml.etree import cElementTree
 
 PAGE_TAG = "page"
 SITEINFO_TAG = "siteinfo"
-XML_NAMESPACES = {"": "http://www.mediawiki.org/xml/export-0.10/"}
+XML_NAMESPACES = {"": "http://www.mediawiki.org/xml/export-0.11/"}
 
 
 def doc_generator(f):


### PR DESCRIPTION
To fix
```bash
> python _tools/parse_documents.py dewiki-20250120-pages-articles.xml.bz2

Traceback (most recent call last):
  File "/Users/maxjakob/src/rally-tracks/wikipedia/_tools/parse_documents.py", line 59, in <module>
    to_json(file_name)
  File "/Users/maxjakob/src/rally-tracks/wikipedia/_tools/parse_documents.py", line 28, in to_json
    for doc_data in doc_generator(fp):
  File "/Users/maxjakob/src/rally-tracks/wikipedia/_tools/parse_documents.py", line 16, in doc_generator
    yield parse_page(element, namespaces)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maxjakob/src/rally-tracks/wikipedia/_tools/parse_documents.py", line 42, in parse_page
    "title": element.find("title", XML_NAMESPACES).text,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'text'
```

See https://www.mediawiki.org/wiki/Help:Export#Export_format