### PR TITLE
Use a 5s refresh for k8s application logs unless the refresh_interval is specified

### DIFF
--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -17,7 +17,8 @@
         }
         {#- non-serverless-index-settings-marker-start #}
         {%- if build_flavor != "serverless" or serverless_operator == true %},
-        "number_of_routing_shards": "30"
+        "number_of_routing_shards": "30",
+        "refresh_interval": {{ refresh_interval | default("5s") | tojson }}
         {%- endif %}
         {#- non-serverless-index-settings-marker-end #}
         {%- if disable_pipelines is not true %},


### PR DESCRIPTION
Partially reverts 9fae039 to use a 5s refresh for K8s application logs while still allowing it to be configured as a track parameter. 