### PR TITLE
Make the `tsdb` track compatible with Elasticsearch 7.17

### DIFF
--- a/tsdb/README.md
+++ b/tsdb/README.md
@@ -195,6 +195,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `number_of_shards` (default: 1)
 * `refresh_interval` (default not defined)
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use.
+* `include_source_mode` (default: true): used to explicitly exclude `index.mapping.source.mode` setting when running with Elasticsearch v7.
 * `source_mode` (default: synthetic): Should the `_source` be `stored` to disk exactly as sent (the Elasticsearch default outside of TSDB mode), thrown away (`disabled`), or reconstructed on the fly (`synthetic`)
 * `index_mode` (default: time_series): Whether to make a standard index (`standard`) or time series index (`time_series`)
 * `codec` (default: default): The codec to use compressing the index. `default` uses more space and less cpu. `best_compression` uses less space and more cpu.

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -126,7 +126,7 @@
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
         }
-        {% if index_mode | default('time_series') is equalto 'time_series' and skip_running_tsdb_aggs is not defined %}
+        {% if p_index_mode == "time_series" and skip_running_tsdb_aggs is not defined %}
         ,{
           "operation": "date-histo-memory-usage-hour",
           "warmup-iterations": 50,
@@ -385,7 +385,7 @@
           }
         }
         {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
-        {% if index_mode | default('time_series') is equalto 'standard' %}
+        {% if p_index_mode != "time_series" and p_index_mode != "logsdb" %}
         ,{
           "operation": "search_by_doc_id",
           "warmup-iterations": 50,

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -161,7 +161,8 @@
         }
         {% endif %}
       ]
-    },
+    }
+    {% p_enable_downsamplig_challenge %},
     {
       "name": "downsample",
       "description": "Indexes the whole document corpus and executes a few downsampling operations using different interval values",
@@ -283,7 +284,9 @@
           "iterations": 100
         }
       ]
-    },
+    }
+    {% endif %}
+    {% if p_enable_low_latency_challenge %},
     {
       "name": "low-latency",
       "description": "Indexes the whole document corpus and executes low-latency queries. Assertions might result in race failure.",
@@ -409,3 +412,4 @@
         {%- endif %}
       ]
     }
+    {% endif %}

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -150,7 +150,7 @@
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
-        }
+        },
         {% endif %}
         {
           "operation": "esql-fetch-500",

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -152,14 +152,12 @@
           "iterations": 100
         }
         {% endif %}
-        {%- if p_include_esql_queries %},
         {
           "operation": "esql-fetch-500",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
         }
-        {% endif %}
       ]
     }
     {% if p_enable_downsample_challenge %},

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -152,12 +152,14 @@
           "iterations": 100
         }
         {% endif %}
-        ,{
+        {%- if p_include_esql_queries %},
+        {
           "operation": "esql-fetch-500",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
         }
+        {% endif %}
       ]
     },
     {

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -162,7 +162,7 @@
         {% endif %}
       ]
     }
-    {% p_enable_downsamplig_challenge %},
+    {% p_enable_downsample_challenge %},
     {
       "name": "downsample",
       "description": "Indexes the whole document corpus and executes a few downsampling operations using different interval values",

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -162,7 +162,7 @@
         {% endif %}
       ]
     }
-    {% p_enable_downsample_challenge %},
+    {% if p_enable_downsample_challenge %},
     {
       "name": "downsample",
       "description": "Indexes the whole document corpus and executes a few downsampling operations using different interval values",

--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -16,7 +16,9 @@
         "refresh_interval": "{{refresh_interval}}",
         {% endif %}
         "codec": "{{codec | default('default')}}",
+        {% if index_mode == "time_series" or "index_mode" == "logsdb" %}
         "mode": "{{index_mode | default('time_series')}}",
+        {% endif %}
         {% if index_mode | default('time_series') is equalto 'time_series' %}
         "routing_path": [
           "metricset.name",

--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -1,6 +1,7 @@
 {% import "rally.helpers" as rally with context %}
 {# TODO By default, source_mode should be "synthetic" if index_mode == "time_series" else "stored" #}
 {% set p_source_mode = (source_mode | default("synthetic")) %}
+{% set p_include_source_mode = (include_source_mode | default(true)) %}
 {
   "index_patterns": ["k8s*"],
   "data_stream": {},
@@ -38,7 +39,7 @@
           "synthetic_source_keep": "{{synthetic_source_keep}}",
           {% endif %}
           "total_fields.limit": 10000
-          {% if p_source_mode == "synthetic" or p_source_mode == "stored" %},
+          {% if p_include_source_mode %},
           "source.mode": {{ p_source_mode | tojson }}
           {% endif %}
         }

--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -35,8 +35,10 @@
           {% if synthetic_source_keep %}
           "synthetic_source_keep": "{{synthetic_source_keep}}",
           {% endif %}
-          "total_fields.limit": 10000,
+          "total_fields.limit": 10000
+          {% if p_source_mode == "synthetic" or p_source_mode == "stored" %},
           "source.mode": {{ p_source_mode | tojson }}
+          {% endif %}
         }
       }
     },

--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -16,10 +16,10 @@
         "refresh_interval": "{{refresh_interval}}",
         {% endif %}
         "codec": "{{codec | default('default')}}",
-        {% if index_mode == "time_series" or "index_mode" == "logsdb" %}
-        "mode": "{{index_mode | default('time_series')}}",
+        {% if p_index_mode == "time_series" or p_index_mode == "logsdb" %}
+        "mode": "{{p_index_mode}}",
         {% endif %}
-        {% if index_mode | default('time_series') is equalto 'time_series' %}
+        {% if p_index_mode == "time_series" %}
         "routing_path": [
           "metricset.name",
           "kubernetes.container.name",

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -13,11 +13,13 @@
       {% endif %}
       {%- endif -%}{# non-serverless-index-settings-marker-end #}
       "codec": "{{codec | default('default')}}",
-      "mode": "{{index_mode | default('time_series')}}",
+      {% if p_index_mode == "time_series" or p_index_mode == "logsdb" %}
+      "mode": "{{p_index_mode}}",
+      {% endif %}
       {% if refresh_interval %}
       "refresh_interval": "{{refresh_interval}}",
       {% endif %}
-      {% if index_mode | default('time_series') is equalto 'time_series' %}
+      {% if p_index_mode == "time_series" %}
       "routing_path": [
         "metricset.name",
         "kubernetes.container.name",

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -1,7 +1,7 @@
 {% import "rally.helpers" as rally with context %}
 {# TODO By default, source_mode should be "synthetic" if index_mode == "time_series" else "stored" #}
 {% set p_source_mode = (source_mode | default("synthetic")) %}
-{% set p_include_source_mode = (include_source_mode | default(true))) %}
+{% set p_include_source_mode = (include_source_mode | default(true)) %}
 {
   "settings": {
     "index": {

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -38,7 +38,7 @@
         "synthetic_source_keep": "{{synthetic_source_keep}}",
         {% endif %}
         "total_fields.limit": 10000
-        {% if p_source_mode == "synthetic" || p_source_mode == "stored" %},
+        {% if p_source_mode == "synthetic" or p_source_mode == "stored" %},
         "source.mode": {{ p_source_mode | tojson }}
         {% endif %}
       }

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -1,6 +1,7 @@
 {% import "rally.helpers" as rally with context %}
 {# TODO By default, source_mode should be "synthetic" if index_mode == "time_series" else "stored" #}
 {% set p_source_mode = (source_mode | default("synthetic")) %}
+{% set p_include_source_mode = (include_source_mode | default(true))) %}
 {
   "settings": {
     "index": {
@@ -38,7 +39,7 @@
         "synthetic_source_keep": "{{synthetic_source_keep}}",
         {% endif %}
         "total_fields.limit": 10000
-        {% if p_source_mode == "synthetic" or p_source_mode == "stored" %},
+        {% if p_include_source_mode %},
         "source.mode": {{ p_source_mode | tojson }}
         {% endif %}
       }

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -37,8 +37,10 @@
         {% if synthetic_source_keep %}
         "synthetic_source_keep": "{{synthetic_source_keep}}",
         {% endif %}
-        "total_fields.limit": 10000,
+        "total_fields.limit": 10000
+        {% if p_source_mode == "synthetic" || p_source_mode == "stored" %},
         "source.mode": {{ p_source_mode | tojson }}
+        {% endif %}
       }
     }
   },

--- a/tsdb/operations/default.json
+++ b/tsdb/operations/default.json
@@ -1,4 +1,6 @@
 {% set p_document_ids = (document_ids | default(["Rpgg6gSYETjE4x8VrIAPNQ==", "AVdIG3TktHA+a3U2gW29QA==", "DeiNU57QgAml0UMiPg7hWA==", "3o6jhoyitLP3RPjSAEMRgQ=="])) %}
+{% set p_include_time_series_aggs = (include_time_series_aggs | default(true)) %}
+
 {
   "name": "delete-doc-id-pipeline",
   "operation-type": "raw-request",

--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -9,8 +9,8 @@
 
 {% set p_include_esql_queries = (include_esql_queries | default(true)) %}
 {% set p_index_mode = (index_mode | default("time_series")) %}
-{% set p_enable_downsample_challenge = (enable_downsample_challenge | default(true)) %}
-{% set p_enable_low_latency_challenge = (enable_low_latency_challenge | default(true)) %}
+{% set p_enable_downsample_challenge = (enable_downsample_challenge | default(false)) %}
+{% set p_enable_low_latency_challenge = (enable_low_latency_challenge | default(false)) %}
 
 {
   "version": 2,

--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -7,6 +7,8 @@
 {% set p_recovery_poll_timeout = (recovery_poll_timeout | default("1m")) %}
 {% set p_recovery_max_operations_count = (recovery_max_operations_count | default(16777216)) %}
 
+{% set p_include_esql_queries = (include_esql_queries | default(build_flavor != "serverless")) %}
+
 {
   "version": 2,
   "description": "metricbeat information for elastic-app k8s cluster",

--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -7,7 +7,7 @@
 {% set p_recovery_poll_timeout = (recovery_poll_timeout | default("1m")) %}
 {% set p_recovery_max_operations_count = (recovery_max_operations_count | default(16777216)) %}
 
-{% set p_include_esql_queries = (include_esql_queries | default(build_flavor != "serverless")) %}
+{% set p_include_esql_queries = (include_esql_queries | default(true)) %}
 {% set p_index_mode = (index_mode | default("time_series")) %}
 
 {

--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -9,6 +9,8 @@
 
 {% set p_include_esql_queries = (include_esql_queries | default(true)) %}
 {% set p_index_mode = (index_mode | default("time_series")) %}
+{% set p_enable_downsample_challenge = (enable_downsample_challenge | default(true)) %}
+{% set p_enable_low_latency_challenge = (enable_low_latency_challenge | default(true)) %}
 
 {
   "version": 2,

--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -8,6 +8,7 @@
 {% set p_recovery_max_operations_count = (recovery_max_operations_count | default(16777216)) %}
 
 {% set p_include_esql_queries = (include_esql_queries | default(build_flavor != "serverless")) %}
+{% set p_index_mode = (index_mode | default("time_series")) %}
 
 {
   "version": 2,

--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -7,7 +7,6 @@
 {% set p_recovery_poll_timeout = (recovery_poll_timeout | default("1m")) %}
 {% set p_recovery_max_operations_count = (recovery_max_operations_count | default(16777216)) %}
 
-{% set p_include_esql_queries = (include_esql_queries | default(true)) %}
 {% set p_index_mode = (index_mode | default("time_series")) %}
 {% set p_enable_downsample_challenge = (enable_downsample_challenge | default(false)) %}
 {% set p_enable_low_latency_challenge = (enable_low_latency_challenge | default(false)) %}


### PR DESCRIPTION
Here we make sure we exclude things from the configuration which are incompatible with
Elasticsearch v7. This is required to be able to use the challenge and the dataset in an
upgrade test which indexes metrics data into Elasticsearch 7.17.17 in standard mode. In that version
some things like `source.mode`, synthetic source, time series aggregations and so on were not available.
Also we need to disable the downsampling and low latency challenges because:
* downsampling requires a time series index as a source index, which is not available in Elasticsearch v7
* the low latency challenge uses document IDs to fetch documents which are likely different in Elasticsearch v7