### PR TITLE
Add index without setup challenge

### DIFF
--- a/elastic/logs/challenges/logging-indexing-no-setup.json
+++ b/elastic/logs/challenges/logging-indexing-no-setup.json
@@ -1,0 +1,23 @@
+{% import "rally.helpers" as rally %}
+{
+  "name": "logging-pure-indexing-only",
+  "description": "Indexes logs, either throttled or un-throttled, for a specified time period and volume per day",
+  "schedule": [
+    {
+      "name": "bulk-index",
+      "operation": {
+        "operation-type": "raw-bulk",
+        "param-source": "processed-source",
+        "time-format": "milliseconds",
+        "profile": "fixed_interval",
+        "bulk-size": {{ p_bulk_size }},
+        "detailed-results": true
+      },
+      "clients": {{ p_bulk_indexing_clients }}{% if p_throttle_indexing %},
+      "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+      "schedule": "timestamp-throttler",
+      "max-delay-secs": 1
+      {% endif %}
+    }
+  ]
+}


### PR DESCRIPTION
As part of [competitive benchmarking](https://github.com/elastic/competitive-benchmarking/), I'm using rally as a dataset "generator" which sends data to a fake elasticsearch endpoint which fans out the same documents to multiple different log data stores (victorialogs, clickhouse, loki, ...)

For this use case, I need a challenge that skips all the Elasticsearch setup (because there might not even be an Elasticsearch) and only sends the documents via bulk.

This PR is adding that, it's basically a simpler version of `logging-indexing`