### PR TITLE
http_logs add search with int sort

### DIFF
--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -195,6 +195,26 @@
           "iterations": 100,
           "target-throughput": 2
         },
+        {
+          "operation": "sort_size_desc",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "operation": "sort_size_asc",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "operation": "sort_status_desc",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "operation": "sort_status_asc",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
 {%- if not runtime_fields is defined %}
         {
           "operation": "sort_keyword_can_match_shortcut",
@@ -273,4 +293,28 @@
           "warmup-iterations": 10,
           "iterations": 100,
           "target-throughput": 0.5
+        },
+        {
+          "name": "sort-size-desc-after-force-merge-1-seg",
+          "operation": "sort_size_desc",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "name": "sort-size-asc-after-force-merge-1-seg",
+          "operation": "sort_size_asc",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "name": "sort-status-desc-after-force-merge-1-seg",
+          "operation": "sort_status_desc",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "name": "sort-status-asc-after-force-merge-1-seg",
+          "operation": "sort_status_asc",
+          "warmup-iterations": 200,
+          "iterations": 100
         }

--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -195,6 +195,7 @@
           "iterations": 100,
           "target-throughput": 2
         },
+{%- if not runtime_fields is defined %}
         {
           "operation": "sort_size_desc",
           "warmup-iterations": 200,
@@ -215,7 +216,6 @@
           "warmup-iterations": 200,
           "iterations": 100
         },
-{%- if not runtime_fields is defined %}
         {
           "operation": "sort_keyword_can_match_shortcut",
           "warmup-iterations": 200,
@@ -286,14 +286,15 @@
           "warmup-iterations": 10,
           "iterations": 100,
           "target-throughput": 1
-        },
+        },       
         {
           "name": "asc-sort-with-after-timestamp-after-force-merge-1-seg",
           "operation": "asc_sort_with_after_timestamp",
           "warmup-iterations": 10,
           "iterations": 100,
           "target-throughput": 0.5
-        },
+        }
+{%- if not runtime_fields is defined %},         
         {
           "name": "sort-size-desc-after-force-merge-1-seg",
           "operation": "sort_size_desc",
@@ -318,3 +319,4 @@
           "warmup-iterations": 200,
           "iterations": 100
         }
+{%- endif %}        

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -335,6 +335,58 @@
       }
     },
     {
+      "name": "sort_size_desc",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"size" : "desc"}
+        ]
+      }
+    },
+    {
+      "name": "sort_size_asc",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"size" : "asc"}
+        ]
+      }
+    },
+    {
+      "name": "sort_status_desc",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"status" : "desc"}
+        ]
+      }
+    },
+    {
+      "name": "sort_status_asc",
+      "operation-type": "search",
+      "index": "logs-*",
+      "body": {
+        "query": {
+          "match_all": {}
+        },
+        "sort" : [
+          {"status" : "asc"}
+        ]
+      }
+    },
+    {
       "name": "sort_numeric_can_match_shortcut",
       "operation-type": "search",
       "index": "logs-*",


### PR DESCRIPTION
This adds sorting on integer fields of "size" and "status".
We are optimizing integer sort in elastic/elasticsearch/pull/127968,
and it would be nice to have dedicated operations for integer sort.

Notice, no target-throughput for these operations, as when optimization is merged
we expect massive speedups.