### PR TITLE
Increase cluster health timeout in esql-ccs-snapshot challenge

### DIFF
--- a/elastic/logs/operations/esql.json
+++ b/elastic/logs/operations/esql.json
@@ -366,7 +366,8 @@
         {% if p_esql_ccs_remote_nodes_count > 0 %}
         "wait_for_nodes": {{ p_esql_ccs_remote_nodes_count }},
         {% endif %}
-        "wait_for_no_relocating_shards": "true"
+        "wait_for_no_relocating_shards": "true",
+        "timeout": "60s"
       },
       "retry-until-success": true
     }


### PR DESCRIPTION
This is a temporary workaround for lack of support for `retry-until-success` parameter in `multi-cluster-wrapper`. This increases the `GET _cluster/health` timeout from 30 to 60 seconds to avoid failures in the nightly runs.

Long-term fix discussed in https://github.com/elastic/rally-tracks/pull/737.