### PR TITLE
ES|QL JOIN: Add option for parallel query execution

### DIFF
--- a/joins/README.md
+++ b/joins/README.md
@@ -39,6 +39,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `bulk_size` (default: 10000)
 * `bulk_indexing_clients` (default: 8): Number of clients that issue bulk indexing requests.
 * `ingest_percentage` (default: 100): A number between 0 and 100 that defines how much of the document corpus should be ingested. It will be applied to the main index and to the large join indexes (ie. not to join indexes with up to 500K documents)
+* `max_concurrent_shards_per_node` (default 10): A number between 1 and 100 that defines how many concurrent threads will run per query in a node
 * `number_of_replicas` (default: 1): This only applies to the main index (not to lookup indexes)
 * `number_of_shards` (default: 5): This only applies to the main index (not to lookup indexes)
 * `source_mode` (default: stored): Should the `_source` be `stored` to disk exactly as sent (the default), thrown away (`disabled`), or reconstructed on the fly (`synthetic`)
@@ -46,6 +47,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
 * `auto_expand_replicas` (default: "0-all"): Set the auto_expand_replicas behaviour for lookup indices.
+* `query_clients` (default 1): number of queries to be run in parallel
 
 
 ### License

--- a/joins/challenges/default.json
+++ b/joins/challenges/default.json
@@ -73,42 +73,42 @@
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit1",
           "tags": ["lookup", "join", "limit1"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit1000",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit10000",
           "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_keep_limit10000",
           "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 5,
           "iterations": 20
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
@@ -118,7 +118,7 @@
         {
           "operation": "esql_lookup_join_100k_to_{{idx_suffix[i]}}",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
@@ -127,7 +127,7 @@
         {
           "operation": "esql_lookup_join_100k_keys_x10_limit1000",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 5,
           "iterations": 50
         },
@@ -135,7 +135,7 @@
         {
           "operation": "esql_lookup_join_1k_keys_where_no_match",
           "tags": ["lookup", "join"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 5,
           "iterations": 20
         },
@@ -143,7 +143,7 @@
         {
           "operation": "esql_lookup_join_1k_100k_200k_500k",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         }

--- a/joins/challenges/large.json
+++ b/joins/challenges/large.json
@@ -73,49 +73,49 @@
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit1",
           "tags": ["lookup", "join", "limit1"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit1000",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit10000",
           "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_keep_limit10000",
           "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 5,
           "iterations": 20
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_no_match",
           "tags": ["lookup", "join"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 5,
           "iterations": 20
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
@@ -125,7 +125,7 @@
         {
           "operation": "esql_lookup_join_100k_to_{{idx_suffix[i]}}",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
@@ -134,7 +134,7 @@
         {
           "operation": "esql_lookup_join_100k_keys_x10_limit1000",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 5,
           "iterations": 50
         },
@@ -142,7 +142,7 @@
         {
           "operation": "esql_lookup_join_1k_100k_200k_500k",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         }

--- a/joins/challenges/small.json
+++ b/joins/challenges/small.json
@@ -68,35 +68,35 @@
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit1",
           "tags": ["lookup", "join", "limit1"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit1000",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit10000",
           "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_keep_limit10000",
           "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
         {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
@@ -106,7 +106,7 @@
         {
           "operation": "esql_lookup_join_100k_to_{{idx_suffix[i]}}",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         },
@@ -115,7 +115,7 @@
         {
           "operation": "esql_lookup_join_100k_keys_x10_limit1000",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 5,
           "iterations": 50
         },
@@ -123,7 +123,7 @@
         {
           "operation": "esql_lookup_join_1k_keys_sort_limit10000",
           "tags": ["lookup", "join", "limit10000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 5,
           "iterations": 20
         },
@@ -131,7 +131,7 @@
         {
           "operation": "esql_lookup_join_1k_keys_where_no_match",
           "tags": ["lookup", "join"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 5,
           "iterations": 20
         },
@@ -139,7 +139,7 @@
         {
           "operation": "esql_lookup_join_1k_100k_200k_500k",
           "tags": ["lookup", "join", "limit1000"],
-          "clients": 1,
+          "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 50
         }

--- a/joins/operations/default.json
+++ b/joins/operations/default.json
@@ -56,37 +56,44 @@
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit1",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1"
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1000"
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit10000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 10000"
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 10000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_keep_limit10000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | keep @timestamp, lookup_keyword_0 | limit 10000"
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | keep @timestamp, lookup_keyword_0 | limit 10000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_sort_limit10000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | sort lookup_keyword_0 asc | limit 10000"
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | sort lookup_keyword_0 asc | limit 10000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val 1*\" | limit 1000"
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val 1*\" | limit 1000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_no_match",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where concat(lookup_keyword_0, \"foo\") == \"bar\""
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where concat(lookup_keyword_0, \"foo\") == \"bar\"",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
 {% endfor %}
 
@@ -95,17 +102,20 @@
     {
       "name": "esql_lookup_join_100k_to_{{idx_suffix[i]}}",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | rename key_100000 as key_{{key_suffix[i]}}| lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1000"
+      "query": "FROM join_base_idx | rename key_100000 as key_{{key_suffix[i]}}| lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
 {% endfor %}
 
     {
       "name": "esql_lookup_join_100k_keys_x10_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_100000_f10_x10 on key_100000 | limit 1000"
+      "query": "FROM join_base_idx | lookup join lookup_idx_100000_f10_x10 on key_100000 | limit 1000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_1k_100k_200k_500k",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_1000_f10 on key_1000 | rename lookup_keyword_0 as lk_1k | lookup join lookup_idx_100000_f10 on key_100000 | rename lookup_keyword_0 as lk_100k | lookup join lookup_idx_200000_f10 on key_200000 | rename lookup_keyword_0 as lk_200k | lookup join lookup_idx_500000_f10 on key_500000 | rename lookup_keyword_0 as lk_500k | keep id, key_1000, key_100000, key_200000, key_500000, lk_1k, lk_100k, lk_200k, lk_500k | limit 1000"
+      "query": "FROM join_base_idx | lookup join lookup_idx_1000_f10 on key_1000 | rename lookup_keyword_0 as lk_1k | lookup join lookup_idx_100000_f10 on key_100000 | rename lookup_keyword_0 as lk_100k | lookup join lookup_idx_200000_f10 on key_200000 | rename lookup_keyword_0 as lk_200k | lookup join lookup_idx_500000_f10 on key_500000 | rename lookup_keyword_0 as lk_500k | keep id, key_1000, key_100000, key_200000, key_500000, lk_1k, lk_100k, lk_200k, lk_500k | limit 1000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     }


### PR DESCRIPTION
Adding an option to run ES|QL JOIN tracks with multiple query clients, in parallel.
By default, the number of clients is 1, but it can be changed with the track parameter `query_clients`