### PR TITLE
Fix misplaced comma in TSDB track

### DIFF
--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -125,9 +125,9 @@
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
-        },
+        }
         {% if p_index_mode == "time_series" and skip_running_tsdb_aggs is not defined %}
-        {
+        ,{
           "operation": "date-histo-memory-usage-hour",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
@@ -150,9 +150,9 @@
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
-        },
+        }
         {% endif %}
-        {
+        ,{
           "operation": "esql-fetch-500",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},

--- a/tsdb/challenges/default.json
+++ b/tsdb/challenges/default.json
@@ -125,9 +125,9 @@
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},
           "iterations": 100
-        }
+        },
         {% if p_index_mode == "time_series" and skip_running_tsdb_aggs is not defined %}
-        ,{
+        {
           "operation": "date-histo-memory-usage-hour",
           "warmup-iterations": 50,
           "clients": {{ search_clients | default(1) | int }},


### PR DESCRIPTION
https://github.com/elastic/rally-tracks/pull/743 introduced this problem:

```
% esrally info --track=tsdb --track-params="index_mode:standard"

    ____        ____
   / __ \____ _/ / /_  __
  / /_/ / __ `/ / / / / /
 / _, _/ /_/ / / / /_/ /
/_/ |_|\__,_/_/_/\__, /
                /____/

[ERROR] Cannot info. Could not load '/Users/grzegorz/.rally/benchmarks/tracks/default/tsdb/track.json': Expecting ',' delimiter: line 510 column 9 (char 10509). Lines containing the error:

          "iterations": 100
        }
        
        {
--------^ Error is here
          "operation": "esql-fetch-500",
          "warmup-iterations": 50,

The complete track has been written to '/var/folders/fy/mlp_1k2s5yx_vm9gt82dc3140000gn/T/tmpso8ke_8q.json' for diagnosis.
```