### PR TITLE
Support target ingest throughput options to wikipedia scaling challenges

### DIFF
--- a/wikipedia/README.md
+++ b/wikipedia/README.md
@@ -84,7 +84,9 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
   - `as_warmup_time_periods` (default: [600,600,600,600,600])
   - `as_time_periods` (default: [1800,1800,1800,1800,1800])
   - `as_ingest_clients` (default: [1,2,4,8,16])
-  - `as_target_throughputs` (default: [-1,-1,-1,-1,-1])
+  - `as_ingest_target_throughputs` (default: [-1,-1,-1,-1,-1])
+
+When `as_ingest_target_throughputs` is a positive number, the ingest throughput formula in documents per second is `ingest_bulk_size * as_ingest_target_throughputs`.
 
 ### Parameters for search-autoscale challenge
 
@@ -98,6 +100,8 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
   - `as_search_clients` (default: [1,2,4,8,16])
   - `as_search_target_throughputs` (default: [-1,-1,-1,-1,-1])
 
+When `as_search_target_throughputs` is a positive number, the search throughput formula in documents per second is `search_size * as_search_target_throughputs`.
+
 ### Parameters for ingest-search-autoscale challenge
 
 - Initial indexing:
@@ -109,11 +113,14 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 - Ingest Operations:
   - `ingest_bulk_size` (default: 100)
   - `as_ingest_clients` (default: [1,2,4,8,16])
-  - `as_target_throughputs` (default: [-1,-1,-1,-1,-1])
+  - `as_ingest_target_throughputs` (default: [-1,-1,-1,-1,-1])
 - Search Operations:
   - `search_size` (default: 10)
   - `as_search_clients` (default: [1,2,4,8,16])
   - `as_search_target_throughputs` (default: [-1,-1,-1,-1,-1])
+
+When `as_ingest_target_throughputs` is a positive number, the ingest throughput formula in documents per second is `ingest_bulk_size * as_ingest_target_throughputs`.
+When `as_search_target_throughputs` is a positive number, the search throughput formula in documents per second is `search_size * as_search_target_throughputs`.
 
 ### License
 

--- a/wikipedia/README.md
+++ b/wikipedia/README.md
@@ -81,9 +81,10 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
   - `initial_ingest_bulk_size` (default: 100)
 - Ingest Operations:
   - `ingest_bulk_size` (default: 100)
-  - `as_warmup_time_periods` (default: [600,600,600,600,600]) 
+  - `as_warmup_time_periods` (default: [600,600,600,600,600])
   - `as_time_periods` (default: [1800,1800,1800,1800,1800])
   - `as_ingest_clients` (default: [1,2,4,8,16])
+  - `as_target_throughputs` (default: [-1,-1,-1,-1,-1])
 
 ### Parameters for search-autoscale challenge
 
@@ -108,6 +109,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 - Ingest Operations:
   - `ingest_bulk_size` (default: 100)
   - `as_ingest_clients` (default: [1,2,4,8,16])
+  - `as_target_throughputs` (default: [-1,-1,-1,-1,-1])
 - Search Operations:
   - `search_size` (default: 10)
   - `as_search_clients` (default: [1,2,4,8,16])

--- a/wikipedia/challenges/common/ingest-autoscale-schedule.json
+++ b/wikipedia/challenges/common/ingest-autoscale-schedule.json
@@ -24,12 +24,12 @@
   }
 }
 {%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600,600,600,600,600]))%}
-{%- set p_as_target_throughputs = (as_target_throughputs | default([-1,-1,-1,-1,-1]))%}
+{%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([-1,-1,-1,-1,-1]))%}
 {%- set p_as_time_periods = (as_time_periods | default([1800,1800,1800,1800,1800]))%}
 {%- set p_as_ingest_clients = (as_ingest_clients | default([1,2,4,8,16]))%}
 {%- set p_ingest_bulk_size = (ingest_bulk_size | default(100))%}
 {%- for i in range(p_as_ingest_clients|length) %},
-  {%- if p_as_target_throughputs[i] < 0 %}
+  {%- if p_as_ingest_target_throughputs[i] < 0 %}
   {
     "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
     "clients": {{p_as_ingest_clients[i]}},
@@ -52,7 +52,7 @@
     },
     "warmup-time-period": {{p_as_warmup_time_periods[i]}},
     "time-period": {{p_as_time_periods[i]}},
-    "target-throughput": {{p_as_target_throughputs[i]}}
+    "target-throughput": {{p_as_ingest_target_throughputs[i]}}
   }
   {%- endif %}
 {%- endfor %}

--- a/wikipedia/challenges/common/ingest-autoscale-schedule.json
+++ b/wikipedia/challenges/common/ingest-autoscale-schedule.json
@@ -24,19 +24,35 @@
   }
 }
 {%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600,600,600,600,600]))%}
+{%- set p_as_target_throughputs = (as_target_throughputs | default([-1,-1,-1,-1,-1]))%}
 {%- set p_as_time_periods = (as_time_periods | default([1800,1800,1800,1800,1800]))%}
 {%- set p_as_ingest_clients = (as_ingest_clients | default([1,2,4,8,16]))%}
 {%- set p_ingest_bulk_size = (ingest_bulk_size | default(100))%}
 {%- for i in range(p_as_ingest_clients|length) %},
-{
-  "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
-  "clients": {{p_as_ingest_clients[i]}},
-  "operation": {
-    "operation-type": "bulk",
-    "bulk-size": {{p_ingest_bulk_size}},
-    "looped": true
-  },
-  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-  "time-period": {{p_as_time_periods[i]}}
-}
+  {%- if p_as_target_throughputs[i] < 0 %}
+  {
+    "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
+    "clients": {{p_as_ingest_clients[i]}},
+    "operation": {
+      "operation-type": "bulk",
+      "bulk-size": {{p_ingest_bulk_size}},
+      "looped": true
+    },
+    "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+    "time-period": {{p_as_time_periods[i]}}
+  }
+  {%- else %}
+  {
+    "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
+    "clients": {{p_as_ingest_clients[i]}},
+    "operation": {
+      "operation-type": "bulk",
+      "bulk-size": {{p_ingest_bulk_size}},
+      "looped": true
+    },
+    "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+    "time-period": {{p_as_time_periods[i]}},
+    "target-throughput": {{p_as_target_throughputs[i]}}
+  }
+  {%- endif %}
 {%- endfor %}

--- a/wikipedia/challenges/common/ingest-search-autoscale-schedule.json
+++ b/wikipedia/challenges/common/ingest-search-autoscale-schedule.json
@@ -24,6 +24,7 @@
   }
 }
 {%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600,600,600,600,600]))%}
+{%- set p_as_target_throughputs = (as_target_throughputs | default([-1,-1,-1,-1,-1]))%}
 {%- set p_as_time_periods = (as_time_periods | default([1800,1800,1800,1800,1800]))%}
 {%- set p_as_ingest_clients = (as_ingest_clients | default([1,1,1,1,1]))%}
 {%- set p_ingest_bulk_size = (ingest_bulk_size | default(100))%}
@@ -36,6 +37,7 @@
     "warmup-time-period": {{p_as_time_periods[i]}},
     "time-period": {{p_as_warmup_time_periods[i]}},
     "tasks": [
+  {%- if p_as_target_throughputs[i] < 0 %}
       {
         "name": "parallel-ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
         "clients": {{p_as_ingest_clients[i]}},
@@ -47,6 +49,20 @@
         "warmup-time-period": {{p_as_warmup_time_periods[i]}},
         "time-period": {{p_as_time_periods[i]}}
       },
+  {%- else %}
+  {
+    "name": "parallel-ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
+    "clients": {{p_as_ingest_clients[i]}},
+    "operation": {
+      "operation-type": "bulk",
+      "bulk-size": {{p_ingest_bulk_size}},
+      "looped": true
+    },
+    "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+    "time-period": {{p_as_time_periods[i]}},
+    "target-throughput": {{p_as_target_throughputs[i]}}
+  },
+  {%- endif %}
   {%- if p_as_search_target_throughputs[i] < 0 %}
       {
         "name": "parallel-search-{{loop.index}}-c{{p_as_search_clients[i]}}-s{{p_search_size}}",

--- a/wikipedia/challenges/common/ingest-search-autoscale-schedule.json
+++ b/wikipedia/challenges/common/ingest-search-autoscale-schedule.json
@@ -24,7 +24,7 @@
   }
 }
 {%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600,600,600,600,600]))%}
-{%- set p_as_target_throughputs = (as_target_throughputs | default([-1,-1,-1,-1,-1]))%}
+{%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([-1,-1,-1,-1,-1]))%}
 {%- set p_as_time_periods = (as_time_periods | default([1800,1800,1800,1800,1800]))%}
 {%- set p_as_ingest_clients = (as_ingest_clients | default([1,1,1,1,1]))%}
 {%- set p_ingest_bulk_size = (ingest_bulk_size | default(100))%}
@@ -37,7 +37,7 @@
     "warmup-time-period": {{p_as_time_periods[i]}},
     "time-period": {{p_as_warmup_time_periods[i]}},
     "tasks": [
-  {%- if p_as_target_throughputs[i] < 0 %}
+  {%- if p_as_ingest_target_throughputs[i] < 0 %}
       {
         "name": "parallel-ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
         "clients": {{p_as_ingest_clients[i]}},
@@ -60,7 +60,7 @@
     },
     "warmup-time-period": {{p_as_warmup_time_periods[i]}},
     "time-period": {{p_as_time_periods[i]}},
-    "target-throughput": {{p_as_target_throughputs[i]}}
+    "target-throughput": {{p_as_ingest_target_throughputs[i]}}
   },
   {%- endif %}
   {%- if p_as_search_target_throughputs[i] < 0 %}


### PR DESCRIPTION
Adds optional target ingestion throughput parameters to the `ingest-autoscale` and `ingest-search-autoscale` challenges.