### PR TITLE
Add random vector track configuration and datastream mapping

### DIFF
--- a/random_vector/README.md
+++ b/random_vector/README.md
@@ -2,29 +2,73 @@
 
 This track is designed for benchmarking filtered search on random vectors.
 
-By default, the `flat` vector_index_type is utilized to evaluate the performance
-of brute force search over vectors filtered by a partition ID.
+By default, the flat vector_index_type is utilized to evaluate the performance of brute force search over vectors filtered by a partition ID.
+
+## Index Type Configuration
+
+The track supports creating either an index or datastream based on the `index_type` parameter:
+- `index_type: "datastream"` (default) - Creates a data stream
+- `index_type: "index"` - Creates a regular index
 
 ## Indexing
 
-To begin indexing, the track initiates `index_clients` clients, each executing `index_iterations` bulk operations of size `index_bulk_size`. 
-Consequently, the total number of documents indexed by the track is calculated as follows: `index_clients` * `index_iterations` * `index_bulk_size`.
+Indexing runs in one of two modes, depending on whether `index_target_throughput` is specified.
+The track launches `index_clients` parallel clients. Each client sends `index_iterations` bulk requests, with each request containing `index_bulk_size` documents.
 
-Each document in the bulk is assigned a random vector of dimensions `dims` and a random partition ID.
-The resulting index is sorted on the partition id. This helps make sure vectors are close together when we do filtered searches.
+The total number of documents indexed is:
+`index_clients` × `index_iterations` × `index_bulk_size`
+
+* If `index_target_throughput` is set, each client will send bulk operations at a rate of:
+  `index_target_throughput` ÷ `index_clients` bulk requests per second.
+* If `index_target_throughput` is not set, each client will send bulk operations as fast as possible.
+
+### Document content and index layout
+
+Each document indexed includes:
+
+* A random vector with `dims` dimensions.
+* A randomly assigned partition ID.
+
+The index is sorted by partition ID. 
+This ensures that vectors from the same partition are stored close together, improving the efficiency of filtered searches.
 
 ## Search Operations
 
 Search operations involve filtering by a random partition ID and scoring against a random query vector. 
 These operations are executed against the index using various DSL flavors, including script score and knn section.
 
-### Parameters
+## Challenges
+
+### Default Challenge: `index-and-search`
+The standard challenge that creates an index/datastream, indexes documents, and performs search operations.
+
+### Autoscale Challenge: `ingest-search-autoscale`
+A specialized challenge that mimics autoscaling behavior with configurable steps and parallel search/indexing operations.
+
+**Autoscaling Parameters:**
+- `as_ingest_clients` - Array of client counts for each autoscaling step
+- `as_ingest_bulk_size` - Array of bulk sizes for each step
+- `as_ingest_target_throughputs` - Array of target throughputs for each step
+- `as_ingest_index_iterations` - Array of iteration counts for each step
+
+**Parallel Operation Parameters:**
+- `parallel_warmup_time_periods` - Warmup duration for parallel operations
+- `parallel_time_periods` - Duration for parallel operations
+- `parallel_indexing_clients` - Number of parallel indexing clients
+- `parallel_ingest_target_throughputs` - Target throughput for parallel indexing
+- `parallel_indexing_bulk_size` - Bulk size for parallel indexing
+- `parallel_search_clients` - Number of parallel search clients
+
+## Parameters
 
 This track accepts the following parameters with Rally 0.8.0+ using `--track-params`:
 
+### Basic Parameters
  - number_of_shards (default: 1)
  - number_of_replicas (default: 0)
  - vector_index_type (default: flat)
+ - index_type (default: datastream) - Choose between "index" or "datastream"
+ - index_target_throughput (default: undefined)
  - index_clients (default: 1)
  - index_iterations (default: 1000)
  - index_bulk_size (default: 1000)
@@ -32,3 +76,19 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - search_clients (default: 8)
  - dims (default: 128)
  - partitions (default: 1000)
+ - use_synthetic_source (default: false)
+ - routing (default: false)
+
+### Autoscaling Parameters (for ingest-search-autoscale challenge)
+ - as_ingest_clients (default: [5,20,5]) - Array of client counts per step
+ - as_ingest_bulk_size (default: [100,100,100]) - Array of bulk sizes per step
+ - as_ingest_target_throughputs (default: [10,50,10]) - Array of target throughputs per step
+ - as_ingest_index_iterations (default: [1000,2000,1500]) - Array of iteration counts per step
+
+### Parallel Operation Parameters (for ingest-search-autoscale challenge)
+ - parallel_warmup_time_periods (default: 10) - Warmup duration in time periods
+ - parallel_time_periods (default: 10) - Operation duration in time periods
+ - parallel_indexing_clients (default: 1) - Number of parallel indexing clients
+ - parallel_ingest_target_throughputs (default: 1) - Target throughput for parallel indexing
+ - parallel_indexing_bulk_size (default: 10) - Bulk size for parallel indexing
+ - parallel_search_clients (default: 10) - Number of parallel search clients

--- a/random_vector/challenges/common/ingest-autoscale-schedule.json
+++ b/random_vector/challenges/common/ingest-autoscale-schedule.json
@@ -1,0 +1,96 @@
+{%- set p_index_type = (index_type | default("datastream"))%}
+
+{%- if (p_index_type == "datastream") -%}
+{
+  
+    "name": "create-ingest-pipeline",
+    "operation": "create-ingest-pipeline"
+},
+{%- endif -%}
+{
+  
+    "name": "delete-data-stream",
+    "operation": "delete-data-stream"
+},
+{
+    "name": "delete-index",
+    "operation": "delete-index",
+    "ignore": [401,404]
+},
+{
+  
+    "name": "delete-data-stream-template",
+    "operation": "delete-data-stream-template"
+ 
+}, 
+{%- if p_index_type == "datastream" -%}
+{
+    "name": "create-data-stream-template",
+    "operation": "create-data-stream-template"
+ 
+},
+{%- endif -%}
+{%- if p_index_type == "datastream" -%}
+{
+    "name": "create-data-stream",
+    "operation": "create-data-stream"
+ 
+},
+{%- endif -%}
+{%- if p_index_type == "index" -%}
+{
+    "name": "create-index",
+    "operation": "create-index"
+},
+{%- endif -%}
+{
+  "name": "check-cluster-health",
+  "operation": "check-cluster-health"
+}
+{%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([10,50,10]))%}
+{%- set p_as_ingest_clients = (as_ingest_clients | default([5,20,5]))%}
+{%- set p_as_ingest_bulk_size = (as_ingest_bulk_size | default([100,100,100]))%}
+{%- set p_as_ingest_index_iterations = (as_ingest_index_iterations | default([1000,2000,1500]))%}
+{%- for i in range(p_as_ingest_clients|length) %},
+    {
+      "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_as_ingest_bulk_size[i]}}-tt{{p_as_ingest_target_throughputs[i]}}-it{{p_as_ingest_index_iterations[i]}}",
+      "operation": "random-bulk-indexing-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_as_ingest_bulk_size[i]}}-tt{{p_as_ingest_target_throughputs[i]}}-it{{p_as_ingest_index_iterations[i]}}",
+      "target-throughput":  {{p_as_ingest_target_throughputs[i]}},
+      "clients": {{ p_as_ingest_clients[i] | default(1) | int }},
+      "iterations": {{ p_as_ingest_index_iterations[i]}},
+      "bulk-size": {{ p_as_ingest_bulk_size[i]}},
+      "iterations": {{ p_as_ingest_index_iterations[i] | default(1000) | int }},
+      "looped": true
+    }
+
+{%- endfor %}
+{%- set p_as_parallel_indexing_clients = (parallel_indexing_clients | default(1))%}
+{%- set p_as_parallel_ingest_target_throughputs = (parallel_ingest_target_throughputs | default(1))%}
+{%- set p_as_parallel_indexing_bulk_size = (parallel_indexing_bulk_size | default(10))%}
+{%- set p_as_parallel_warmup_time_periods = (parallel_warmup_time_periods | default(10))%}
+{%- set p_as_parallel_time_periods = (parallel_time_periods | default(10))%}
+{%- set p_as_parallel_search_clients = (parallel_search_clients | default(10))%}
+,{
+  "parallel": {
+    "completed-by": "parallel-random-indexing",
+    "tasks": [
+      {
+        "name": "parallel-random-indexing",
+        "operation": "random-bulk-indexing",
+        "clients": {{ p_as_parallel_indexing_clients | default(1) | int }},
+        "target-throughput":  {{p_as_parallel_ingest_target_throughputs | default(1) | int}},
+        "bulk-size": {{ p_as_parallel_indexing_bulk_size | default(10)}},        
+        "warmup-time-period": {{p_as_parallel_warmup_time_periods}},
+        "time-period": {{p_as_parallel_time_periods}}
+      },
+      {
+        "name": "parallel-knn-filtered-search-multiple-client",
+        "operation": "brute-force-filtered-search",
+        "script": false,
+        "clients": {{ p_as_parallel_search_clients | default(1) | int }},
+        "warmup-time-period": {{p_as_parallel_warmup_time_periods}},
+        "time-period": {{p_as_parallel_time_periods}}
+      }
+    ]
+  }
+}

--- a/random_vector/challenges/default.json
+++ b/random_vector/challenges/default.json
@@ -1,16 +1,49 @@
+{%- set p_index_type = (index_type | default("datastream"))%}
+
 {
   "name": "index-and-search",
   "description": "Create an index and index doc with random content into it.",
   "default": true,
   "schedule": [
+    {%- if p_index_type == "datastream" -%}
+   {
+  
+    "name": "create-ingest-pipeline",
+    "operation": "create-ingest-pipeline"
+   },
+  {%- endif -%}
+   {
+  
+    "name": "delete-data-stream",
+    "operation": "delete-data-stream"
+   },
     {
       "name": "delete-index",
-      "operation": "delete-index"
+      "operation": "delete-index",
+      "ignore": [401,404]
     },
     {
+  
+      "name": "delete-data-stream-template",
+      "operation": "delete-data-stream-template"
+   
+   }, 
+   {%- if p_index_type == "datastream" -%}
+   {
+    "name": "create-data-stream-template",
+    "operation": "create-data-stream-template"
+ 
+   },
+   {%- endif -%}
+   {
+    {%- if p_index_type == "datastream" -%}
+      "name": "create-data-stream",
+      "operation": "create-data-stream"
+    {%- else -%}
       "name": "create-index",
       "operation": "create-index"
-    },
+    {%- endif -%}
+  },
     {
       "name": "check-cluster-health",
       "operation": "check-cluster-health"
@@ -18,9 +51,11 @@
     {
       "name": "random-indexing",
       "operation": "random-bulk-indexing",
+      {%- if index_target_throughput is defined %}
+      "target-throughput": {{ index_target_throughput | int }},
+      {%- endif %}
       "clients": {{ index_clients | default(1) | int }},
-      "iterations": {{ index_iterations | default(1000) | int }},
-      "bulk-size": {{ index_bulk_size | default(1000)}}
+      "iterations": {{ index_iterations | default(1000) | int }}
     },
     {
       "name": "refresh-after-index",
@@ -60,5 +95,13 @@
       "iterations": {{ search_iterations | default(1000) | int }},
       "clients": {{ search_clients | default(8) | int }}
     }
+  ]
+},
+{
+  "name": "ingest-search-autoscale",
+  "description": "Benchmark bulk indexing with configurable steps",
+  "default": false,
+  "schedule": [
+    {{ rally.collect(parts="common/ingest-autoscale-schedule.json") }}
   ]
 }

--- a/random_vector/datastream-mapping.json
+++ b/random_vector/datastream-mapping.json
@@ -1,17 +1,12 @@
 {
   "settings": {
-    "index": {
-      {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {# non-serverless-index-settings-marker-start #}
+    {%- if build_flavor != "serverless" or serverless_operator == true -%}
       "number_of_shards": {{number_of_shards | default(1)}},
       "number_of_replicas": {{number_of_replicas | default(0)}},
-      {%- endif -%}{# non-serverless-index-settings-marker-end #}
-      "sort": {
-        "field": "partition_id"
-      }
-      {%- if use_synthetic_source | default(false) -%},
-      "mapping.source.mode": "synthetic"
-      {%- endif -%}
-    }
+    {%- endif -%}
+    {# non-serverless-index-settings-marker-end #}
+      "refresh_interval" : "1s"
   },
   "mappings": {
     {%- if routing | default(false) -%}

--- a/random_vector/operations/default.json
+++ b/random_vector/operations/default.json
@@ -1,6 +1,91 @@
 {
   "name": "delete-index",
   "operation-type": "delete-index",
+  "ignore": [401,404],
+  "include-in-reporting": false
+},
+{
+  "name": "create-ingest-pipeline",
+  "operation-type": "put-pipeline",
+  "id": "add-timestamp",
+  "body": {
+    "processors": [
+      {
+        "set": {
+          "field": "@timestamp",
+          "value": {{'"{{_ingest.timestamp}}"'}}
+        }
+      }
+    ]
+  },
+  "include-in-reporting": false
+},
+{
+  "name": "delete-data-stream",
+  "operation-type": "raw-request",
+  "method": "DELETE",
+  "path": "/_data_stream/index",
+  "ignore": [404],
+  "include-in-reporting": false
+},
+{
+  "name": "delete-data-stream-template",
+  "operation-type": "raw-request",
+  "method": "DELETE",
+  "ignore": [404],
+  "path": "/_index_template/index",
+  "include-in-reporting": false
+},
+{
+  "name": "create-data-stream-template",
+  "operation-type": "raw-request",
+  "method": "PUT",
+  "path": "/_index_template/index",
+  "body": {
+    "index_patterns": ["index"],
+    "data_stream": { },
+    "template": {
+      "settings": {
+        {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+        "number_of_shards": {{number_of_shards | default(1)}},
+        "number_of_replicas": {{number_of_replicas | default(0)}},
+        {%- endif -%}{# non-serverless-index-settings-marker-end #}
+        "index.default_pipeline": "add-timestamp",
+        "mapping.source.mode": "synthetic",
+        "refresh_interval" : "1s",
+        "sort": {
+          "field": "partition_id"
+        }
+      },
+      "mappings": {
+        "properties": {
+          "@timestamp": {
+            "type": "date"
+          },
+          "emb": {
+            "type": "dense_vector",
+            "dims":  {{ dims | default(128) | tojson }},
+            "index": true,
+            "similarity": "cosine",
+            "index_options": {
+              "type": {{ vector_index_type | default("flat") | tojson }}
+            }
+          },
+          "partition_id": {
+            "type": "keyword"
+          }
+        }
+      }
+    },
+    "priority": 200
+  },
+  "include-in-reporting": false
+},
+{
+  "name": "create-data-stream",
+  "operation-type": "raw-request",
+  "method": "PUT",
+  "path": "/_data_stream/index",
   "include-in-reporting": false
 },
 {
@@ -20,15 +105,38 @@
 {
   "name": "random-bulk-indexing",
   "operation-type": "bulk",
+  "refresh": "wait_for",
   "param-source": "random-bulk-param-source",
-  "dims": {{dims | default(128)}},
-  "partitions": {{partitions | default(1000)}}
+  "dims": {{ dims | default(128) | int }},
+  "partitions": {{ partitions | default(1000) | int }},
+  "routing": {{ routing | default(false) | tojson }},
+  {%- if index_type == "index" -%}
+  "routing": {{ routing | default(false) | tojson }},
+  {%- endif -%}
+  "bulk-size": {{ index_bulk_size | default(1000)}}
 },
 {
   "name": "brute-force-filtered-search",
   "operation-type": "search",
   "param-source": "knn-param-source",
-  "dims": {{dims | default(128)}},
-  "partitions": {{partitions | default(1000)}}
+  "dims": {{ dims | default(128) | int }},
+  "partitions": {{ partitions | default(1000) | int }}
 }
-
+{%- set p_as_ingest_clients = (as_ingest_clients | default([5,20,5]))%}
+{%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([10,50,10]))%}
+{%- set p_as_ingest_index_iterations = (as_ingest_index_iterations | default([1000,2000,1500]))%}
+{%- set p_as_ingest_bulk_size = (as_ingest_bulk_size | default([100,100,100]))%}
+{%- for i in range(p_as_ingest_clients|length) %},
+{
+  "name": "random-bulk-indexing-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_as_ingest_bulk_size[i]}}-tt{{p_as_ingest_target_throughputs[i]}}-it{{p_as_ingest_index_iterations[i]}}",
+  "operation-type": "bulk",
+  "refresh": "wait_for",
+  "param-source": "random-bulk-param-source",
+  "dims": {{ dims | default(128) | int }},
+  "partitions": {{ partitions | default(1000) | int }},
+  "routing": {{ routing | default(false) | tojson }},
+  {%- if index_type == "index" -%}
+  "routing": {{ routing | default(false) | tojson }},
+  {%- endif -%}
+  "bulk-size": {{ p_as_ingest_bulk_size[i] }}}
+{%- endfor %}

--- a/random_vector/track.json
+++ b/random_vector/track.json
@@ -5,7 +5,11 @@
   "indices": [
     {
       "name": "index",
+      {%- if (index_type == "datastream") -%}
+      "body": "datastream-mapping.json"
+      {%- else -%}
       "body": "index-mapping.json"
+      {%- endif -%}
     }
   ],
   "operations": [

--- a/random_vector/track.py
+++ b/random_vector/track.py
@@ -10,6 +10,19 @@ class RandomBulkParamSource(ParamSource):
         self._index_name = params.get("index", track.indices[0].name)
         self._dims = params.get("dims", 128)
         self._partitions = params.get("partitions", 1000)
+        self._routing = params.get("routing", False)
+        self._index_type = params.get("index_type", "datastream")
+        self._as_ingest_clients = params.get("as_ingest_clients", [5,20,5])
+        self._as_ingest_bulk_size = params.get("as_ingest_bulk_size", [100,100,100])
+        self._as_ingest_target_throughputs = params.get("as_ingest_target_throughputs", [10,50,10])
+        self._as_ingest_index_iterations = params.get("as_ingest_index_iterations", [1000,2000,1500])
+        self._parallel_warmup_time_periods = params.get("parallel_warmup_time_periods", 10)
+        self._parallel_time_periods = params.get("parallel_time_periods", 10)
+        self._parallel_indexing_clients = params.get("parallel_indexing_clients", 1)
+        self._parallel_ingest_target_throughputs = params.get("parallel_ingest_target_throughputs", 1)
+        self._parallel_indexing_bulk_size = params.get("parallel_indexing_bulk_size", 10)
+        self._parallel_search_clients = params.get("parallel_search_clients", 10)
+
 
     def params(self):
         import numpy as np
@@ -18,7 +31,10 @@ class RandomBulkParamSource(ParamSource):
         for _ in range(self._bulk_size):
             vec = np.random.rand(self._dims)
             partition_id = random.randint(0, self._partitions)
-            bulk_data.append({"index": {"_index": self._index_name, "routing": partition_id}})
+            metadata = {"_index": self._index_name}
+            if self._routing:
+                metadata["routing"] = partition_id
+            bulk_data.append({"create": metadata})
             bulk_data.append({"partition_id": partition_id, "emb": vec.tolist()})
 
         return {


### PR DESCRIPTION
This PR adds comprehensive configuration for the random vector track, including new datastream mapping and autoscale schedule functionality. New files added: challenges/common/ingest-autoscale-schedule.json and datastream-mapping.json. Modified files include README.md, challenges/default.json, index-mapping.json, operations/default.json, track.json, and track.py. The changes add support for datastream-based operations and ingest autoscaling schedule configuration.