### PR TITLE
elastic/logs: use the common custom settings component template for K8s application logs

### DIFF
--- a/elastic/logs/templates/component/track-custom-shared-settings.json
+++ b/elastic/logs/templates/component/track-custom-shared-settings.json
@@ -1,17 +1,19 @@
-{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) -%}
 {
   "template": {
     "settings": {
       "index": {
-        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-          {% if p_include_non_serverless_index_settings %}
+        {#- non-serverless-index-settings-marker-start #}
+        {%- if build_flavor != "serverless" or serverless_operator == true %}
+        {%- if p_include_non_serverless_index_settings %}
         "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}"{%- if refresh_interval -%},{%- endif -%}
-          {% endif %}
-        {%- endif -%}{# non-serverless-index-settings-marker-end #}
-        {% if refresh_interval -%}
-        "refresh_interval": "{{ refresh_interval }}"
+        "number_of_replicas": "{{ number_of_replicas | default(1) }}"
+        {%- if refresh_interval -%},
+        "refresh_interval": {{ refresh_interval | tojson }}
         {%- endif %}
+        {%- endif %}
+        {%- endif %}
+        {#- non-serverless-index-settings-marker-end #}
       }
     }
   }

--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -10,27 +10,26 @@
             "limit": "10000"
           }
         },
-        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-        "number_of_routing_shards": "30",
-        "number_of_shards": "{{ number_of_shards | default(1) }}",
-        "number_of_replicas": "{{ number_of_replicas | default(1) }}",
-        {%- endif -%}{# non-serverless-index-settings-marker-end #}
         "query": {
           "default_field": [
             "message"
           ]
-        },
-        {%- if disable_pipelines is not true %}
-        "default_pipeline": "logs-k8-app",
+        }
+        {#- non-serverless-index-settings-marker-start #}
+        {%- if build_flavor != "serverless" or serverless_operator == true %},
+        "number_of_routing_shards": "30"
         {%- endif %}
-        {% if route_on_sort_fields | default(false) is true %}
+        {#- non-serverless-index-settings-marker-end #}
+        {%- if disable_pipelines is not true %},
+        "default_pipeline": "logs-k8-app"
+        {%- endif %}
+        {%- if route_on_sort_fields | default(false) is true %},
         "sort": {
           "field": [ "host.name", "event.code", "log.file.path", "@timestamp" ],
           "order": [ "asc", "asc", "asc", "desc" ]
         },
-        "logsdb.route_on_sort_fields": true,
+        "logsdb.route_on_sort_fields": true
         {% endif %}
-        "refresh_interval": "5s"
       }
     },
     "mappings": {
@@ -2005,6 +2004,7 @@
   },
   "composed_of": [
     "logs-mappings",
+    "track-custom-shared-settings",
     "track-custom-mappings",
     "track-data-stream-lifecycle",
     "track-shared-logsdb-mode"


### PR DESCRIPTION
Allow common index settings configurable in the `track-custom-shard-settings` component template to be utilized by the K8s application logs composable template. Also includes some minor jinja clean up.