### PR TITLE
Remove fixed refresh interval from k8s-logging template

### DIFF
--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -17,8 +17,7 @@
         }
         {#- non-serverless-index-settings-marker-start #}
         {%- if build_flavor != "serverless" or serverless_operator == true %},
-        "number_of_routing_shards": "30",
-        "refresh_interval": {{ refresh_interval | default("5s") | tojson }}
+        "number_of_routing_shards": "30"
         {%- endif %}
         {#- non-serverless-index-settings-marker-end #}
         {%- if disable_pipelines is not true %},


### PR DESCRIPTION
This is hiding a performance issue, that we're going to investigate (again).
@inqueue would this be ok for nightly env? iirc the issue that benchmark didn't complete in time was fixed, by introducing `elastic-logs-logsdb-just-basic` config.

Revert "Partial revert of 9fae039: use a 5s refresh for k8s application logs unless the refresh_interval is specified (#766)"

This reverts commit 2b89a0162c62ffc4b70a3587feb562b576e581f2.

Relates to #2463