### PR TITLE
Add autoscaling challenges to msmarco-v2-vector track

### DIFF
--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -64,7 +64,7 @@ $ python _tools/parse_queries.py -r
 ### Parameters
 
 This track accepts the following parameters with Rally 0.8.0+ using `--track-params`:
-
+ - `vector_index_type` (default: bbq_hnsw)
  - `aggressive_merge_policy` (default: false): Whether to apply a more aggressive merge strategy.
  - `index_refresh_interval` (default: unset): The index refresh interval.
  - `initial_indexing_bulk_indexing_clients` (default: 5)
@@ -82,3 +82,57 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - `search_ops` (default: [(10, 20, 0), (10, 20, 20), (10, 50, 0), (10, 50, 20), (10, 100, 0), (10, 100, 20), (10, 200, 0), (10, 200, 20), (10, 500, 0), (10, 500, 20), (10, 1000, 0), (10, 1000, 20), (100, 120, 0), (100, 120, 120), (100, 200, 0), (100, 200, 120), (100, 500, 0), (100, 500, 120), (100, 1000, 0), (100, 1000, 120)]): The search and recall operations to run (k, ef_search, num_rescore).
  - `standalone_search_iterations` (default: 10000)
  - `vector_index_type` (default: "int8_hnsw"): The index kind for storing the vectors.
+
+### Parameters for ingest-autoscale challenge
+
+- Mapping:
+    - `vector_index_type` (default: bbq_hnsw)
+- Initial indexing:
+    - `initial_ingest_clients` (default: 4)
+    - `initial_ingest_bulk_size` (default: 100)
+- Ingest Operations:
+    - `ingest_bulk_size` (default: 100)
+    - `as_warmup_time_periods` (default: [600,600,600,600,600])
+    - `as_time_periods` (default: [1800,1800,1800,1800,1800])
+    - `as_ingest_clients` (default: [1,2,4,8,16])
+    - `as_ingest_target_throughputs` (default: [-1,-1,-1,-1,-1])
+
+When `as_ingest_target_throughputs` is a positive number, the ingest throughput formula in documents per second is `ingest_bulk_size * as_ingest_target_throughputs`.
+
+### Parameters for search-autoscale challenge
+
+- Mapping:
+  - `vector_index_type` (default: bbq_hnsw)
+- Initial indexing:
+    - `initial_ingest_clients` (default: 4)
+    - `initial_ingest_bulk_size` (default: 100)
+- Search Operations:
+    - `search_size` (default: 10)
+    - `as_warmup_time_periods` (default: [600,600,600,600,600])
+    - `as_time_periods` (default: [1800,1800,1800,1800,1800])
+    - `as_search_clients` (default: [1,2,4,8,16])
+    - `as_search_target_throughputs` (default: [-1,-1,-1,-1,-1])
+
+When `as_search_target_throughputs` is a positive number, the search throughput formula in documents per second is `search_size * as_search_target_throughputs`.
+
+### Parameters for ingest-search-autoscale challenge
+
+- Mapping:
+    - `vector_index_type` (default: bbq_hnsw)
+- Initial indexing:
+    - `initial_ingest_clients` (default: 4)
+    - `initial_ingest_bulk_size` (default: 100)
+- Operations:
+    - `as_warmup_time_periods` (default: [600,600,600,600,600])
+    - `as_time_periods` (default: [1800,1800,1800,1800,1800])
+- Ingest Operations:
+    - `ingest_bulk_size` (default: 100)
+    - `as_ingest_clients` (default: [1,2,4,8,16])
+    - `as_ingest_target_throughputs` (default: [-1,-1,-1,-1,-1])
+- Search Operations:
+    - `search_size` (default: 10)
+    - `as_search_clients` (default: [1,2,4,8,16])
+    - `as_search_target_throughputs` (default: [-1,-1,-1,-1,-1])
+
+When `as_ingest_target_throughputs` is a positive number, the ingest throughput formula in documents per second is `ingest_bulk_size * as_ingest_target_throughputs`.
+When `as_search_target_throughputs` is a positive number, the search throughput formula in documents per second is `search_size * as_search_target_throughputs`.

--- a/msmarco-v2-vector/challenges/common/ingest-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/ingest-autoscale-schedule.json
@@ -1,0 +1,65 @@
+{
+  "name": "delete-index",
+  "operation": {
+    "operation-type": "delete-index"
+  }
+},
+{
+  "name": "create-index",
+  "operation": {
+    "operation-type": "create-index"
+  }
+},
+{
+  "name": "check-cluster-health",
+  "operation": "check-cluster-health"
+},
+{
+  "name": "initial-ingest",
+  "clients": {{ initial_ingest_clients | default(4) | int}},
+  "operation": {
+    "operation-type": "bulk",
+    "bulk-size": {{ initial_ingest_bulk_size | default(100) | int}},
+    "ingest-percentage": {{initial_ingest_percentage | default(100) | int}}
+  }
+}
+{%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600,600,600,600,600]))%}
+{%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([-1,-1,-1,-1,-1]))%}
+{%- set p_as_time_periods = (as_time_periods | default([1800,1800,1800,1800,1800]))%}
+{%- set p_as_ingest_clients = (as_ingest_clients | default([1,2,4,8,16]))%}
+{%- set p_ingest_bulk_size = (ingest_bulk_size | default(100))%}
+{%- for i in range(p_as_ingest_clients|length) %},
+  {%- if p_as_ingest_target_throughputs[i] < 0 %}
+{
+  "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
+  "clients": {{p_as_ingest_clients[i]}},
+  "operation": {
+    "operation-type": "bulk",
+    "bulk-size": {{p_ingest_bulk_size}},
+    "looped": true
+  },
+  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+  "time-period": {{p_as_time_periods[i]}}
+},
+  {%- else %}
+{
+  "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
+  "clients": {{p_as_ingest_clients[i]}},
+  "operation": {
+    "operation-type": "bulk",
+    "bulk-size": {{p_ingest_bulk_size}},
+    "looped": true
+  },
+  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+  "time-period": {{p_as_time_periods[i]}},
+  "target-throughput": {{p_as_ingest_target_throughputs[i]}}
+},
+  {%- endif %}
+{
+  "name": "post-ingest-sleep-{{loop.index}}",
+  "operation": {
+    "operation-type": "sleep",
+    "duration": {{ post_ingest_sleep_duration|default(60) }}
+  }
+}
+{%- endfor %}

--- a/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
@@ -1,0 +1,122 @@
+{
+  "name": "delete-index",
+  "operation": {
+    "operation-type": "delete-index"
+  }
+},
+{
+  "name": "create-index",
+  "operation": {
+    "operation-type": "create-index"
+  }
+},
+{
+  "name": "check-cluster-health",
+  "operation": "check-cluster-health"
+},
+{
+  "name": "initial-ingest",
+  "clients": {{ initial_ingest_clients | default(4) | int}},
+  "operation": {
+    "operation-type": "bulk",
+    "bulk-size": {{ initial_ingest_bulk_size | default(100) | int}},
+    "ingest-percentage": {{initial_ingest_percentage | default(100) | int}}
+  }
+}
+{%- set p_vector_index_type = (vector_index_type | default("bbq_hnsw"))%}
+{%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600,600,600,600,600]))%}
+{%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([-1,-1,-1,-1,-1]))%}
+{%- set p_as_time_periods = (as_time_periods | default([1800,1800,1800,1800,1800]))%}
+{%- set p_as_ingest_clients = (as_ingest_clients | default([1,1,1,1,1]))%}
+{%- set p_ingest_bulk_size = (ingest_bulk_size | default(100))%}
+{%- set p_as_search_clients = (as_search_clients | default([1,2,4,8,16]))%}
+{%- set p_as_search_target_throughputs = (as_search_target_throughputs | default([-1,-1,-1,-1,-1]))%}
+{%- for i in range(p_as_warmup_time_periods|length) %},
+{
+  "parallel": {
+    "warmup-time-period": {{p_as_time_periods[i]}},
+    "time-period": {{p_as_warmup_time_periods[i]}},
+    "tasks": [
+  {%- if p_as_ingest_target_throughputs[i] < 0 %}
+      {
+        "name": "parallel-ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
+        "clients": {{p_as_ingest_clients[i]}},
+        "operation": {
+          "operation-type": "bulk",
+          "bulk-size": {{p_ingest_bulk_size}},
+          "looped": true
+        },
+        "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+        "time-period": {{p_as_time_periods[i]}}
+      },
+  {%- else %}
+  {
+    "name": "parallel-ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
+    "clients": {{p_as_ingest_clients[i]}},
+    "operation": {
+      "operation-type": "bulk",
+      "bulk-size": {{p_ingest_bulk_size}},
+      "looped": true
+    },
+    "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+    "time-period": {{p_as_time_periods[i]}},
+    "target-throughput": {{p_as_ingest_target_throughputs[i]}}
+  },
+  {%- endif %}
+  {%- if p_as_search_target_throughputs[i] < 0 %}
+      {
+        "name": "parallel-search-{{loop.index}}-c{{p_as_search_clients[i]}}-s10",
+        "clients": {{p_as_search_clients[i]}},
+        "operation": {
+          "operation-type": "search",
+          "param-source": "knn-param-source",
+          "k": 10,
+          "num-candidates": 100,
+          {%- if p_vector_index_type == "bbq_hnsw" %}
+          "oversample-rescore": 3,
+          {%- endif %}
+          "looped": true
+        },
+        "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+        "time-period": {{p_as_time_periods[i]}}
+      }
+  {%- else %}
+      {
+        "name": "parallel-search-{{loop.index}}-c{{p_as_search_clients[i]}}-s10-t{{p_as_search_target_throughputs[i]}}",
+        "clients": {{p_as_search_clients[i]}},
+        "operation": {
+          "operation-type": "search",
+          "param-source": "knn-param-source",
+          "k": 10,
+          "num-candidates": 100,
+          {%- if p_vector_index_type == "bbq_hnsw" %}
+          "oversample-rescore": 3,
+          {%- endif %}
+          "looped": true
+        },
+        "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+        "time-period": {{p_as_time_periods[i]}},
+        "target-throughput": {{p_as_search_target_throughputs[i]}}
+      },
+      {
+        "name": "parallel-search-{{loop.index}}-c{{p_as_search_clients[i]}}-s10-t{{p_as_search_target_throughputs[i]}}",
+        "clients": {{p_as_search_clients[i]}},
+        "operation": {
+          "operation-type": "search",
+          "param-source": "knn-param-source",
+          "k": 10,
+          "num-candidates": 100,
+          {%- if p_vector_index_type == "bbq_hnsw" %}
+          "oversample-rescore": 3,
+          {%- endif %}
+          "looped": true
+        },
+        "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+        "time-period": {{p_as_time_periods[i]}},
+        "target-throughput": {{p_as_search_target_throughputs[i]}}
+      }
+  {%- endif %}
+    ]
+  }
+}
+{%- endfor %}

--- a/msmarco-v2-vector/challenges/common/search-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/search-autoscale-schedule.json
@@ -1,0 +1,101 @@
+{
+  "name": "delete-index",
+  "operation": {
+    "operation-type": "delete-index"
+  }
+},
+{
+  "name": "create-index",
+  "operation": {
+    "operation-type": "create-index"
+  }
+},
+{
+  "name": "check-cluster-health",
+  "operation": "check-cluster-health"
+},
+{
+  "name": "initial-ingest",
+  "clients": {{ initial_ingest_clients | default(4) | int}},
+  "operation": {
+    "operation-type": "bulk",
+    "bulk-size": {{ initial_ingest_bulk_size | default(100) | int}},
+    "ingest-percentage": {{initial_ingest_percentage | default(100) | int}}
+  }
+}
+{%- set p_vector_index_type = (vector_index_type | default("bbq_hnsw"))%}
+{%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600,600,600,600,600]))%}
+{%- set p_as_time_periods = (as_time_periods | default([1800,1800,1800,1800,1800]))%}
+{%- set p_as_search_clients = (as_search_clients | default([1,2,4,8,16]))%}
+{%- set p_as_search_target_throughputs = (as_search_target_throughputs | default([-1,-1,-1,-1,-1]))%}
+{%- for i in range(p_as_warmup_time_periods|length) %},
+  {%- if p_as_search_target_throughputs[i] < 0 %}
+{
+  "name": "search-{{loop.index}}-c{{p_as_search_clients[i]}}-s10",
+  "clients": {{p_as_search_clients[i]}},
+  "operation": {
+    "operation-type": "search",
+    "param-source": "knn-param-source",
+    "k": 10,
+    "num-candidates": 100,
+    {%- if p_vector_index_type == "bbq_hnsw" %}
+    "oversample-rescore": 3,
+    {%- endif %}
+    "looped": true
+  },
+  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+  "time-period": {{p_as_time_periods[i]}}
+},
+{
+  "name": "search-{{loop.index}}-c{{p_as_search_clients[i]}}-s100",
+  "clients": {{p_as_search_clients[i]}},
+  "operation": {
+    "operation-type": "search",
+    "param-source": "knn-param-source",
+    "k": 100,
+    "num-candidates": 500,
+    {%- if p_vector_index_type == "bbq_hnsw" %}
+    "oversample-rescore": 3,
+    {%- endif %}
+    "looped": true
+  },
+  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+  "time-period": {{p_as_time_periods[i]}}
+}
+  {%- else %}
+{
+  "name": "search-{{loop.index}}-c{{p_as_search_clients[i]}}-s10-t{{p_as_search_target_throughputs[i]}}",
+  "clients": {{p_as_search_clients[i]}},
+  "operation": {
+    "operation-type": "search",
+    "param-source": "knn-param-source",
+    "k": 10,
+    "num-candidates": 100,
+    {%- if p_vector_index_type == "bbq_hnsw" %}
+    "oversample-rescore": 3,
+    {%- endif %}
+    "looped": true
+  },
+  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+  "time-period": {{p_as_time_periods[i]}},
+  "target-throughput": {{p_as_search_target_throughputs[i]}}
+},
+{
+  "name": "search-{{loop.index}}-c{{p_as_search_clients[i]}}-s100-t{{p_as_search_target_throughputs[i]}}",
+  "clients": {{p_as_search_clients[i]}},
+  "operation": {
+    "operation-type": "search",
+    "param-source": "knn-param-source",
+    "k": 100,
+    "num-candidates": 500,
+    {%- if p_vector_index_type == "bbq_hnsw" %}
+    "oversample-rescore": 3,
+    {%- endif %}
+    "looped": true
+  },
+  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
+  "time-period": {{p_as_time_periods[i]}},
+  "target-throughput": {{p_as_search_target_throughputs[i]}}
+}
+  {%- endif %}
+{%- endfor %}

--- a/msmarco-v2-vector/challenges/default.json
+++ b/msmarco-v2-vector/challenges/default.json
@@ -107,4 +107,28 @@
     }
     {%- endfor %}
   ]
+},
+{
+  "name": "ingest-autoscale",
+  "description": "Benchmark bulk indexing with configurable steps",
+  "default": false,
+  "schedule": [
+    {{ rally.collect(parts="common/ingest-autoscale-schedule.json") }}
+  ]
+},
+{
+  "name": "search-autoscale",
+  "description": "Benchmark search queries with configurable scaling steps",
+  "default": false,
+  "schedule": [
+    {{ rally.collect(parts="common/search-autoscale-schedule.json") }}
+  ]
+},
+{
+  "name": "ingest-search-autoscale",
+  "description": "Benchmark concurrent queries and bulk indexing with configurable scaling steps",
+  "default": false,
+  "schedule": [
+    {{ rally.collect(parts="common/ingest-search-autoscale-schedule.json") }}
+  ]
 }

--- a/msmarco-v2-vector/index-vectors-only-mapping.json
+++ b/msmarco-v2-vector/index-vectors-only-mapping.json
@@ -1,14 +1,16 @@
 {
   "settings": {
-    {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
     "index": {
+      {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {%- if index_refresh_interval is defined %}
       "index_refresh_interval": {{ index_refresh_interval | tojson }},
       {%- endif %}
       {% if preload_pagecache %}
       "store.preload": [ "vec", "vex", "vem"],
       {% endif %}
+      {%- if use_synthetic_source|default(false) -%}
       "mapping.source.mode": "synthetic",
+      {% endif %}
       "number_of_shards": {{number_of_shards | default(1)}},
       "number_of_replicas": {{number_of_replicas | default(0)}}
       {% if aggressive_merge_policy %},
@@ -20,8 +22,12 @@
         }
       }
       {% endif %}
+      {%- else %}{# non-serverless-index-settings-marker-end #}
+        {%- if use_synthetic_source|default(false) -%}
+      "mapping.source.mode": "synthetic",
+        {% endif %}
+      {% endif %}
     }
-    {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },
   "mappings": {
     "dynamic": false,
@@ -36,7 +42,7 @@
         "index": true,
         "similarity": "dot_product",
         "index_options": {
-          "type": {{ vector_index_type | default("int8_hnsw") | tojson }}
+          "type": {{ vector_index_type | default("bbq_hnsw") | tojson }}
         }
       }
     }

--- a/msmarco-v2-vector/operations/default.json
+++ b/msmarco-v2-vector/operations/default.json
@@ -25,7 +25,7 @@
   "bulk-size": {{parallel_indexing_bulk_size | default(50)}},
   "ingest-percentage": {{parallel_indexing_ingest_percentage | default(100)}}
 }
-{%- set p_search_ops = (search_ops | default([(10, 20, 0), (10, 20, 20), (10, 50, 0), (10, 50, 20), (10, 100, 0), (10, 100, 20), (10, 200, 0), (10, 200, 20), (10, 500, 0), (10, 500, 20), (10, 1000, 0), (10, 1000, 20), (100, 120, 0), (100, 120, 120), (100, 200, 0), (100, 200, 120), (100, 500, 0), (100, 500, 120), (100, 1000, 0), (100, 1000, 120)]))%}
+{%- set p_search_ops = (search_ops | default([(10, 20, 0), (10, 20, 1), (10, 50, 0), (10, 50, 2), (10, 100, 0), (10, 100, 2), (10, 200, 0), (10, 200, 2), (10, 500, 0), (10, 500, 2), (10, 1000, 0), (10, 1000, 2), (100, 120, 0), (100, 120, 1), (100, 200, 0), (100, 200, 1), (100, 500, 0), (100, 500, 120), (100, 1000, 0), (100, 1000, 120)]))%}
 {%- for i in range(p_search_ops|length) %},
 {
   {%- if p_search_ops[i][2] > 0 -%}
@@ -37,7 +37,7 @@
   "param-source": "knn-param-source",
   "k": {{p_search_ops[i][0]}},
   "num-candidates": {{p_search_ops[i][1]}},
-  "num-rescore": {{p_search_ops[i][2]}}
+  "oversample-rescore": {{p_search_ops[i][2]}}
 },
 {
   {%- if p_search_ops[i][2] > 0 -%}
@@ -49,7 +49,7 @@
   "param-source": "knn-recall-param-source",
   "k": {{p_search_ops[i][0]}},
   "num-candidates": {{p_search_ops[i][1]}},
-  "num-rescore": {{p_search_ops[i][2]}},
+  "oversample-rescore": {{p_search_ops[i][2]}},
   "include-in-reporting": false
 }
 {%- endfor %}

--- a/msmarco-v2-vector/track.py
+++ b/msmarco-v2-vector/track.py
@@ -68,24 +68,6 @@ def read_qrels(qrels_input_file):
     return qrels
 
 
-def get_rescore_query(vec, window_size):
-    return {
-        "window_size": window_size,
-        "query": {
-            "query_weight": 0,
-            "rescore_query": {
-                "script_score": {
-                    "query": {"match_all": {}},
-                    "script": {
-                        "source": "double value = dotProduct(params.query_vector, 'emb'); return sigmoid(1, Math.E, -value);",
-                        "params": {"query_vector": vec},
-                    },
-                }
-            },
-        },
-    }
-
-
 class KnnParamSource:
     def __init__(self, track, params, **kwargs):
         # choose a suitable index: if there is only one defined for this track
@@ -114,21 +96,21 @@ class KnnParamSource:
     def params(self):
         top_k = self._params.get("k", 10)
         num_candidates = self._params.get("num-candidates", 50)
-        num_rescore = self._params.get("num-rescore", 0)
         query_vec = self._queries[self._iters]
+        knn_query = {"field": "emb", "query_vector": query_vec, "k": top_k, "num_candidates": num_candidates}
+        if self._params.get("oversample-rescore", 0) > 0:
+            knn_query["rescore_vector"] = {"oversample": self._params.get("oversample-rescore")}
+        if "filter" in self._params:
+            knn_query["filter"] = self._params["filter"]
         result = {
             "index": self._index_name,
             "cache": self._params.get("cache", False),
             "size": top_k,
             "body": {
-                "knn": {"field": "emb", "query_vector": query_vec, "k": max(top_k, num_rescore), "num_candidates": num_candidates},
-                "_source": False,
+                "knn": knn_query,
+                "_source": False
             },
         }
-        if num_rescore > 0:
-            result["body"]["rescore"] = get_rescore_query(query_vec, num_rescore)
-        if "filter" in self._params:
-            result["body"]["knn"]["filter"] = self._params["filter"]
 
         self._iters += 1
         if self._iters >= self._maxIters:
@@ -157,7 +139,7 @@ class KnnRecallParamSource:
             "cache": self._params.get("cache", False),
             "size": self._params.get("k", 10),
             "num_candidates": self._params.get("num-candidates", 100),
-            "num_rescore": self._params.get("num-rescore", 0),
+            "oversample_rescore": self._params.get("oversample-rescore", 0),
         }
 
 
@@ -165,7 +147,6 @@ class KnnRecallRunner:
     async def __call__(self, es, params):
         top_k = params["size"]
         num_candidates = params["num_candidates"]
-        num_rescore = params["num_rescore"]
         index = params["index"]
         request_cache = params["cache"]
 
@@ -181,19 +162,16 @@ class KnnRecallRunner:
             for line in queries_file:
                 query = json.loads(line)
                 query_id = query["query_id"]
+
+                knn_query = {"field": "emb", "query_vector": query["emb"], "k": top_k, "num_candidates": num_candidates}
+                if params["oversample_rescore"] > 0:
+                    knn_query["rescore_vector"] = {"oversample": params["oversample_rescore"]}
                 body = {
-                    "knn": {
-                        "field": "emb",
-                        "query_vector": query["emb"],
-                        "k": max(top_k, num_rescore),
-                        "num_candidates": num_candidates,
-                    },
+                    "knn": knn_query,
                     "_source": False,
                     "fields": ["docid"],
                     "profile": True,
                 }
-                if num_rescore > 0:
-                    body["rescore"] = get_rescore_query(query["emb"], num_rescore)
                 knn_result = await es.search(index=index, request_cache=request_cache, size=top_k, body=body)
                 knn_hits = []
                 for hit in knn_result["hits"]["hits"]:
@@ -222,7 +200,8 @@ class KnnRecallRunner:
                 "k": top_k,
                 "num_candidates": num_candidates,
                 "avg_nodes_visited": statistics.mean(nodes_visited) if any([x > 0 for x in nodes_visited]) else None,
-                "99th_percentile_nodes_visited": compute_percentile(nodes_visited, 99) if any([x > 0 for x in nodes_visited]) else None,
+                "99th_percentile_nodes_visited": compute_percentile(nodes_visited, 99) if any(
+                    [x > 0 for x in nodes_visited]) else None,
             }
             if exact_total > 0
             else None

--- a/msmarco-v2-vector/track.py
+++ b/msmarco-v2-vector/track.py
@@ -106,10 +106,7 @@ class KnnParamSource:
             "index": self._index_name,
             "cache": self._params.get("cache", False),
             "size": top_k,
-            "body": {
-                "knn": knn_query,
-                "_source": False
-            },
+            "body": {"knn": knn_query, "_source": False},
         }
 
         self._iters += 1
@@ -200,8 +197,7 @@ class KnnRecallRunner:
                 "k": top_k,
                 "num_candidates": num_candidates,
                 "avg_nodes_visited": statistics.mean(nodes_visited) if any([x > 0 for x in nodes_visited]) else None,
-                "99th_percentile_nodes_visited": compute_percentile(nodes_visited, 99) if any(
-                    [x > 0 for x in nodes_visited]) else None,
+                "99th_percentile_nodes_visited": compute_percentile(nodes_visited, 99) if any([x > 0 for x in nodes_visited]) else None,
             }
             if exact_total > 0
             else None


### PR DESCRIPTION
This PR adds three new challenges to msmarco-v2-vector similar to the Wikipedia autoscaling challenges:
  * ingest-autoscale
  * search-autoscale
  * ingest-search-autoscale

It also replaces the rescorer usage with the oversample parameter added in the knn section.