### PR TITLE
Add new challenge to elastic/logs to benchmark the INSIST_🐔 esql command

### DIFF
--- a/elastic/logs/challenges/logging-chicken.json
+++ b/elastic/logs/challenges/logging-chicken.json
@@ -44,21 +44,21 @@
       "tags": ["esql", "settings"]
     },
     {
-      "operation": "ckicken_1",
+      "operation": "chicken_1",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "full-text"]
     },
     {
-      "operation": "ckicken_2",
+      "operation": "chicken_2",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
       "tags": ["esql", "full-text"]
     },
     {
-      "operation": "ckicken_3",
+      "operation": "chicken_3",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},

--- a/elastic/logs/challenges/logging-chicken.json
+++ b/elastic/logs/challenges/logging-chicken.json
@@ -46,29 +46,29 @@
     {
       "operation": "chicken_1",
       "clients": {{ p_search_clients }},
-      "warmup-iterations": {{ warmup_iterations | default(20) }},
-      "iterations": {{ iterations | default(100) }},
+      "warmup-iterations": {{ warmup_iterations | default(3) }},
+      "iterations": {{ iterations | default(5) }},
       "tags": ["esql", "insist"]
     },
     {
       "operation": "chicken_2",
       "clients": {{ p_search_clients }},
-      "warmup-iterations": {{ warmup_iterations | default(20) }},
-      "iterations": {{ iterations | default(100) }},
+      "warmup-iterations": {{ warmup_iterations | default(3) }},
+      "iterations": {{ iterations | default(5) }},
       "tags": ["esql", "insist"]
     },
     {
       "operation": "chicken_3",
       "clients": {{ p_search_clients }},
-      "warmup-iterations": {{ warmup_iterations | default(20) }},
-      "iterations": {{ iterations | default(100) }},
+      "warmup-iterations": {{ warmup_iterations | default(3) }},
+      "iterations": {{ iterations | default(5) }},
       "tags": ["esql", "insist"]
     },
     {
       "operation": "chicken_4",
       "clients": {{ p_search_clients }},
-      "warmup-iterations": {{ warmup_iterations | default(20) }},
-      "iterations": {{ iterations | default(100) }},
+      "warmup-iterations": {{ warmup_iterations | default(3) }},
+      "iterations": {{ iterations | default(5) }},
       "tags": ["esql", "insisit"]
     }
   ]

--- a/elastic/logs/challenges/logging-chicken.json
+++ b/elastic/logs/challenges/logging-chicken.json
@@ -1,0 +1,68 @@
+{% import "rally.helpers" as rally %}
+{
+  "name": "logging-insist-chicken",
+  "description": "INSIST_🐔 everything",
+  "schedule": [
+    {% include "tasks/index-setup.json" %},
+    {
+      "name": "bulk-index",
+      "operation": {
+        "operation-type": "raw-bulk",
+        "param-source": "processed-source",
+        "time-format": "milliseconds",
+        "profile": "fixed_interval",
+        "bulk-size": {{ p_bulk_size }},
+        "detailed-results": true
+      },
+      "clients": {{ p_bulk_indexing_clients }}{% if p_throttle_indexing %},
+      "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
+      "schedule": "timestamp-throttler",
+      "max-delay-secs": 1
+      {% endif %}
+    },
+    {
+        "name": "refresh-after-index",
+        "index": "logs-*",
+        "operation": "refresh"
+    },
+    {
+        "name": "wait-until-index-merges-fininshes",
+        "operation": {
+          "operation-type": "index-stats",
+          "index": "logs-*",
+          "condition": {
+            "path": "_all.total.merges.current",
+            "expected-value": 0
+          },
+          "retry-until-success": true,
+          "include-in-reporting": false
+        },
+        "tags": ["wait"]
+    },
+    {
+      "operation": "disable_query_cache",
+      "tags": ["esql", "settings"]
+    },
+    {
+      "operation": "ckicken_1",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["esql", "full-text"]
+    },
+    {
+      "operation": "ckicken_2",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["esql", "full-text"]
+    },
+    {
+      "operation": "ckicken_3",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["esql", "full-text"]
+    }
+  ]
+}

--- a/elastic/logs/challenges/logging-chicken.json
+++ b/elastic/logs/challenges/logging-chicken.json
@@ -70,7 +70,7 @@
       "warmup-iterations": {{ warmup_iterations | default(3) }},
       "iterations": {{ iterations | default(5) }},
       "tags": ["esql", "insist"]
-    }
+    },
     {
       "operation": "chicken_3_with_where",
       "clients": {{ p_search_clients }},

--- a/elastic/logs/challenges/logging-chicken.json
+++ b/elastic/logs/challenges/logging-chicken.json
@@ -53,6 +53,7 @@
     {
       "operation": "chicken_1",
       "clients": {{ p_search_clients }},
+      {# TODO: restore iterations / warmup_iterations once insist_:chicken: has acceptable performance #}
       "warmup-iterations": {{ warmup_iterations | default(3) }},
       "iterations": {{ iterations | default(5) }},
       "tags": ["esql", "insist"]

--- a/elastic/logs/challenges/logging-chicken.json
+++ b/elastic/logs/challenges/logging-chicken.json
@@ -44,6 +44,13 @@
       "tags": ["esql", "settings"]
     },
     {
+      "operation": "limit_500",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["esql"]
+    },
+    {
       "operation": "chicken_1",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(3) }},
@@ -63,13 +70,20 @@
       "warmup-iterations": {{ warmup_iterations | default(3) }},
       "iterations": {{ iterations | default(5) }},
       "tags": ["esql", "insist"]
+    }
+    {
+      "operation": "chicken_3_with_where",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(3) }},
+      "iterations": {{ iterations | default(5) }},
+      "tags": ["esql", "insist"]
     },
     {
       "operation": "chicken_4",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(3) }},
       "iterations": {{ iterations | default(5) }},
-      "tags": ["esql", "insisit"]
+      "tags": ["esql", "insist"]
     }
   ]
 }

--- a/elastic/logs/challenges/logging-chicken.json
+++ b/elastic/logs/challenges/logging-chicken.json
@@ -48,21 +48,28 @@
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["esql", "full-text"]
+      "tags": ["esql", "insist"]
     },
     {
       "operation": "chicken_2",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["esql", "full-text"]
+      "tags": ["esql", "insist"]
     },
     {
       "operation": "chicken_3",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(20) }},
       "iterations": {{ iterations | default(100) }},
-      "tags": ["esql", "full-text"]
+      "tags": ["esql", "insist"]
+    },
+    {
+      "operation": "chicken_4",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(20) }},
+      "iterations": {{ iterations | default(100) }},
+      "tags": ["esql", "insisit"]
     }
   ]
 }

--- a/elastic/logs/operations/esql-chicken.json
+++ b/elastic/logs/operations/esql-chicken.json
@@ -1,4 +1,9 @@
     {
+      "name": "limit_500",
+      "operation-type": "esql",
+      "query": "FROM logs-* | LIMIT 500"
+    },
+    {
       "name": "chicken_1",
       "operation-type": "esql",
       "query": "FROM logs-* | INSIST_🐔 agent.id | EVAL col0 = COALESCE(agent.id, \"\") | WHERE MATCH(message, \"204.188.85.203\") and col0 == \"703ef3bd-dc06-4c6c-a621-13c89245e6b0\""
@@ -12,6 +17,11 @@
       "name": "chicken_3",
       "operation-type": "esql",
       "query": "FROM logs-* | INSIST_🐔 agent.id | STATS c=count() BY agent.id, data_stream.dataset | SORT c DESC"
+    },
+    {
+      "name": "chicken_3_with_where",
+      "operation-type": "esql",
+      "query": "FROM logs-* | INSIST_🐔 agent.id | EVAL end_time = DATE_PARSE(\"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'\",\"{{ bulk_end_date }}\") | WHERE @timestamp >= end_time - 1 hour | STATS c=count() BY agent.id, data_stream.dataset | SORT c DESC"
     },
     {
       "name": "chicken_4",

--- a/elastic/logs/operations/esql-chicken.json
+++ b/elastic/logs/operations/esql-chicken.json
@@ -12,4 +12,9 @@
       "name": "chicken_3",
       "operation-type": "esql",
       "query": "FROM logs-* | INSIST_🐔 agent.id | STATS c=count() BY agent.id, data_stream.dataset | SORT c DESC"
+    },
+    {
+      "name": "chicken_4",
+      "operation-type": "esql",
+      "query": "FROM logs-* | INSIST_🐔 agent.hostname | EVAL col0 = COALESCE(agent.hostname, \"elasticsearch-ci-immutable-centos-7-1599241536066250344\") | WHERE col0 ==  \"elasticsearch-ci-immutable-centos-7-1599241536066250344\""
     }

--- a/elastic/logs/operations/esql-chicken.json
+++ b/elastic/logs/operations/esql-chicken.json
@@ -1,15 +1,15 @@
     {
       "name": "ckicken_1",
       "operation-type": "esql",
-      "query": "FROM logs | INSIST_🐔 resource.attributes.agent.id | EVAL col0 = COALESCE(resource.attributes.agent.id, \"\") | WHERE MATCH(message, \"204.188.85.203\") and col0 == \"703ef3bd-dc06-4c6c-a621-13c89245e6b0\""
+      "query": "FROM logs-* | INSIST_🐔 agent.id | EVAL col0 = COALESCE(agent.id, \"\") | WHERE MATCH(message, \"204.188.85.203\") and col0 == \"703ef3bd-dc06-4c6c-a621-13c89245e6b0\""
     },
     {
       "name": "chicken_2",
       "operation-type": "esql",
-      "query": "FROM logs | INSIST_🐔 attributes.event.dataset,attributes.kubernetes.container.image |  EVAL col0 = COALESCE(attributes.kubernetes.container.image, \"\") | WHERE col0 != \"\" | STATS col1 = COUNT() BY col0,stream.name"
+      "query": "FROM logs-* | INSIST_🐔 event.dataset,kubernetes.container.image |  EVAL col0 = COALESCE(kubernetes.container.image, \"\") | WHERE col0 != \"\" | STATS col1 = COUNT(message) BY col0,data_stream.dataset"
     },
     {
       "name": "chicken_3",
       "operation-type": "esql",
-      "query": "FROM logs-* METADATA _index | INSIST_🐔 agent.id | STATS c=count(*) BY agent.id | SORT c DESC"
+      "query": "FROM logs-* | INSIST_🐔 agent.id | STATS c=count(message) BY agent.id | SORT c DESC"
     }

--- a/elastic/logs/operations/esql-chicken.json
+++ b/elastic/logs/operations/esql-chicken.json
@@ -1,0 +1,15 @@
+    {
+      "name": "ckicken_1",
+      "operation-type": "esql",
+      "query": "FROM logs | INSIST_🐔 resource.attributes.agent.id | EVAL col0 = COALESCE(resource.attributes.agent.id, \"\") | WHERE MATCH(message, \"204.188.85.203\") and col0 == \"703ef3bd-dc06-4c6c-a621-13c89245e6b0\""
+    },
+    {
+      "name": "chicken_2",
+      "operation-type": "esql",
+      "query": "FROM logs | INSIST_🐔 attributes.event.dataset,attributes.kubernetes.container.image |  EVAL col0 = COALESCE(attributes.kubernetes.container.image, \"\") | WHERE col0 != \"\" | STATS col1 = COUNT() BY col0,stream.name"
+    },
+    {
+      "name": "chicken_3",
+      "operation-type": "esql",
+      "query": "FROM logs-* METADATA _index | INSIST_🐔 agent.id | STATS c=count(*) BY agent.id | SORT c DESC"
+    }

--- a/elastic/logs/operations/esql-chicken.json
+++ b/elastic/logs/operations/esql-chicken.json
@@ -3,6 +3,7 @@
       "operation-type": "esql",
       "query": "FROM logs-* | LIMIT 500"
     },
+    {# TODO: All COALESCE usages can be removed once https://github.com/elastic/elasticsearch/issues/130220 is fixed #}
     {
       "name": "chicken_1",
       "operation-type": "esql",

--- a/elastic/logs/operations/esql-chicken.json
+++ b/elastic/logs/operations/esql-chicken.json
@@ -6,10 +6,10 @@
     {
       "name": "chicken_2",
       "operation-type": "esql",
-      "query": "FROM logs-* | INSIST_🐔 event.dataset,kubernetes.container.image |  EVAL col0 = COALESCE(kubernetes.container.image, \"\") | WHERE col0 != \"\" | STATS col1 = COUNT(message) BY col0,data_stream.dataset"
+      "query": "FROM logs-* | INSIST_🐔 event.dataset,kubernetes.container.image |  EVAL col0 = COALESCE(kubernetes.container.image, \"\") | WHERE col0 != \"\" | STATS col1 = COUNT() BY col0,data_stream.dataset"
     },
     {
       "name": "chicken_3",
       "operation-type": "esql",
-      "query": "FROM logs-* | INSIST_🐔 agent.id | STATS c=count(message) BY agent.id | SORT c DESC"
+      "query": "FROM logs-* | INSIST_🐔 agent.id | STATS c=count() BY agent.id, data_stream.dataset | SORT c DESC"
     }

--- a/elastic/logs/operations/esql-chicken.json
+++ b/elastic/logs/operations/esql-chicken.json
@@ -1,5 +1,5 @@
     {
-      "name": "ckicken_1",
+      "name": "chicken_1",
       "operation-type": "esql",
       "query": "FROM logs-* | INSIST_🐔 agent.id | EVAL col0 = COALESCE(agent.id, \"\") | WHERE MATCH(message, \"204.188.85.203\") and col0 == \"703ef3bd-dc06-4c6c-a621-13c89245e6b0\""
     },

--- a/elastic/logs/operations/esql-chicken.json
+++ b/elastic/logs/operations/esql-chicken.json
@@ -11,7 +11,7 @@
     {
       "name": "chicken_2",
       "operation-type": "esql",
-      "query": "FROM logs-* | INSIST_🐔 event.dataset,kubernetes.container.image |  EVAL col0 = COALESCE(kubernetes.container.image, \"\") | WHERE col0 != \"\" | STATS col1 = COUNT() BY col0,data_stream.dataset"
+      "query": "FROM logs-* | INSIST_🐔 kubernetes.container.image |  EVAL col0 = COALESCE(kubernetes.container.image, \"\") | WHERE col0 != \"\" | STATS col1 = COUNT() BY col0,data_stream.dataset"
     },
     {
       "name": "chicken_3",
@@ -26,5 +26,5 @@
     {
       "name": "chicken_4",
       "operation-type": "esql",
-      "query": "FROM logs-* | INSIST_🐔 agent.hostname | EVAL col0 = COALESCE(agent.hostname, \"elasticsearch-ci-immutable-centos-7-1599241536066250344\") | WHERE col0 ==  \"elasticsearch-ci-immutable-centos-7-1599241536066250344\""
+      "query": "FROM logs-* | INSIST_🐔 agent.hostname | EVAL col0 = COALESCE(agent.hostname, \"\") | WHERE col0 ==  \"elasticsearch-ci-immutable-centos-7-1599241536066250344\""
     }

--- a/elastic/logs/tasks/index-setup.json
+++ b/elastic/logs/tasks/index-setup.json
@@ -60,6 +60,7 @@
     "operation-type": "create-data-stream"
   }
 },
+{% if p_mapping == "mapped" %}
 {
   "name": "validate-package-template-installation",
   "operation": {
@@ -68,6 +69,7 @@
     "asset-types": ["index-templates"]
   }
 },
+{% endif %}
 {
   "name": "update-custom-package-templates",
   "operation": {

--- a/elastic/logs/templates/composable/logs-dynamic-false.json
+++ b/elastic/logs/templates/composable/logs-dynamic-false.json
@@ -1,0 +1,34 @@
+{
+  "name": "logs-dynamic-false",
+  "index_template": {
+    "index_patterns": [
+      "logs-*-*"
+    ],
+    "template": {
+      "settings": {},
+      "mappings": {
+        "dynamic": false,
+        "properties": {
+          "@timestamp": {
+            "type": "date"
+          },
+          "message": {
+            "type": "match_only_text"
+          }
+        }
+      }
+    },
+    "composed_of": [
+      "logs@settings",
+      "track-custom-mappings",
+      "track-custom-shared-settings",
+      "track-data-stream-lifecycle",
+      "track-shared-logsdb-mode"
+    ],
+    "priority": 200,
+    "data_stream": {
+      "hidden": false,
+      "allow_custom_routing": false
+    }
+  }
+}

--- a/elastic/logs/templates/composable/logs-dynamic-false.json
+++ b/elastic/logs/templates/composable/logs-dynamic-false.json
@@ -20,7 +20,7 @@
     },
     "composed_of": [
       "logs@settings",
-      "track-custom-mappings",
+      "logs@mappings",
       "track-custom-shared-settings",
       "track-data-stream-lifecycle",
       "track-shared-logsdb-mode"

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -73,6 +73,8 @@
 
 {% set es_version = "7.13.2" %}
 
+{% set p_mapping = ( mapping | default('mapped') ) %}
+
 {% set p_integration_ratios = (integration_ratios | default({
     "kafka": {
       "corpora": {
@@ -218,6 +220,7 @@
     }
   ],
   "component-templates": [
+    {% if p_mapping == "mapped" %}
     {% if build_flavor != "serverless" %}
       {
           "name": ".fleet_agent_id_verification-1",
@@ -339,6 +342,7 @@
         "name": "logs-system.syslog@custom",
         "template": "./templates/component/logs-system.syslog@custom.json"
     },
+    {% endif %}
     {
         "name": "track-custom-mappings",
         "template": "./templates/component/track-custom-mappings.json"
@@ -361,6 +365,7 @@
     }
   ],
   "composable-templates": [
+    {% if p_mapping == "mapped" %}
     {
         "name": "logs-kafka.log",
         "index-pattern": "logs-kafka.log-*",
@@ -469,6 +474,16 @@
         "delete-matching-indices": false,
         "template": "./templates/composable/auditbeat-quantitative.json"
     }
+    {% endif %}
+    {% if p_mapping == "unmapped" %}
+    {
+        "name": "logs-unmapped",
+        "index-pattern": "logs-*-*",
+        "delete-matching-indices": false,
+        "template": "./templates/composable/logs-dynamic-false.json",
+        "template-path": "index_template"
+    }
+    {% endif %}
   ],
   "corpora": [
     {


### PR DESCRIPTION
Also add `mapping` track parameter which controls whether all fields are mapped or whether almost all fields are unmapped. This allows for benchmarking elastic/logs in an unmapped context with experimental INSIST_🐔 esql command.