### PR TITLE
Remove duplicate task definition in msmarco

### DIFF
--- a/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
@@ -97,23 +97,6 @@
         "warmup-time-period": {{p_as_warmup_time_periods[i]}},
         "time-period": {{p_as_time_periods[i]}},
         "target-throughput": {{p_as_search_target_throughputs[i]}}
-      },
-      {
-        "name": "parallel-search-{{loop.index}}-c{{p_as_search_clients[i]}}-s10-t{{p_as_search_target_throughputs[i]}}",
-        "clients": {{p_as_search_clients[i]}},
-        "operation": {
-          "operation-type": "search",
-          "param-source": "knn-param-source",
-          "k": 10,
-          "num-candidates": 100,
-          {%- if p_vector_index_type == "bbq_hnsw" %}
-          "oversample-rescore": 3,
-          {%- endif %}
-          "looped": true
-        },
-        "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-        "time-period": {{p_as_time_periods[i]}},
-        "target-throughput": {{p_as_search_target_throughputs[i]}}
       }
   {%- endif %}
     ]


### PR DESCRIPTION
Running the track yields error:

> esrally.track.loader.TrackSyntaxError: Track 'msmarco-v2-vector' is invalid. Challenge 'ingest-search-autoscale' contains multiple tasks with the name 'parallel-search-1-c50-s10-t100'. Please use the task's name property to assign a unique name for each task.

The `ingest-search-autoscale` has a duplicate block that creates the same task twice. This removes the extraneous block.