### PR TITLE
Add a custom param test

### DIFF
--- a/it/test_custom_parameters.py
+++ b/it/test_custom_parameters.py
@@ -1,0 +1,29 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+pytest_rally = pytest.importorskip("pytest_rally")
+
+
+class TestCustomParameters:
+    def test_tsdb_esql(self, es_cluster, rally):
+        ret = rally.race(
+            track="tsdb",
+            track_params={"run_esql_aggs": True, "index_mode": "time_series"},
+        )
+        assert ret == 0


### PR DESCRIPTION
in #780 it was seen that certain paths through the track wont be tested, since they are gated on parameters being set. This adds a single test file that can be expanded as / when we spot other tracks that have similar behaviour