### PR TITLE
Add use_doc_values_skipper track param to elastic/logs

### DIFF
--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -16,6 +16,9 @@
             {% if synthetic_source_keep %}
             ,"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
             {% endif %}
+            {% if use_doc_values_skipper %}
+            ,"mapping.use_doc_values_skipper": {{ use_doc_values_skipper | tojson }}
+            {% endif %}
         }
         {% endif %}
       }


### PR DESCRIPTION
This allows us to disable doc value skippers in nighly. Which is enabled by default now in snapshot builds.