### PR TITLE
Add ES|QL JOINS track designed to run nightly

### DIFF
--- a/joins/challenges/nightly.json
+++ b/joins/challenges/nightly.json
@@ -1,0 +1,107 @@
+    {
+      "name": "esql-nightly",
+      "description": "Performance benchmarks for internal R&D on query languages. Intended to be fast enough to be executed nightly",
+      "default": false,
+      "schedule": [
+        {
+          "operation": "delete-index",
+          "tags": ["setup"]
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
+              {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+                {% if p_include_non_serverless_index_settings %}
+              "index.translog.flush_threshold_size": "4g",
+                {% endif %}
+              {%- endif -%}{# non-serverless-index-settings-marker-end #}
+              "index.codec": "best_compression",
+              "index.refresh_interval": "30s"
+            }{%- endif %}
+          },
+          "tags": ["setup"]
+        },
+
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "join_base_idx",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            },
+            "retry-until-success": true
+          },
+          "tags": ["setup"]
+        },
+
+        {
+          "operation": "index-base",
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "tags": ["setup"]
+        },
+        {
+          "operation": "index-lookup-100k",
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "tags": ["setup"]
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "tags": ["setup"]
+        },
+        
+        {
+          "operation": "esql_lookup_join_100k_keys_limit1",
+          "tags": ["lookup", "join", "limit1"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_keep_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_where_limit1000",
+          "tags": ["lookup", "join", "limit1000"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_sort_limit10000",
+          "tags": ["lookup", "join", "limit10000"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_where_no_match",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        }
+
+      ]
+    }

--- a/joins/operations/default.json
+++ b/joins/operations/default.json
@@ -20,6 +20,13 @@
       "ingest-percentage": 100
     },
     {
+      "name": "index-lookup-100k",
+      "operation-type": "bulk",
+      "indices": ["lookup_idx_100000_f10"],
+      "bulk-size": {{bulk_size | default(10000)}},
+      "ingest-percentage": 100
+    },
+    {
       "name": "index-lookup-100k_x10",
       "operation-type": "bulk",
       "indices": ["lookup_idx_100000_f10_x10"],


### PR DESCRIPTION
New nightly track for ES|QL joins.
The intention is to run it with `ingest_percentage:10`, so that it takes less than one hour to finish.
It runs only with key cardinality = 100k, but it also executes expensive queries, like join on the full dataset.