### PR TITLE
Additional track changes for ES|QL full text functions

### DIFF
--- a/elastic/logs/challenges/logging-querying-esql.json
+++ b/elastic/logs/challenges/logging-querying-esql.json
@@ -1,0 +1,140 @@
+{% import "rally.helpers" as rally %}
+{
+  "name": "logging-querying-esql",
+  "description": "Applies an ESQL query workload. Ensures data streams exist so queries can be run, but does not remove existing data.",
+  "parameters": {
+    "generate-data": {{ true | tojson if bulk_start_date and bulk_end_date else false | tojson }}
+  },
+  "schedule": [
+    {% include "tasks/index-setup.json" %},
+    {% if bulk_start_date and bulk_end_date %}
+      {
+        "name": "bulk-index",
+        "operation": {
+          "operation-type": "raw-bulk",
+          "param-source": "processed-source",
+          "time-format": "milliseconds",
+          "profile": "fixed_interval",
+          "init-load": true,
+          "bulk-size": {{ p_bulk_size }},
+          "detailed-results": true
+        },
+        "clients": {{ p_bulk_indexing_clients }},
+        "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+      }
+      {%- if force_merge_max_num_segments is defined %},
+      {
+        "name": "refresh-after-index",
+        "index": "logs-*",
+        "operation": "refresh"
+      },
+      {
+        "name": "wait-until-index-merges-fininshes",
+        "operation": {
+          "operation-type": "index-stats",
+          "index": "logs-*",
+          "condition": {
+            "path": "_all.total.merges.current",
+            "expected-value": 0
+          },
+          "retry-until-success": true,
+          "include-in-reporting": false
+        }
+      },
+      {
+        "operation": {
+          "operation-type": "force-merge",
+          "index": "logs-*",
+          "request-timeout": 36000,
+          "max-num-segments": {{ force_merge_max_num_segments | tojson }}
+        }
+      },
+      {
+        "name": "wait-until-merges-finish",
+        "operation": {
+          "operation-type": "index-stats",
+          "index": "logs-*",
+          "condition": {
+            "path": "_all.total.merges.current",
+            "expected-value": 0
+          },
+          "retry-until-success": true,
+          "include-in-reporting": false
+        }
+      },
+      {
+        "name": "refresh-after-force-merge",
+        "index": "logs-*",
+        "operation": "refresh"
+      }
+      {%- endif %}
+      {# non-serverless-index-statistics-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%},
+      {
+        "name": "compression-stats",
+        "operation": {
+          "operation-type": "compression-statistics",
+          "param-source": "create-datastream-source"
+        }
+      }
+      {%- endif -%}{# non-serverless-index-statistics-marker-end #}
+      ,
+    {% endif %}
+    {
+      "operation": "esql_apache_match_query",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 20,
+      "tags": ["esql", "search"]
+    },
+    {
+      "operation": "esql_kafka_match_query",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 20,
+      "tags": ["esql", "search"]
+    },
+    {
+      "operation": "esql_qstr_query",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 20,
+      "tags": ["esql", "search"]
+    },
+    {
+      "operation": "esql_kql_query",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 20,
+      "tags": ["esql", "search"]
+    },
+    {
+      "operation": "esql_postgres_qstr_query",
+      "clients": 1,
+      "warmup-iterations": 5,
+      "iterations": 20,
+      "tags": ["esql", "search"]
+    }{%- if build_flavor != "serverless" or serverless_operator == true %},
+    {
+      "operation": "disable_query_cache",
+      "tags": ["esql", "settings"]
+    },
+    {
+      "operation": "search_kafka_uery",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "search"]
+    },
+    {
+      "operation": "search_postrgres_query",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql", "search"]
+    },
+    {
+      "operation": "enable_query_cache",
+      "tags": ["esql", "settings"]
+    }{%- endif %}
+  ]
+}

--- a/elastic/logs/challenges/logging-querying-esql.json
+++ b/elastic/logs/challenges/logging-querying-esql.json
@@ -80,70 +80,98 @@
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["esql", "search"]
+      "tags": ["esql", "full-text"]
     },
     {
-      "operation": "kafka_match_esql_query",
+      "operation": "apache_equals_esql_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["esql", "search"]
+      "tags": ["esql", "like"]
+    },
+    {
+      "operation": "kafka_qstr_esql_query",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["esql", "full-text"]
+    },
+    {
+      "operation": "kafka_like_esql_query",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["esql", "like"]
     },
     {
       "operation": "qstr_esql_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["esql", "search"]
+      "tags": ["esql", "full-text"]
     },
     {
       "operation": "kql_esql_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["esql", "search"]
+      "tags": ["esql", "full-text"]
+    },
+    {
+      "operation": "kql_like_esql_query",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["esql", "like"]
     },
     {
       "operation": "syslog_qstr_esql_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["esql", "search"]
+      "tags": ["esql", "full-text"]
+    },
+    {
+      "operation": "syslog_like_esql_query",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["esql", "like"]
     }{%- if build_flavor != "serverless" or serverless_operator == true %},
     {
       "operation": "apache_match_query_dsl_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["search"]
+      "tags": ["search", "full-text"]
     },
     {
-      "operation": "kafka_query_dsl_query",
+      "operation": "kafka_qstr_dsl_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["search"]
+      "tags": ["search", "full-text"]
     },
     {
       "operation": "qstr_query_dsl_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["search"]
+      "tags": ["search", "full-text"]
     },
     {
       "operation": "kql_query_dsl_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["search"]
+      "tags": ["search", "full-text"]
     },
     {
       "operation": "syslog_query_dsl_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["search"]
+      "tags": ["search", "full-text"]
     },
     {
       "operation": "enable_query_cache",

--- a/elastic/logs/challenges/logging-querying-esql.json
+++ b/elastic/logs/challenges/logging-querying-esql.json
@@ -111,7 +111,7 @@
       "tags": ["esql", "settings"]
     },
     {
-      "operation": "search_kafka_uery",
+      "operation": "search_kafka_query",
       "clients": 1,
       "warmup-iterations": 10,
       "iterations": 50,

--- a/elastic/logs/challenges/logging-querying-esql.json
+++ b/elastic/logs/challenges/logging-querying-esql.json
@@ -6,7 +6,7 @@
     "generate-data": {{ true | tojson if bulk_start_date and bulk_end_date else false | tojson }}
   },
   "schedule": [
-    {% include "tasks/index-setup.json" %},
+    {% include "tasks/many-shards-setup.json" %},
     {% if bulk_start_date and bulk_end_date %}
       {
         "name": "bulk-index",
@@ -39,7 +39,8 @@
           },
           "retry-until-success": true,
           "include-in-reporting": false
-        }
+        },
+        "tags": ["wait"]
       },
       {
         "operation": {
@@ -68,15 +69,6 @@
         "operation": "refresh"
       }
       {%- endif %}
-      {# non-serverless-index-statistics-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%},
-      {
-        "name": "compression-stats",
-        "operation": {
-          "operation-type": "compression-statistics",
-          "param-source": "create-datastream-source"
-        }
-      }
-      {%- endif -%}{# non-serverless-index-statistics-marker-end #}
       ,
     {% endif %}
     {

--- a/elastic/logs/challenges/logging-querying-esql.json
+++ b/elastic/logs/challenges/logging-querying-esql.json
@@ -72,61 +72,82 @@
       ,
     {% endif %}
     {
-      "operation": "esql_apache_match_query",
+      "operation": "disable_query_cache",
+      "tags": ["esql", "settings"]
+    },
+    {
+      "operation": "apache_match_esql_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     },
     {
-      "operation": "esql_kafka_match_query",
+      "operation": "kafka_match_esql_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     },
     {
-      "operation": "esql_qstr_query",
+      "operation": "qstr_esql_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     },
     {
-      "operation": "esql_kql_query",
+      "operation": "kql_esql_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     },
     {
-      "operation": "esql_postgres_qstr_query",
+      "operation": "syslog_qstr_esql_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     }{%- if build_flavor != "serverless" or serverless_operator == true %},
     {
-      "operation": "disable_query_cache",
-      "tags": ["esql", "settings"]
-    },
-    {
-      "operation": "search_kafka_query",
+      "operation": "apache_match_query_dsl_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["esql", "search"]
+      "tags": ["search"]
     },
     {
-      "operation": "search_postrgres_query",
+      "operation": "kafka_query_dsl_query",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["esql", "search"]
+      "tags": ["search"]
+    },
+    {
+      "operation": "qstr_query_dsl_query",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["search"]
+    },
+    {
+      "operation": "kql_query_dsl_query",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["search"]
+    },
+    {
+      "operation": "syslog_query_dsl_query",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["search"]
     },
     {
       "operation": "enable_query_cache",
-      "tags": ["esql", "settings"]
+      "tags": ["settings"]
     }{%- endif %}
   ]
 }

--- a/elastic/logs/challenges/logging-querying-esql.json
+++ b/elastic/logs/challenges/logging-querying-esql.json
@@ -73,37 +73,37 @@
     {% endif %}
     {
       "operation": "esql_apache_match_query",
-      "clients": 1,
-      "warmup-iterations": 5,
-      "iterations": 20,
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     },
     {
       "operation": "esql_kafka_match_query",
-      "clients": 1,
-      "warmup-iterations": 5,
-      "iterations": 20,
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     },
     {
       "operation": "esql_qstr_query",
-      "clients": 1,
-      "warmup-iterations": 5,
-      "iterations": 20,
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     },
     {
       "operation": "esql_kql_query",
-      "clients": 1,
-      "warmup-iterations": 5,
-      "iterations": 20,
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     },
     {
       "operation": "esql_postgres_qstr_query",
-      "clients": 1,
-      "warmup-iterations": 5,
-      "iterations": 20,
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     }{%- if build_flavor != "serverless" or serverless_operator == true %},
     {
@@ -112,16 +112,16 @@
     },
     {
       "operation": "search_kafka_query",
-      "clients": 1,
-      "warmup-iterations": 10,
-      "iterations": 50,
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     },
     {
       "operation": "search_postrgres_query",
-      "clients": 1,
-      "warmup-iterations": 10,
-      "iterations": 50,
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "search"]
     },
     {

--- a/elastic/logs/operations/esql-full-text-search.json
+++ b/elastic/logs/operations/esql-full-text-search.json
@@ -1,16 +1,63 @@
 
     {
-      "name": "esql_apache_match_query",
+      "name": "apache_match_esql_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE data_stream.dataset: \"apache.access\" AND http.response.status_code: 404 AND user_agent.name: \"Firefox\" AND @timestamp >= \"2022-04-14T20:53:58Z\" AND @timestamp < \"2022-04-14T21:08:58Z\" | SORT @timestamp DESC | LIMIT 20"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE event.dataset: \"apache.access\" AND http.response.status_code: 404 AND user_agent.name: \"Firefox\" | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | SORT @timestamp DESC | LIMIT 20"
     },
     {
-      "name": "esql_kafka_match_query",
-      "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE data_stream.dataset: \"kafka.log\" AND kafka.log.trace.class: \"java.io.IOException\" AND @timestamp >= \"2022-04-17T21:52:08Z\" AND @timestamp < \"2022-04-18T21:52:08Z\" | SORT @timestamp DESC | LIMIT 500"
+      "name": "apache_match_query_dsl_query",
+      "operation-type": "search",
+      "index": "{{p_esql_target_prefix}}logs-*",
+      "body": {
+        "query": {
+          "bool": {
+            "must": [],
+            "filter": [
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "match": {
+                        "event.dataset": "apache.access"
+                      }
+                    }
+                  ],
+                  "minimum_should_match": 1
+                }
+              },
+              {
+                "match": {
+                  "http.response.status_code": 404
+                }
+              },
+              {
+                "match": {
+                  "user_agent.name": "Firefox"
+                }
+              },
+              {
+                "range": {
+                  "@timestamp": {
+                    "format": "strict_date_optional_time",
+                    "gte": "{{bulk_start_date}}T09:10:05.477Z",
+                    "lte": "{{bulk_end_date}}T21:10:05.477Z"
+                  }
+                }
+              }
+            ],
+            "should": [],
+            "must_not": []
+          }
+        }
+      }
     },
     {
-      "name": "search_kafka_query",
+      "name": "kafka_match_esql_query",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE event.dataset: \"kafka.log\" AND QSTR(\"Connection * disconnected\") | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | SORT @timestamp DESC | LIMIT 500"
+    },
+    {
+      "name": "kafka_query_dsl_query",
       "operation-type": "search",
       "index": "{{p_esql_target_prefix}}logs-*",
       "body": {
@@ -31,16 +78,16 @@
                 }
               },
               {
-                "match_phrase": {
-                  "kafka.log.trace.class": "java.io.IOException"
+                "query_string": {
+                  "query": "Connection * disconnected"
                 }
               },
               {
                 "range": {
                   "@timestamp": {
                     "format": "strict_date_optional_time",
-                    "gte": "2022-04-17T21:52:08.615Z",
-                    "lte": "2022-04-18T21:52:08.615Z"
+                    "gte": "{{bulk_start_date}}T21:52:08.615Z",
+                    "lte": "{{bulk_end_date}}T21:52:08.615Z"
                   }
                 }
               }
@@ -53,26 +100,88 @@
       }
     },
     {
-      "name": "esql_qstr_query",
+      "name": "qstr_esql_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE qstr(\"java.lang.NullPointerException\", {\"default_field\": \"*\"}) | LIMIT 500"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE qstr(\"slack\", {\"default_field\": \"*\"}) | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | LIMIT 500"
     },
     {
-      "name": "esql_kql_query",
-      "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE kql(\"googlebigquery\") | LIMIT 500"
-    },
-    {
-      "name": "esql_postgres_qstr_query",
-      "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE postgresql.log.query IS NOT NULL AND qstr(\"copy pgbench_accounts from stdin\", {\"default_field\":\"*\"}) AND event.duration >= 200000000 AND @timestamp >= \"2022-04-19T20:13:05Z\" AND @timestamp < \"2022-04-20T20:13:05Z\" | LIMIT 100"
-    },
-    {
-      "name": "search_postrgres_query",
+      "name": "qstr_query_dsl_query",
       "operation-type": "search",
       "index": "{{p_esql_target_prefix}}logs-*",
       "body": {
-        "size": 0,
+        "query": {
+          "bool": {
+            "must": [],
+            "filter": [
+              {
+                "query_string": {
+                  "query": "slack"
+                }
+              },
+              {
+                "range": {
+                  "@timestamp": {
+                    "format": "strict_date_optional_time",
+                    "gte": "{{bulk_start_date}}T21:52:08.615Z",
+                    "lte": "{{bulk_end_date}}T21:52:08.615Z"
+                  }
+                }
+              }
+            ],
+            "should": [],
+            "must_not": []
+          }
+        },
+        "size": 500
+      }
+    },
+    {
+      "name": "kql_esql_query",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE kql(\"query\") | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | LIMIT 500"
+    },
+    {
+      "name": "kql_query_dsl_query",
+      "operation-type": "search",
+      "index": "{{p_esql_target_prefix}}logs-*",
+      "body": {
+        "query": {
+          "bool": {
+            "must": [],
+            "filter": [
+              {
+                "kql": {
+                  "query": "query"
+                }
+              },
+              {
+                "range": {
+                  "@timestamp": {
+                    "format": "strict_date_optional_time",
+                    "gte": "{{bulk_start_date}}T07:52:08.615Z",
+                    "lte": "{{bulk_end_date}}T07:52:08.615Z"
+                  }
+                }
+              }
+            ],
+            "should": [],
+            "must_not": []
+          }
+        },
+        "size": 500
+      }
+    },
+    {
+      "name": "syslog_qstr_esql_query",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE event.dataset: \"system.syslog\" AND qstr(\"Stopped*\") | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | LIMIT 100"
+    },
+    {
+      "name": "syslog_query_dsl_query",
+      "operation-type": "search",
+      "index": "{{p_esql_target_prefix}}logs-*",
+      "body": {
+        "size": 100,
         "query": {
            "bool": {
             "filter": [
@@ -83,8 +192,8 @@
                       "bool": {
                         "should": [
                           {
-                            "exists": {
-                              "field": "postgresql.log.query"
+                            "match": {
+                              "event.dataset": "system.syslog"
                             }
                           }
                         ],
@@ -95,48 +204,23 @@
                       "bool": {
                         "should": [
                           {
-                            "range": {
-                              "event.duration": {
-                                "gte": "200000000"
-                              }
+                            "query_string": {
+                              "query": "Stopped*"
                             }
                           }
                         ],
                         "minimum_should_match": 1
-                      }
-                    },
-                    {
-                      "bool": {
-                        "must_not": {
-                          "multi_match": {
-                            "type": "phrase",
-                            "query": "copy pgbench_accounts from stdin",
-                            "lenient": true
-                          }
-                        }
                       }
                     }
                   ]
                 }
               },
               {
-                "bool": {
-                  "should": [
-                    {
-                      "exists": {
-                        "field": "event.duration"
-                      }
-                    }
-                  ],
-                  "minimum_should_match": 1
-                }
-              },
-              {
                 "range": {
                   "@timestamp": {
                     "format": "strict_date_optional_time",
-                    "gte": "2022-04-19T20:13:05.675Z",
-                    "lte": "2022-04-20T20:13:05.675Z"
+                    "gte": "{{bulk_start_date}}T20:13:05.675Z",
+                    "lte": "{{bulk_end_date}}T20:13:05.675Z"
                   }
                 }
               }

--- a/elastic/logs/operations/esql-full-text-search.json
+++ b/elastic/logs/operations/esql-full-text-search.json
@@ -10,7 +10,7 @@
       "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE data_stream.dataset: \"kafka.log\" AND kafka.log.trace.class: \"java.io.IOException\" AND @timestamp >= \"2022-04-17T21:52:08Z\" AND @timestamp < \"2022-04-18T21:52:08Z\" | SORT @timestamp DESC | LIMIT 500"
     },
     {
-      "name": "search_kafka_uery",
+      "name": "search_kafka_query",
       "operation-type": "search",
       "index": "{{p_esql_target_prefix}}logs-*",
       "body": {

--- a/elastic/logs/operations/esql-full-text-search.json
+++ b/elastic/logs/operations/esql-full-text-search.json
@@ -1,0 +1,149 @@
+
+    {
+      "name": "esql_apache_match_query",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE data_stream.dataset: \"apache.access\" AND http.response.status_code: 404 AND user_agent.name: \"Firefox\" AND @timestamp >= \"2022-04-14T20:53:58Z\" AND @timestamp < \"2022-04-14T21:08:58Z\" @timestamp | SORT @timestamp DESC | LIMIT 20"
+    },
+    {
+      "name": "esql_kafka_match_query",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE data_stream.dataset: \"kafka.log\" AND kafka.log.trace.class: \"java.io.IOException\" AND @timestamp >= \"2022-04-17T21:52:08Z\" AND @timestamp < \"2022-04-18T21:52:08Z\" @timestamp | SORT @timestamp DESC | LIMIT 500"
+    },
+    {
+      "name": "search_kafka_uery",
+      "operation-type": "search",
+      "index": "{{p_esql_target_prefix}}logs-*",
+      "body": {
+        "query": {
+          "bool": {
+            "must": [],
+            "filter": [
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "exists": {
+                        "field": "kafka.log.trace.class"
+                      }
+                    }
+                  ],
+                  "minimum_should_match": 1
+                }
+              },
+              {
+                "match_phrase": {
+                  "kafka.log.trace.class": "java.io.IOException"
+                }
+              },
+              {
+                "range": {
+                  "@timestamp": {
+                    "format": "strict_date_optional_time",
+                    "gte": "2022-04-17T21:52:08.615Z",
+                    "lte": "2022-04-18T21:52:08.615Z"
+                  }
+                }
+              }
+            ],
+            "should": [],
+            "must_not": []
+          }
+        },
+        "size": 500
+      }
+    },
+    {
+      "name": "esql_qstr_query",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE qstr(\"*:java.lang.NullPointerException\") | LIMIT 500"
+    },
+    {
+      "name": "esql_kql_query",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE kql(\"googlebigquery\") | LIMIT 500"
+    },
+    {
+      "name": "esql_postgres_qstr_query",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE postgresql.log.query IS NOT NULL AND qstr(\"copy pgbench_accounts from stdin\", {\"default_fields\":\"*\"}) AND event.duration >= 200000000 AND @timestamp >= \"2022-04-19T20:13:05Z\" AND @timestamp < \"2022-04-20T20:13:05Z\" | LIMIT 100"
+    },
+    {
+      "name": "search_postrgres_query",
+      "operation-type": "search",
+      "index": "{{p_esql_target_prefix}}logs-*",
+      "body": {
+        "size": 0,
+        "query": {
+           "bool": {
+            "filter": [
+              {
+                "bool": {
+                  "filter": [
+                    {
+                      "bool": {
+                        "should": [
+                          {
+                            "exists": {
+                              "field": "postgresql.log.query"
+                            }
+                          }
+                        ],
+                        "minimum_should_match": 1
+                      }
+                    },
+                    {
+                      "bool": {
+                        "should": [
+                          {
+                            "range": {
+                              "event.duration": {
+                                "gte": "200000000"
+                              }
+                            }
+                          }
+                        ],
+                        "minimum_should_match": 1
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "multi_match": {
+                            "type": "phrase",
+                            "query": "copy pgbench_accounts from stdin",
+                            "lenient": true
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "should": [
+                    {
+                      "exists": {
+                        "field": "event.duration"
+                      }
+                    }
+                  ],
+                  "minimum_should_match": 1
+                }
+              },
+              {
+                "range": {
+                  "@timestamp": {
+                    "format": "strict_date_optional_time",
+                    "gte": "2022-04-19T20:13:05.675Z",
+                    "lte": "2022-04-20T20:13:05.675Z"
+                  }
+                }
+              }
+            ],
+            "should": [],
+            "must_not": []
+          }
+        }
+      }
+    }

--- a/elastic/logs/operations/esql-full-text-search.json
+++ b/elastic/logs/operations/esql-full-text-search.json
@@ -2,7 +2,7 @@
     {
       "name": "apache_match_esql_query",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE event.dataset: \"apache.access\" AND http.response.status_code: 404 AND user_agent.name: \"Firefox\" | SORT @timestamp DESC | LIMIT 500",
+      "query": "FROM {{p_esql_target_prefix}}logs-*| WHERE event.dataset: \"apache.access\" AND http.response.status_code: 404 AND user_agent.name: \"Firefox\" | SORT @timestamp DESC | LIMIT 500",
       "filter": {
         "range": {
           "@timestamp": {
@@ -16,7 +16,7 @@
     {
       "name": "apache_equals_esql_query",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE event.dataset == \"apache.access\" AND http.response.status_code == 404 AND user_agent.name == \"Firefox\" | SORT @timestamp DESC | LIMIT 500",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE event.dataset == \"apache.access\" AND http.response.status_code == 404 AND user_agent.name == \"Firefox\" | SORT @timestamp DESC | LIMIT 500",
       "filter": {
         "range": {
           "@timestamp": {
@@ -163,7 +163,7 @@
     {
       "name": "qstr_esql_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE qstr(\"slack\") | SORT @timestamp DESC | LIMIT 500",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE QSTR(\"slack\") | SORT @timestamp DESC | LIMIT 500",
       "filter": {
         "range": {
           "@timestamp": {
@@ -281,7 +281,7 @@
     {
       "name": "syslog_qstr_esql_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE qstr(\"event.dataset: system.syslog\") AND qstr(\"Stopped*\") | SORT @timestamp DESC | LIMIT 500",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE QSTR(\"event.dataset: system.syslog\") AND QSTR(\"Stopped*\") | SORT @timestamp DESC | LIMIT 500",
       "filter": {
         "range": {
           "@timestamp": {

--- a/elastic/logs/operations/esql-full-text-search.json
+++ b/elastic/logs/operations/esql-full-text-search.json
@@ -2,7 +2,30 @@
     {
       "name": "apache_match_esql_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE event.dataset: \"apache.access\" AND http.response.status_code: 404 AND user_agent.name: \"Firefox\" | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | SORT @timestamp DESC | LIMIT 20"
+      "query": "FROM logs-* | WHERE event.dataset: \"apache.access\" AND http.response.status_code: 404 AND user_agent.name: \"Firefox\" | SORT @timestamp DESC | LIMIT 500",
+      "filter": {
+        "range": {
+          "@timestamp": {
+            "format": "strict_date_optional_time",
+            "gte": "{{bulk_start_date}}T09:10:05.477Z",
+            "lte": "{{bulk_end_date}}T21:10:05.477Z"
+          }
+        }
+      }
+    },
+    {
+      "name": "apache_equals_esql_query",
+      "operation-type": "esql",
+      "query": "FROM logs-* | WHERE event.dataset == \"apache.access\" AND http.response.status_code == 404 AND user_agent.name == \"Firefox\" | SORT @timestamp DESC | LIMIT 500",
+      "filter": {
+        "range": {
+          "@timestamp": {
+            "format": "strict_date_optional_time",
+            "gte": "{{bulk_start_date}}T09:10:05.477Z",
+            "lte": "{{bulk_end_date}}T21:10:05.477Z"
+          }
+        }
+      }
     },
     {
       "name": "apache_match_query_dsl_query",
@@ -48,16 +71,47 @@
             "should": [],
             "must_not": []
           }
+        },
+        "size": 500,
+        "sort": [
+          {
+            "@timestamp": {
+              "order": "desc"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "kafka_qstr_esql_query",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE QSTR(\"event.dataset: kafka.log AND Connection * disconnected\") | SORT @timestamp DESC | LIMIT 500",
+      "filter": {
+        "range": {
+          "@timestamp": {
+            "format": "strict_date_optional_time",
+            "gte": "{{bulk_start_date}}T09:10:05.477Z",
+            "lte": "{{bulk_end_date}}T21:52:08.615Z"
+          }
         }
       }
     },
     {
-      "name": "kafka_match_esql_query",
+      "name": "kafka_like_esql_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE event.dataset: \"kafka.log\" AND QSTR(\"Connection * disconnected\") | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | SORT @timestamp DESC | LIMIT 500"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE event.dataset == \"kafka.log\" AND message LIKE \"Connection * disconnected\" | SORT @timestamp DESC | LIMIT 500",
+      "filter": {
+        "range": {
+          "@timestamp": {
+            "format": "strict_date_optional_time",
+            "gte": "{{bulk_start_date}}T09:10:05.477Z",
+            "lte": "{{bulk_end_date}}T21:52:08.615Z"
+          }
+        }
+      }
     },
     {
-      "name": "kafka_query_dsl_query",
+      "name": "kafka_qstr_dsl_query",
       "operation-type": "search",
       "index": "{{p_esql_target_prefix}}logs-*",
       "body": {
@@ -69,8 +123,8 @@
                 "bool": {
                   "should": [
                     {
-                      "exists": {
-                        "field": "kafka.log.trace.class"
+                      "query_string": {
+                        "query": "event.dataset: kafka.log"
                       }
                     }
                   ],
@@ -86,7 +140,7 @@
                 "range": {
                   "@timestamp": {
                     "format": "strict_date_optional_time",
-                    "gte": "{{bulk_start_date}}T21:52:08.615Z",
+                    "gte": "{{bulk_start_date}}T09:10:05.477Z",
                     "lte": "{{bulk_end_date}}T21:52:08.615Z"
                   }
                 }
@@ -96,13 +150,29 @@
             "must_not": []
           }
         },
-        "size": 500
+        "size": 500,
+        "sort": [
+          {
+            "@timestamp": {
+              "order": "desc"
+            }
+          }
+        ]
       }
     },
     {
       "name": "qstr_esql_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE qstr(\"slack\", {\"default_field\": \"*\"}) | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | LIMIT 500"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE qstr(\"slack\") | SORT @timestamp DESC | LIMIT 500",
+      "filter": {
+        "range": {
+          "@timestamp": {
+            "format": "strict_date_optional_time",
+            "gte": "{{bulk_start_date}}T21:52:08.615Z",
+            "lte": "{{bulk_end_date}}T21:52:08.615Z"
+          }
+        }
+      }
     },
     {
       "name": "qstr_query_dsl_query",
@@ -132,13 +202,43 @@
             "must_not": []
           }
         },
-        "size": 500
+        "size": 500,
+        "sort": [
+          {
+            "@timestamp": {
+              "order": "desc"
+            }
+          }
+        ]
       }
     },
     {
       "name": "kql_esql_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE kql(\"query\") | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | LIMIT 500"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE kql(\"query\") | SORT @timestamp DESC | LIMIT 500",
+      "filter": {
+        "range": {
+          "@timestamp": {
+            "format": "strict_date_optional_time",
+            "gte": "{{bulk_start_date}}T07:52:08.615Z",
+            "lte": "{{bulk_end_date}}T07:52:08.615Z"
+          }
+        }
+      }
+    },
+    {
+      "name": "kql_like_esql_query",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE message like \"*query*\" | SORT @timestamp DESC | LIMIT 500",
+      "filter": {
+        "range": {
+          "@timestamp": {
+            "format": "strict_date_optional_time",
+            "gte": "{{bulk_start_date}}T07:52:08.615Z",
+            "lte": "{{bulk_end_date}}T07:52:08.615Z"
+          }
+        }
+      }
     },
     {
       "name": "kql_query_dsl_query",
@@ -168,20 +268,49 @@
             "must_not": []
           }
         },
-        "size": 500
+        "size": 500,
+        "sort": [
+          {
+            "@timestamp": {
+              "order": "desc"
+            }
+          }
+        ]
       }
     },
     {
       "name": "syslog_qstr_esql_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE event.dataset: \"system.syslog\" AND qstr(\"Stopped*\") | EVAL start_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_start_date }}\"), end_time = DATE_PARSE(\"yyyy-MM-dd\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= start_time AND @timestamp <= end_time | LIMIT 100"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE qstr(\"event.dataset: system.syslog\") AND qstr(\"Stopped*\") | SORT @timestamp DESC | LIMIT 500",
+      "filter": {
+        "range": {
+          "@timestamp": {
+            "format": "strict_date_optional_time",
+            "gte": "{{bulk_start_date}}T20:13:05.675Z",
+            "lte": "{{bulk_end_date}}T20:13:05.675Z"
+          }
+        }
+      }
+    },
+    {
+      "name": "syslog_like_esql_query",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE event.dataset == \"system.syslog\" AND message LIKE \"Stopped*\" | SORT @timestamp DESC | LIMIT 500",
+      "filter": {
+        "range": {
+          "@timestamp": {
+            "format": "strict_date_optional_time",
+            "gte": "{{bulk_start_date}}T20:13:05.675Z",
+            "lte": "{{bulk_end_date}}T20:13:05.675Z"
+          }
+        }
+      }
     },
     {
       "name": "syslog_query_dsl_query",
       "operation-type": "search",
       "index": "{{p_esql_target_prefix}}logs-*",
       "body": {
-        "size": 100,
         "query": {
            "bool": {
             "filter": [
@@ -192,8 +321,8 @@
                       "bool": {
                         "should": [
                           {
-                            "match": {
-                              "event.dataset": "system.syslog"
+                            "query_string": {
+                              "query": "event.dataset: system.syslog"
                             }
                           }
                         ],
@@ -228,6 +357,14 @@
             "should": [],
             "must_not": []
           }
-        }
+        },
+        "size": 500,
+        "sort": [
+          {
+            "@timestamp": {
+              "order": "desc"
+            }
+          }
+        ]
       }
     }

--- a/elastic/logs/operations/esql-full-text-search.json
+++ b/elastic/logs/operations/esql-full-text-search.json
@@ -2,12 +2,12 @@
     {
       "name": "esql_apache_match_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE data_stream.dataset: \"apache.access\" AND http.response.status_code: 404 AND user_agent.name: \"Firefox\" AND @timestamp >= \"2022-04-14T20:53:58Z\" AND @timestamp < \"2022-04-14T21:08:58Z\" @timestamp | SORT @timestamp DESC | LIMIT 20"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE data_stream.dataset: \"apache.access\" AND http.response.status_code: 404 AND user_agent.name: \"Firefox\" AND @timestamp >= \"2022-04-14T20:53:58Z\" AND @timestamp < \"2022-04-14T21:08:58Z\" | SORT @timestamp DESC | LIMIT 20"
     },
     {
       "name": "esql_kafka_match_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE data_stream.dataset: \"kafka.log\" AND kafka.log.trace.class: \"java.io.IOException\" AND @timestamp >= \"2022-04-17T21:52:08Z\" AND @timestamp < \"2022-04-18T21:52:08Z\" @timestamp | SORT @timestamp DESC | LIMIT 500"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE data_stream.dataset: \"kafka.log\" AND kafka.log.trace.class: \"java.io.IOException\" AND @timestamp >= \"2022-04-17T21:52:08Z\" AND @timestamp < \"2022-04-18T21:52:08Z\" | SORT @timestamp DESC | LIMIT 500"
     },
     {
       "name": "search_kafka_uery",
@@ -55,7 +55,7 @@
     {
       "name": "esql_qstr_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE qstr(\"*:java.lang.NullPointerException\") | LIMIT 500"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE qstr(\"java.lang.NullPointerException\", {\"default_field\": \"*\"}) | LIMIT 500"
     },
     {
       "name": "esql_kql_query",
@@ -65,7 +65,7 @@
     {
       "name": "esql_postgres_qstr_query",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE postgresql.log.query IS NOT NULL AND qstr(\"copy pgbench_accounts from stdin\", {\"default_fields\":\"*\"}) AND event.duration >= 200000000 AND @timestamp >= \"2022-04-19T20:13:05Z\" AND @timestamp < \"2022-04-20T20:13:05Z\" | LIMIT 100"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | WHERE postgresql.log.query IS NOT NULL AND qstr(\"copy pgbench_accounts from stdin\", {\"default_field\":\"*\"}) AND event.duration >= 200000000 AND @timestamp >= \"2022-04-19T20:13:05Z\" AND @timestamp < \"2022-04-20T20:13:05Z\" | LIMIT 100"
     },
     {
       "name": "search_postrgres_query",

--- a/wikipedia/challenges/default.json
+++ b/wikipedia/challenges/default.json
@@ -38,131 +38,63 @@
       "operation": "wait-until-merges-finish-after-index"
     },
     {
+      "name": "standalone-esql-match-search",
+      "operation": "query-esql-match-search",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+    },
+    {
+      "name": "standalone-query-match-search",
+      "operation": "query-match-search",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+    },
+    {
+      "name": "standalone-esql-qstr-search",
+      "operation": "query-esql-qstr-search",
+      "query-type": "match",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+    },
+    {
       "name": "standalone-query-string-search",
       "operation": "query-string-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
     },
     {
-      "name": "create-default-search-application",
-      "operation": "create-default-search-application"
-    },
-    {
-      "name": "default-search-application-search",
-      "operation": "default-search-application-search",
-      "clients": {{ application_search_clients | default(20) | int }},
-      "time-period": {{ application_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
-    },
-    {
-      "name":"update-query-rules-settings",
-      "tags": ["setup"],
-      "operation": {
-        "operation-type": "raw-request",
-        "method": "PUT",
-        "path": "/_cluster/settings",
-        "body": {
-          "persistent": {
-            "xpack.applications.rules.max_rules_per_ruleset" : 1000
-          }
-        },
-        "include-in-reporting": false
-      }
-    },
-    {
-      "name": "create-query-ruleset-1",
-      "operation": "create-query-ruleset-1",
-      "ruleset_id": "ruleset_1",
-      "ruleset_size": 1
-    },
-    {
-      "name": "create-query-ruleset-10",
-      "operation": "create-query-ruleset-10",
-      "ruleset_id": "ruleset_10",
-      "ruleset_size": 10
-    },
-    {
-      "name": "create-query-ruleset-100",
-      "operation": "create-query-ruleset-100",
-      "ruleset_id": "ruleset_100",
-      "ruleset_size": 100
-    },
-    {
-      "name": "create-query-ruleset-1000",
-      "operation": "create-query-ruleset-1000",
-      "ruleset_id": "ruleset_1000",
-      "ruleset_size": 1000
-    },
-    {
-      "name": "query-rules-search-1",
-      "operation": "query-rules-search-1",
-      "clients": {{ application_search_clients | default(20) | int }},
-      "time-period": {{ application_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
-    },
-    {
-      "name": "query-rules-search-10",
-      "operation": "query-rules-search-10",
-      "clients": {{ application_search_clients | default(20) | int }},
-      "time-period": {{ application_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
-    },
-    {
-      "name": "query-rules-search-100",
-      "operation": "query-rules-search-100",
-      "clients": {{ application_search_clients | default(20) | int }},
-      "time-period": {{ application_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
-    },
-    {
-      "name": "query-rules-search-1000",
-      "operation": "query-rules-search-1000",
-      "clients": {{ application_search_clients | default(20) | int }},
-      "time-period": {{ application_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
-    },
-    {
-      "name": "pinned-search",
-      "operation": "pinned-search",
-      "clients": {{ application_search_clients | default(20) | int }},
-      "time-period": {{ application_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
-    },
-    {
-      "parallel": {
-        "completed-by": "parallel-documents-indexing-query-string-search",
-        "tasks": [
-          {
-            "name": "parallel-documents-indexing-bulk",
-            "operation": "parallel-documents-indexing",
-            "clients": {{ parallel_indexing_bulk_clients | default(1) | int }},
-            "warmup-time-period": {{ parallel_indexing_bulk_warmup_time_period | default(10) | int }},
-            "target-throughput": {{ parallel_indexing_bulk_target_throughput | default(1) | int }}
-          },
-          {
-            "name": "parallel-documents-indexing-query-string-search",
-            "operation": "query-string-search",
-            "clients": {{ parallel_indexing_search_clients | default(20) | int }},
-            "time-period": {{ parallel_indexing_search_time_period | default(300) | int }},
-            "warmup-time-period": {{ parallel_indexing_search_warmup_time_period | default(10) | int }}
-          }
-        ]
-      }
-    },
-    {
-      "name": "standalone-retriever-search",
-      "operation": "retriever-search",
+      "name": "standalone-esql-kql-search",
+      "operation": "query-esql-kql-search",
+      "query-type": "match",
       "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
     },
     {
-      "name": "standalone-retriever-search-with-rerank",
-      "operation": "retriever-search-with-rerank",
+      "name": "standalone-query-kql-search",
+      "operation": "query-kql-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+    },
+    {
+      "name": "standalone-esql-term-search",
+      "operation": "query-esql-term-search",
+      "query-type": "match",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+    },
+    {
+      "name": "standalone-query-term-search",
+      "operation": "query-term-search",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
     }
   ]
 }

--- a/wikipedia/challenges/default.json
+++ b/wikipedia/challenges/default.json
@@ -42,14 +42,14 @@
       "operation": "query-esql-match-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
       "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
     },
     {
       "name": "standalone-query-match-search",
       "operation": "query-match-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
       "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
     },
     {
       "name": "standalone-esql-qstr-search",
@@ -57,14 +57,14 @@
       "query-type": "match",
       "clients": {{ standalone_search_clients | default(20) | int }},
       "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
     },
     {
       "name": "standalone-query-string-search",
       "operation": "query-string-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
       "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
     },
     {
       "name": "standalone-esql-kql-search",
@@ -72,14 +72,14 @@
       "query-type": "match",
       "clients": {{ standalone_search_clients | default(20) | int }},
       "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
     },
     {
       "name": "standalone-query-kql-search",
       "operation": "query-kql-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
       "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
     },
     {
       "name": "standalone-esql-term-search",
@@ -87,14 +87,14 @@
       "query-type": "match",
       "clients": {{ standalone_search_clients | default(20) | int }},
       "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
     },
     {
       "name": "standalone-query-term-search",
       "operation": "query-term-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
       "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
     }
   ]
 }

--- a/wikipedia/challenges/default.json
+++ b/wikipedia/challenges/default.json
@@ -41,14 +41,14 @@
       "name": "standalone-esql-match-search",
       "operation": "query-esql-match-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
       "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
     },
     {
       "name": "standalone-query-match-search",
       "operation": "query-match-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
       "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
     },
     {
@@ -56,14 +56,14 @@
       "operation": "query-esql-qstr-search",
       "query-type": "match",
       "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
       "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
     },
     {
       "name": "standalone-query-string-search",
       "operation": "query-string-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
       "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
     },
     {
@@ -71,14 +71,14 @@
       "operation": "query-esql-kql-search",
       "query-type": "match",
       "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
       "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
     },
     {
       "name": "standalone-query-kql-search",
       "operation": "query-kql-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
       "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
     },
     {
@@ -86,14 +86,14 @@
       "operation": "query-esql-term-search",
       "query-type": "match",
       "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
       "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
     },
     {
       "name": "standalone-query-term-search",
       "operation": "query-term-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(1) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
       "warmup-time-period": {{ standalone_search_warmup_time_period | default(0) | int }}
     }
   ]

--- a/wikipedia/challenges/default.json
+++ b/wikipedia/challenges/default.json
@@ -38,28 +38,6 @@
       "operation": "wait-until-merges-finish-after-index"
     },
     {
-      "name": "standalone-esql-match-search",
-      "operation": "query-esql-match-search",
-      "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
-    },
-    {
-      "name": "standalone-query-match-search",
-      "operation": "query-match-search",
-      "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
-    },
-    {
-      "name": "standalone-esql-qstr-search",
-      "operation": "query-esql-qstr-search",
-      "query-type": "match",
-      "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
-    },
-    {
       "name": "standalone-query-string-search",
       "operation": "query-string-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
@@ -67,31 +45,121 @@
       "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
     },
     {
-      "name": "standalone-esql-kql-search",
-      "operation": "query-esql-kql-search",
-      "query-type": "match",
+      "name": "create-default-search-application",
+      "operation": "create-default-search-application"
+    },
+    {
+      "name": "default-search-application-search",
+      "operation": "default-search-application-search",
+      "clients": {{ application_search_clients | default(20) | int }},
+      "time-period": {{ application_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name":"update-query-rules-settings",
+      "tags": ["setup"],
+      "operation": {
+        "operation-type": "raw-request",
+        "method": "PUT",
+        "path": "/_cluster/settings",
+        "body": {
+          "persistent": {
+            "xpack.applications.rules.max_rules_per_ruleset" : 1000
+          }
+        },
+        "include-in-reporting": false
+      }
+    },
+    {
+      "name": "create-query-ruleset-1",
+      "operation": "create-query-ruleset-1",
+      "ruleset_id": "ruleset_1",
+      "ruleset_size": 1
+    },
+    {
+      "name": "create-query-ruleset-10",
+      "operation": "create-query-ruleset-10",
+      "ruleset_id": "ruleset_10",
+      "ruleset_size": 10
+    },
+    {
+      "name": "create-query-ruleset-100",
+      "operation": "create-query-ruleset-100",
+      "ruleset_id": "ruleset_100",
+      "ruleset_size": 100
+    },
+    {
+      "name": "create-query-ruleset-1000",
+      "operation": "create-query-ruleset-1000",
+      "ruleset_id": "ruleset_1000",
+      "ruleset_size": 1000
+    },
+    {
+      "name": "query-rules-search-1",
+      "operation": "query-rules-search-1",
+      "clients": {{ application_search_clients | default(20) | int }},
+      "time-period": {{ application_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "query-rules-search-10",
+      "operation": "query-rules-search-10",
+      "clients": {{ application_search_clients | default(20) | int }},
+      "time-period": {{ application_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "query-rules-search-100",
+      "operation": "query-rules-search-100",
+      "clients": {{ application_search_clients | default(20) | int }},
+      "time-period": {{ application_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "query-rules-search-1000",
+      "operation": "query-rules-search-1000",
+      "clients": {{ application_search_clients | default(20) | int }},
+      "time-period": {{ application_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "pinned-search",
+      "operation": "pinned-search",
+      "clients": {{ application_search_clients | default(20) | int }},
+      "time-period": {{ application_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ application_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "parallel": {
+        "completed-by": "parallel-documents-indexing-query-string-search",
+        "tasks": [
+          {
+            "name": "parallel-documents-indexing-bulk",
+            "operation": "parallel-documents-indexing",
+            "clients": {{ parallel_indexing_bulk_clients | default(1) | int }},
+            "warmup-time-period": {{ parallel_indexing_bulk_warmup_time_period | default(10) | int }},
+            "target-throughput": {{ parallel_indexing_bulk_target_throughput | default(1) | int }}
+          },
+          {
+            "name": "parallel-documents-indexing-query-string-search",
+            "operation": "query-string-search",
+            "clients": {{ parallel_indexing_search_clients | default(20) | int }},
+            "time-period": {{ parallel_indexing_search_time_period | default(300) | int }},
+            "warmup-time-period": {{ parallel_indexing_search_warmup_time_period | default(10) | int }}
+          }
+        ]
+      }
+    },
+    {
+      "name": "standalone-retriever-search",
+      "operation": "retriever-search",
       "clients": {{ standalone_search_clients | default(20) | int }},
       "time-period": {{ standalone_search_time_period | default(300) | int }},
       "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
     },
     {
-      "name": "standalone-query-kql-search",
-      "operation": "query-kql-search",
-      "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
-    },
-    {
-      "name": "standalone-esql-term-search",
-      "operation": "query-esql-term-search",
-      "query-type": "match",
-      "clients": {{ standalone_search_clients | default(20) | int }},
-      "time-period": {{ standalone_search_time_period | default(300) | int }},
-      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
-    },
-    {
-      "name": "standalone-query-term-search",
-      "operation": "query-term-search",
+      "name": "standalone-retriever-search-with-rerank",
+      "operation": "retriever-search-with-rerank",
       "clients": {{ standalone_search_clients | default(20) | int }},
       "time-period": {{ standalone_search_time_period | default(300) | int }},
       "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}

--- a/wikipedia/challenges/esql-full-text-functions.json
+++ b/wikipedia/challenges/esql-full-text-functions.json
@@ -1,6 +1,6 @@
 {
   "name": "esql-full-text-functions",
-  "description": "Indexes and executes ES@QL and Query DSL full text functions queries",
+  "description": "Indexes and executes ES|QL and Query DSL full text functions queries",
   "schedule": [
     {
       "name": "delete-index",

--- a/wikipedia/challenges/esql-full-text-functions.json
+++ b/wikipedia/challenges/esql-full-text-functions.json
@@ -1,0 +1,99 @@
+{
+  "name": "esql-full-text-functions",
+  "description": "Indexes and executes ES@QL and Query DSL full text functions queries",
+  "schedule": [
+    {
+      "name": "delete-index",
+      "operation": "delete-index"
+    },
+    {
+      "name": "create-index",
+      "operation": "create-index"
+    },
+    {
+      "name": "check-cluster-health",
+      "operation": "check-cluster-health"
+    },
+    {
+      "name": "initial-documents-indexing",
+      "operation": "initial-documents-indexing",
+      "warmup-time-period": {{ initial_indexing_bulk_warmup_time_period | default(40) | int }},
+      "clients": {{ initial_indexing_bulk_clients | default(5) | int }}
+    },
+    {
+      "name": "refresh-after-index",
+      "operation": "refresh-after-index"
+    },
+    {
+      "name": "force-merge",
+      "operation": "force-merge"
+    },
+    {
+      "name": "refresh-after-force-merge",
+      "operation": "refresh-after-force-merge"
+    },
+    {
+      "name": "wait-until-merges-finish-after-index",
+      "operation": "wait-until-merges-finish-after-index"
+    },
+    {
+      "name": "standalone-esql-match-search",
+      "operation": "query-esql-match-search",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "standalone-query-match-search",
+      "operation": "query-match-search",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "standalone-esql-qstr-search",
+      "operation": "query-esql-qstr-search",
+      "query-type": "match",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "standalone-query-string-search",
+      "operation": "query-string-search",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "standalone-esql-kql-search",
+      "operation": "query-esql-kql-search",
+      "query-type": "match",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "standalone-query-kql-search",
+      "operation": "query-kql-search",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "standalone-esql-term-search",
+      "operation": "query-esql-term-search",
+      "query-type": "match",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+    },
+    {
+      "name": "standalone-query-term-search",
+      "operation": "query-term-search",
+      "clients": {{ standalone_search_clients | default(20) | int }},
+      "time-period": {{ standalone_search_time_period | default(300) | int }},
+      "warmup-time-period": {{ standalone_search_warmup_time_period | default(10) | int }}
+    }
+  ]
+}

--- a/wikipedia/operations/default.json
+++ b/wikipedia/operations/default.json
@@ -143,7 +143,64 @@
 {
   "name": "query-string-search",
   "operation-type": "search",
-  "param-source": "query-string-search",
+  "param-source": "query-search",
+  "query-type": "query-string",
+  "size" : {{ query_string_search_page_size | default(20) | int }},
+  "search-fields" : "{{ query_string_search_fields | default("*") }}"
+},
+{
+  "name": "query-esql-qstr-search",
+  "operation-type": "esql",
+  "param-source": "esql-search",
+  "query-type": "query-string",
+  "size" : {{ query_string_search_page_size | default(20) | int }},
+  "search-fields" : "{{ query_string_search_fields | default("*") }}"
+},
+{
+  "name": "query-match-search",
+  "operation-type": "search",
+  "param-source": "query-search",
+  "query-type": "match",
+  "size" : {{ query_string_search_page_size | default(20) | int }},
+  "search-fields" : "{{ query_string_search_fields | default("*") }}"
+},
+{
+  "name": "query-esql-match-search",
+  "operation-type": "esql",
+  "param-source": "esql-search",
+  "query-type": "match",
+  "size" : {{ query_string_search_page_size | default(20) | int }},
+  "search-fields" : "{{ query_string_search_fields | default("*") }}"
+},
+{
+  "name": "query-kql-search",
+  "operation-type": "search",
+  "param-source": "query-search",
+  "query-type": "kql",
+  "size" : {{ query_string_search_page_size | default(20) | int }},
+  "search-fields" : "{{ query_string_search_fields | default("*") }}"
+},
+{
+  "name": "query-esql-kql-search",
+  "operation-type": "esql",
+  "param-source": "esql-search",
+  "query-type": "kql",
+  "size" : {{ query_string_search_page_size | default(20) | int }},
+  "search-fields" : "{{ query_string_search_fields | default("*") }}"
+},
+{
+  "name": "query-term-search",
+  "operation-type": "search",
+  "param-source": "query-search",
+  "query-type": "term",
+  "size" : {{ query_string_search_page_size | default(20) | int }},
+  "search-fields" : "{{ query_string_search_fields | default("*") }}"
+},
+{
+  "name": "query-esql-term-search",
+  "operation-type": "esql",
+  "param-source": "esql-search",
+  "query-type": "term",
   "size" : {{ query_string_search_page_size | default(20) | int }},
   "search-fields" : "{{ query_string_search_fields | default("*") }}"
 },

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -220,7 +220,7 @@ class EsqlSearchParamSource(QueryIteratorParamSource):
         super().__init__(track, params, **kwargs)
         self._index_name = params.get("index", track.indices[0].name if len(track.indices) == 1 else "_all")
         self._search_fields = self._params["search-fields"]
-        self._size = params.get("size", 20)
+        self._size = params.get("size", 10)
         self._query_type = self._params["query-type"]
 
     def params(self):
@@ -250,7 +250,8 @@ class QueryParamSource(QueryIteratorParamSource):
     def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)
         self._index_name = params.get("index", track.indices[0].name if len(track.indices) == 1 else "_all")
-        self._cache = params.get("cache", True)
+        self._cache = params.get("cache", False)
+        self._size = params.get("size", 10)
         self._query_type = self._params["query-type"]
 
     def params(self):
@@ -275,8 +276,8 @@ class QueryParamSource(QueryIteratorParamSource):
             "body": {
                 "_source": {"includes": ["title"]},
                 "query": query_body,
+                "size": self._params["size"],
             },
-            "size": self._params["size"],
             "index": self._index_name,
             "cache": self._cache,
         }

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -239,7 +239,7 @@ class EsqlSearchParamSource(QueryIteratorParamSource):
 
         try:
             return {
-                "query": f'FROM {self._index_name} METADATA _score | WHERE { query_body } | LIMIT { self._size } | KEEP title, _score | SORT _score DESC',
+                "query": f'FROM {self._index_name} METADATA _score | WHERE { query_body } | KEEP title, _score | SORT _score DESC | LIMIT { self._size }',
             }
 
         except StopIteration:

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -220,7 +220,7 @@ class EsqlSearchParamSource(QueryIteratorParamSource):
         super().__init__(track, params, **kwargs)
         self._index_name = params.get("index", track.indices[0].name if len(track.indices) == 1 else "_all")
         self._search_fields = self._params["search-fields"]
-        self._size = params.get("size", 10)
+        self._size = params.get("size", 20)
         self._query_type = self._params["query-type"]
 
     def params(self):
@@ -251,7 +251,7 @@ class QueryParamSource(QueryIteratorParamSource):
         super().__init__(track, params, **kwargs)
         self._index_name = params.get("index", track.indices[0].name if len(track.indices) == 1 else "_all")
         self._cache = params.get("cache", False)
-        self._size = params.get("size", 10)
+        self._size = params.get("size")
         self._query_type = self._params["query-type"]
 
     def params(self):
@@ -276,7 +276,7 @@ class QueryParamSource(QueryIteratorParamSource):
             "body": {
                 "_source": {"includes": ["title"]},
                 "query": query_body,
-                "size": self._params["size"],
+                "size": self._size,
             },
             "index": self._index_name,
             "cache": self._cache,

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -107,30 +107,6 @@ class SearchApplicationSearchParamSource(QueryIteratorParamSource):
             self._queries_iterator = iter(self._sample_queries)
             return self.params()
 
-
-class QueryParamSource(QueryIteratorParamSource):
-    def __init__(self, track, params, **kwargs):
-        super().__init__(track, params, **kwargs)
-        self._index_name = params.get("index", track.indices[0].name if len(track.indices) == 1 else "_all")
-        self._cache = params.get("cache", True)
-
-    def params(self):
-        try:
-            result = {
-                "body": {
-                    "query": {"query_string": {"query": next(self._queries_iterator), "default_field": self._params["search-fields"]}}
-                },
-                "size": self._params["size"],
-                "index": self._index_name,
-                "cache": self._cache,
-            }
-
-            return result
-        except StopIteration:
-            self._queries_iterator = iter(self._sample_queries)
-            return self.params()
-
-
 class CreateQueryRulesetParamSource(ParamSource):
     def __init__(self, track, params, **kwargs):
         super().__init__(track, params, **kwargs)
@@ -237,11 +213,112 @@ class RetrieverParamSource(QueryIteratorParamSource):
             return self.params()
 
 
+# TODO Add other queries, check default fields for search. Compare them with other DSL queries
+class EsqlSearchParamSource(QueryIteratorParamSource):
+    def __init__(self, track, params, **kwargs):
+        super().__init__(track, params, **kwargs)
+        self._index_name = params.get("index", track.indices[0].name if len(track.indices) == 1 else "_all")
+        self._search_fields = self._params["search-fields"]
+        self._size = params.get("size", 20)
+        self._query_type = self._params["query-type"]
+
+    def params(self):
+
+
+        query = next(self._queries_iterator)
+        if self._query_type == "query-string":
+            query_body = f'QSTR("{ query }", {{"default_field": "{ self._search_fields }" }})'
+        elif self._query_type == "match":
+            query_body = f'MATCH(title, "{ query }") OR MATCH(content, "{ query }")'
+        elif self._query_type == "kql":
+            query_body = f'KQL("{ self._search_fields }:{ query }")'
+        elif self._query_type == "term":
+            query_body = f'TERM(title, "{ query }") OR TERM(content, "{ query }")'
+        else:
+            raise ValueError("Unknown query type: " + self._query_type)
+
+        try:
+            return {
+                "query": f'FROM {self._index_name} METADATA _score | WHERE { query_body } | LIMIT { self._size } | KEEP title, _score | SORT _score DESC',
+            }
+
+        except StopIteration:
+            self._queries_iterator = iter(self._sample_queries)
+            return self.params()
+
+class QueryParamSource(QueryIteratorParamSource):
+    def __init__(self, track, params, **kwargs):
+        super().__init__(track, params, **kwargs)
+        self._index_name = params.get("index", track.indices[0].name if len(track.indices) == 1 else "_all")
+        self._cache = params.get("cache", True)
+        self._query_type = self._params["query-type"]
+
+    def params(self):
+
+        try:
+            query = next(self._queries_iterator)
+            if self._query_type == "query-string":
+                query_body = {"query_string": {"query": query, "default_field": self._params["search-fields"]}}
+            elif self._query_type == "kql":
+                query_body = { "kql": {"query": f'{ self._params["search-fields"] }:"{ query }"'} }
+            elif self._query_type == "match":
+                query_body = {
+                    "bool": {
+                        "should": [
+                            {
+                                "match": {
+                                    "title": query
+                                }
+                            },
+                            {
+                                "match": {
+                                    "content": query
+                                }
+                            }
+                        ]
+                    }
+                }
+            elif self._query_type == "term":
+                query_body = {
+                    "bool": {
+                        "should": [
+                            {
+                                "term": {
+                                    "title": query
+                                }
+                            },
+                            {
+                                "term": {
+                                    "content": query
+                                }
+                            }
+                        ]
+                    }
+                }
+            else:
+                raise ValueError("Unknown query type: " + self._query_type)
+
+        except StopIteration:
+            self._queries_iterator = iter(self._sample_queries)
+            return self.params()
+
+        return {
+            "body": {
+                "_source": {"includes": ["title"]},
+                "query": query_body,
+            },
+            "size": self._params["size"],
+            "index": self._index_name,
+            "cache": self._cache,
+        }
+
+
 def register(registry):
-    registry.register_param_source("query-string-search", QueryParamSource)
+    registry.register_param_source("query-search", QueryParamSource)
     registry.register_param_source("create-search-application-param-source", CreateSearchApplicationParamSource)
     registry.register_param_source("search-application-search-param-source", SearchApplicationSearchParamSource)
     registry.register_param_source("create-query-ruleset-param-source", CreateQueryRulesetParamSource)
     registry.register_param_source("query-rules-search-param-source", QueryRulesSearchParamSource)
     registry.register_param_source("pinned-search-param-source", PinnedSearchParamSource)
     registry.register_param_source("retriever-search", RetrieverParamSource)
+    registry.register_param_source("esql-search", EsqlSearchParamSource)


### PR DESCRIPTION
Some additional changes:

elastic/logs track:
- Added queries to check ES|QL full text functions with other ES|QL constructs (LIKE)
- Add Query DSL equivalents to ES|QL queries
- Fix size mismatches on Query DSL and ES|QL queries

wikipedia track:
- Fix size mismatches on Query DSL and ES|QL queries
- Retrieves just title in _source for Query DSL
- Better labelling