### PR TITLE
Import and register all required components for elastic/security

### DIFF
--- a/elastic/security/track.json
+++ b/elastic/security/track.json
@@ -13,7 +13,34 @@
   "packetbeat",
   "winlogbeat"
 ]))%}
-
+{% set p_integration_ratios = (integration_ratios | default({
+  "auditbeat": {
+    "corpora": {
+      "auditbeat-security": 1.0
+    }
+  },
+  "filebeat": {
+    "corpora": {
+      "filebeat-security": 1.0
+    }
+  },
+  "metricbeat": {
+    "corpora": {
+      "metricbeat-security": 1.0
+    }
+  },
+  "packetbeat": {
+    "corpora": {
+      "packetbeat-security": 1.0
+    }
+  },
+  "winlogbeat": {
+    "corpora": {
+      "winlogbeat-security": 1.0
+    }
+  }
+}))
+%}
 {
   "version": 2,
   "description": "Track for simulating Elastic Security workloads",

--- a/elastic/security/track.py
+++ b/elastic/security/track.py
@@ -15,7 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from shared.track_processors import data_generator
+from shared.track_processors.track_id_generator import TrackIdGenerator
 from shared import parameter_sources
+from shared.parameter_sources.processed import ProcessedCorpusParamSource
 from shared.parameter_sources.workflow_selector import WorkflowSelectorParamSource
 from shared.parameter_sources.templates import (
     ComponentTemplateParamSource,
@@ -32,18 +35,14 @@ from security.runners.emit_events import emit_events
 
 
 def register(registry):
-    registry.register_param_source(
-        "add-track-path", parameter_sources.add_track_path
-    )
+    registry.register_param_source("add-track-path", parameter_sources.add_track_path)
     registry.register_param_source(
         "component-template-source", ComponentTemplateParamSource
     )
     registry.register_param_source(
         "composable-template-source", ComposableTemplateParamSource
     )
-    registry.register_param_source(
-        "events-emitter-source", EventsEmitterParamSource
-    )
+    registry.register_param_source("events-emitter-source", EventsEmitterParamSource)
 
     registry.register_runner(
         "check-datastream", datastream.check_health, async_runner=True
@@ -54,9 +53,7 @@ def register(registry):
     registry.register_runner(
         "set-shards-datastream", datastream.shards, async_runner=True
     )
-    registry.register_runner(
-        "emit-events", emit_events, async_runner=True
-    )
+    registry.register_runner("emit-events", emit_events, async_runner=True)
 
     registry.register_runner("create-ilm", create_ilm, async_runner=True)
     registry.register_runner("create-pipeline", create_pipeline, async_runner=True)
@@ -65,3 +62,6 @@ def register(registry):
     registry.register_scheduler("timestamp-throttler", TimestampThrottler)
 
     registry.register_param_source("workflow-selector", WorkflowSelectorParamSource)
+    registry.register_param_source("processed-source", ProcessedCorpusParamSource)
+    registry.register_track_processor(TrackIdGenerator())
+    registry.register_track_processor(data_generator.DataGenerator())


### PR DESCRIPTION
Whilst running some testing on 7.17, i discovered elastic/security wasnt properly backported, so was missing the registration of the components for data generation.

This imports them so the track works under 7.17. The changes seem to be in master, so just backporting to 7.17