### PR TITLE
Adding k100 tasks to so_vector

### DIFF
--- a/so_vector/challenges/default.json
+++ b/so_vector/challenges/default.json
@@ -50,7 +50,21 @@
     {
       "name": "knn-recall-10-50-match-all",
       "operation": "knn-recall-10-50-match-all",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
+      "iterations": 1,
+      "clients": 1
+    },
+    {
+      "name": "knn-search-100-300-match-all",
+      "operation": "knn-search-100-300-match-all",
+      "warmup-iterations": 100,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "knn-recall-100-300-match-all",
+      "operation": "knn-recall-100-300-match-all",
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
@@ -71,7 +85,7 @@
     {
       "name": "knn-recall-10-50-acceptedAnswerId",
       "operation": "knn-recall-10-50-acceptedAnswerId",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
@@ -92,7 +106,7 @@
     {
       "name": "knn-recall-10-50-java",
       "operation": "knn-recall-10-50-java",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
@@ -113,7 +127,7 @@
     {
       "name": "knn-recall-10-50-css",
       "operation": "knn-recall-10-50-css",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
@@ -134,7 +148,7 @@
     {
       "name": "knn-recall-10-50-concurrency",
       "operation": "knn-recall-10-50-concurrency",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
@@ -155,7 +169,7 @@
     {
       "name": "knn-recall-10-50-random-10-percent",
       "operation": "knn-recall-10-50-random-10-percent",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
@@ -169,7 +183,35 @@
     {
       "name": "knn-recall-10-50-random-20-percent",
       "operation": "knn-recall-10-50-random-20-percent",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
+      "iterations": 1,
+      "clients": 1
+    },
+    {
+      "name": "knn-search-100-300-random-10-percent",
+      "operation": "knn-search-100-300-random-10-percent",
+      "warmup-iterations": 100,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "knn-recall-100-300-random-10-percent",
+      "operation": "knn-recall-100-300-random-10-percent",
+      "warmup-iterations": 0,
+      "iterations": 1,
+      "clients": 1
+    },
+        {
+      "name": "knn-search-100-300-random-20-percent",
+      "operation": "knn-search-100-300-random-20-percent",
+      "warmup-iterations": 100,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "knn-recall-100-300-random-20-percent",
+      "operation": "knn-recall-100-300-random-20-percent",
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     }
@@ -198,7 +240,21 @@
     {
       "name": "knn-recall-10-50-match-all-force-merge",
       "operation": "knn-recall-10-50-match-all",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
+      "iterations": 1,
+      "clients": 1
+    },
+    {
+      "name": "knn-search-100-300-match-all-force-merge",
+      "operation": "knn-search-100-300-match-all",
+      "warmup-iterations": 100,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "knn-recall-100-300-match-all-force-merge",
+      "operation": "knn-recall-100-300-match-all",
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
@@ -212,7 +268,7 @@
     {
       "name": "knn-recall-10-50-acceptedAnswerId-force-merge",
       "operation": "knn-recall-10-50-acceptedAnswerId",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
@@ -226,7 +282,7 @@
     {
       "name": "knn-recall-10-50-java-force-merge",
       "operation": "knn-recall-10-50-java",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
@@ -240,14 +296,14 @@
     {
       "name": "knn-recall-10-50-css-force-merge",
       "operation": "knn-recall-10-50-css",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
     {
       "name": "knn-recall-10-50-concurrency-force-merge",
       "operation": "knn-recall-10-50-concurrency",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
@@ -268,7 +324,7 @@
     {
       "name": "knn-recall-10-50-random-10-percent-force-merge",
       "operation": "knn-recall-10-50-random-10-percent",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     },
@@ -282,7 +338,35 @@
     {
       "name": "knn-recall-10-50-random-20-percent-force-merge",
       "operation": "knn-recall-10-50-random-20-percent",
-      "warmup-iterations": 1,
+      "warmup-iterations": 0,
+      "iterations": 1,
+      "clients": 1
+    },
+    {
+      "name": "knn-search-100-300-random-10-percent-force-merge",
+      "operation": "knn-search-100-300-random-10-percent",
+      "warmup-iterations": 100,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "knn-recall-100-300-random-10-percent-force-merge",
+      "operation": "knn-recall-100-300-random-10-percent",
+      "warmup-iterations": 0,
+      "iterations": 1,
+      "clients": 1
+    },
+    {
+      "name": "knn-search-100-300-random-20-percent-force-merge",
+      "operation": "knn-search-100-300-random-20-percent",
+      "warmup-iterations": 100,
+      "iterations": 100,
+      "clients": 1
+    },
+    {
+      "name": "knn-recall-100-300-random-20-percent-force-merge",
+      "operation": "knn-recall-100-300-random-20-percent",
+      "warmup-iterations": 0,
       "iterations": 1,
       "clients": 1
     }

--- a/so_vector/operations/default.json
+++ b/so_vector/operations/default.json
@@ -140,6 +140,35 @@
   }
 },
 {
+  "name": "knn-search-100-300-random-10-percent",
+  "operation-type": "search",
+  "param-source": "knn-param-source",
+  "k": 100,
+  "num_candidates": 300,
+  "filter": {
+    "range": {
+      "questionId": {
+        "lte": 650000
+      }
+    }
+  }
+},
+{
+  "name": "knn-recall-100-300-random-10-percent",
+  "operation-type": "knn-recall",
+  "param-source": "knn-recall-param-source",
+  "k": 100,
+  "num_candidates": 300,
+  "include-in-reporting": false,
+  "filter": {
+    "range": {
+      "questionId": {
+        "lte": 650000
+      }
+    }
+  }
+},
+{
   "name": "knn-search-10-50-random-20-percent",
   "operation-type": "search",
   "param-source": "knn-param-source",
@@ -169,6 +198,35 @@
   }
 },
 {
+  "name": "knn-search-100-300-random-20-percent",
+  "operation-type": "search",
+  "param-source": "knn-param-source",
+  "k": 100,
+  "num_candidates": 300,
+  "filter": {
+    "range": {
+      "questionId": {
+        "lte": 1500000
+      }
+    }
+  }
+},
+{
+  "name": "knn-recall-100-300-random-20-percent",
+  "operation-type": "knn-recall",
+  "param-source": "knn-recall-param-source",
+  "k": 100,
+  "num_candidates": 300,
+  "include-in-reporting": false,
+  "filter": {
+    "range": {
+      "questionId": {
+        "lte": 1500000
+      }
+    }
+  }
+},
+{
   "name": "knn-search-10-50-match-all",
   "operation-type": "search",
   "param-source": "knn-param-source",
@@ -181,6 +239,21 @@
   "param-source": "knn-recall-param-source",
   "k": 10,
   "num_candidates": 50,
+  "include-in-reporting": false
+},
+{
+  "name": "knn-search-100-300-match-all",
+  "operation-type": "search",
+  "param-source": "knn-param-source",
+  "k": 100,
+  "num_candidates": 300 
+},
+{
+  "name": "knn-recall-100-300-match-all",
+  "operation-type": "knn-recall",
+  "param-source": "knn-recall-param-source",
+  "k": 100,
+  "num_candidates": 300,
   "include-in-reporting": false
 },
 {


### PR DESCRIPTION
The final update to so_vector (at least for my current work concerns).

We should also have a k-100 task to measure the higher k recall and latency values for matchall, filter 10%/20%. 

I didn't do it for ALL the tasks as that would get pretty danged expensive, so the two random filter & matchall seemed good.

I also adjusted the recall tasks to NOT do a warm up. We don't care about performance here (we do that with the knn search tasks), so doing it twice (once for warm up and once for measure) was wasted work.