### PR TITLE
Fix ignore parameters in dbpedia and msmarco-passage-ranking

### DIFF
--- a/msmarco-passage-ranking/track.py
+++ b/msmarco-passage-ranking/track.py
@@ -165,8 +165,8 @@ class QueryParamsSource:
             raise Exception(f"The query strategy \\`{self._query_strategy}]\\` is not implemented")
 
         self._iters = (self._iters + 1) % len(self._queries)
-        query["track_total_hits"] = self._track_total_hits,
-        query["size"] = self._size,
+        query["track_total_hits"] = self._track_total_hits
+        query["size"] = self._size
         return {
             "index": self._index_name,
             "cache": self._cache,

--- a/msmarco-passage-ranking/track.py
+++ b/msmarco-passage-ranking/track.py
@@ -165,11 +165,11 @@ class QueryParamsSource:
             raise Exception(f"The query strategy \\`{self._query_strategy}]\\` is not implemented")
 
         self._iters = (self._iters + 1) % len(self._queries)
+        query["track_total_hits"] = self._track_total_hits,
+        query["size"] = self._size,
         return {
             "index": self._index_name,
             "cache": self._cache,
-            "size": self._size,
-            "track_total_hits": self._track_total_hits,
             "body": query,
         }
 

--- a/search/mteb/dbpedia/track.py
+++ b/search/mteb/dbpedia/track.py
@@ -103,13 +103,13 @@ class QueryParamsSource:
     def params(self):
         query_obj = self._queries[self._iters]
         query = generate_query(query_obj["text"], self._title_field, self._title_boost, self._text_field, self._text_boost)
+        query['track_total_hits'] = self._track_total_hits
+        query['size'] = self._size
 
         self._iters = (self._iters + 1) % len(self._queries)
         return {
             "index": self._index_name,
             "cache": self._cache,
-            "size": self._size,
-            "track_total_hits": self._track_total_hits,
             "body": query,
         }
 

--- a/search/mteb/dbpedia/track.py
+++ b/search/mteb/dbpedia/track.py
@@ -103,8 +103,8 @@ class QueryParamsSource:
     def params(self):
         query_obj = self._queries[self._iters]
         query = generate_query(query_obj["text"], self._title_field, self._title_boost, self._text_field, self._text_boost)
-        query['track_total_hits'] = self._track_total_hits
-        query['size'] = self._size
+        query["track_total_hits"] = self._track_total_hits
+        query["size"] = self._size
 
         self._iters = (self._iters + 1) % len(self._queries)
         return {


### PR DESCRIPTION
The `size` and `track_total_hits` params are ignored in the dbpedia and msmarco-passage-ranking tracks. This change fixes the issue by providing the params as part of the search request body.