### PR TITLE
Attempt to minimize noise

### DIFF
--- a/esql/challenges/default.json
+++ b/esql/challenges/default.json
@@ -46,14 +46,14 @@
           "operation": "from_idx_limit_1",
           "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
-          "warmup-iterations": 10,
+          "warmup-iterations": 100,
           "iterations": {{query_iterations | default(100)}}
         },
         {
           "operation": "from_idx_limit_10",
           "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
-          "warmup-iterations": 10,
+          "warmup-iterations": 100,
           "iterations": {{query_iterations | default(100)}}
         },
         {
@@ -76,14 +76,14 @@
           "operation": "from_idx_limit_1_drop_null",
           "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
-          "warmup-iterations": 10,
+          "warmup-iterations": 100,
           "iterations": {{query_iterations | default(100)}}
         },
         {
           "operation": "from_idx_limit_10_drop_null",
           "tags": ["esql_large_schema"],
           "clients":  {{query_clients | default(1)}},
-          "warmup-iterations": 10,
+          "warmup-iterations": 100,
           "iterations": {{query_iterations | default(100)}}
         },
         {


### PR DESCRIPTION
 from_idx_limit_1 and from_idx_limit_10 benchmarks are fairly fast with each measurement ~100-120ms. I would like to add a bit more warmup iterations to attempt to make results a bit more stable.

 For me locally this change added ~10s to the benchmark runtime.