### PR TITLE
Add drop_null_columns challenge to ESQL benchmarks

### DIFF
--- a/esql/challenges/default.json
+++ b/esql/challenges/default.json
@@ -63,6 +63,31 @@
           "warmup-iterations": 10,
           "iterations": 100
         },
+
+
+        {
+          "operation": "from_idx_limit_1000_drop_null",
+          "tags": ["esql_fanout"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 10,
+          "iterations": 100
+        },
+        {
+          "operation": "from_idx_limit_10000_drop_null",
+          "tags": ["esql_fanout"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 10,
+          "iterations": 100
+        },
+        {
+          "operation": "from_idx_limit_1_drop_null",
+          "tags": ["esql_fanout"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 10,
+          "iterations": 100
+        },
+
+
         {
           "operation": "search_limit_1",
           "tags": ["esql_fanout"],

--- a/esql/challenges/default.json
+++ b/esql/challenges/default.json
@@ -1,5 +1,5 @@
     {
-      "name": "esql_fanout",
+      "name": "esql_large_schema",
       "description": "Scale tests for ES|QL",
       "default": true,
       "schedule": [
@@ -44,21 +44,21 @@
         },
         {
           "operation": "from_idx_limit_1000",
-          "tags": ["esql_fanout"],
+          "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 100
         },
         {
           "operation": "from_idx_limit_10000",
-          "tags": ["esql_fanout"],
+          "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 100
         },
         {
           "operation": "from_idx_limit_1",
-          "tags": ["esql_fanout"],
+          "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 100
@@ -67,21 +67,21 @@
 
         {
           "operation": "from_idx_limit_1000_drop_null",
-          "tags": ["esql_fanout"],
+          "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 100
         },
         {
           "operation": "from_idx_limit_10000_drop_null",
-          "tags": ["esql_fanout"],
+          "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 100
         },
         {
           "operation": "from_idx_limit_1_drop_null",
-          "tags": ["esql_fanout"],
+          "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 100
@@ -90,21 +90,21 @@
 
         {
           "operation": "search_limit_1",
-          "tags": ["esql_fanout"],
+          "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 100
         },
         {
           "operation": "search_limit_1000",
-          "tags": ["esql_fanout"],
+          "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 100
         },
         {
           "operation": "search_limit_10000",
-          "tags": ["esql_fanout"],
+          "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 10,
           "iterations": 100

--- a/esql/operations/default.json
+++ b/esql/operations/default.json
@@ -27,6 +27,27 @@
       "operation-type": "esql",
       "query": "FROM idx_* | limit 1"
     },
+
+    {
+    "name": "from_idx_limit_1000_drop_null",
+    "operation-type": "esql",
+    "query": "FROM idx_* | limit 1000",
+    "request-params": { "drop_null_columns": true }
+    },
+    {
+    "name": "from_idx_limit_10000_drop_null",
+    "operation-type": "esql",
+    "query": "FROM idx_* | limit 10000",
+    "request-params": { "drop_null_columns": true }
+    },
+    {
+    "name": "from_idx_limit_1_drop_null",
+    "operation-type": "esql",
+    "query": "FROM idx_* | limit 1",
+    "request-params": { "drop_null_columns": true }
+    },
+
+
     {
       "name": "search_limit_1",
       "operation-type": "search",

--- a/esql/track.json
+++ b/esql/track.json
@@ -28,11 +28,11 @@
   "documents": [
     {
       "target-index": "{{idx_name}}",
-      "source-file": "lookup_idx_1000_f10.json.bz2",
-      "#COMMENT": "Lookup index with 1000 documents and 1000 distinct keys (keyworks, \"0\"..\"999\")",
-      "document-count": 1000,
-      "compressed-bytes": 11229,
-      "uncompressed-bytes": 388790
+      "source-file": "lookup_idx_100000_f10.json.bz2",
+      "#COMMENT": "Lookup index with 100k documents and 100k distinct keys (keyworks, \"0\"..\"99999\")",
+      "document-count": 100000,
+      "compressed-bytes": 2248693,
+      "uncompressed-bytes": 41277790
     }
   ]
 },
@@ -43,11 +43,11 @@
   "documents": [
       {
         "target-index": "idx_0",
-        "source-file": "lookup_idx_1000_f10.json.bz2",
-        "#COMMENT": "Lookup index with 1000 documents and 1000 distinct keys (keyworks, \"0\"..\"999\")",
-        "document-count": 1000,
-        "compressed-bytes": 11229,
-        "uncompressed-bytes": 388790
+        "source-file": "lookup_idx_100000_f10.json.bz2",
+        "#COMMENT": "Lookup index with 100k documents and 100k distinct keys (keyworks, \"0\"..\"99999\")",
+        "document-count": 100000,
+        "compressed-bytes": 2248693,
+        "uncompressed-bytes": 41277790
       }
     ]
   }


### PR DESCRIPTION
New challenges to run queries with `drop_null_columns=true`