### PR TITLE
Add parameter to use patterned_text for message field

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -228,7 +228,8 @@ The following parameters are available:
 * `recovery_poll_timeout` (default: `1m`) - The maximum time to wait for additional translog operations before returning an empty result.
 * `recovery_small_max_batch_size` (default: `4MB`) - The maximum estimated size for the batch of translog operations to return.
 * `recovery_large_max_batch_size` (default: `32MB`) - The maximum estimated size for the batch of translog operations to return.
-* `recovery_max_operations_count` (default: `16777216`) - The maximum number of translog operations to return in a single batch.
+* recovery_max_operations_count (default: `16777216`) - The maximum number of translog operations to return in a single batch.
+* `pattern_text_message_field` (default: `false`) - If true use `patterned_text` for all message fields, else `match_only_text`. 
 
 ### Data Download Parameters
 

--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -228,7 +228,7 @@ The following parameters are available:
 * `recovery_poll_timeout` (default: `1m`) - The maximum time to wait for additional translog operations before returning an empty result.
 * `recovery_small_max_batch_size` (default: `4MB`) - The maximum estimated size for the batch of translog operations to return.
 * `recovery_large_max_batch_size` (default: `32MB`) - The maximum estimated size for the batch of translog operations to return.
-* recovery_max_operations_count (default: `16777216`) - The maximum number of translog operations to return in a single batch.
+* `recovery_max_operations_count (default: `16777216`) - The maximum number of translog operations to return in a single batch.
 * `patterned_text_message_field` (default: `false`) - If true use `patterned_text` for all message fields, else `match_only_text`. 
 
 ### Data Download Parameters

--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -229,7 +229,7 @@ The following parameters are available:
 * `recovery_small_max_batch_size` (default: `4MB`) - The maximum estimated size for the batch of translog operations to return.
 * `recovery_large_max_batch_size` (default: `32MB`) - The maximum estimated size for the batch of translog operations to return.
 * recovery_max_operations_count (default: `16777216`) - The maximum number of translog operations to return in a single batch.
-* `pattern_text_message_field` (default: `false`) - If true use `patterned_text` for all message fields, else `match_only_text`. 
+* `patterned_text_message_field` (default: `false`) - If true use `patterned_text` for all message fields, else `match_only_text`. 
 
 ### Data Download Parameters
 

--- a/elastic/logs/templates/component/auditbeat-mappings.json
+++ b/elastic/logs/templates/component/auditbeat-mappings.json
@@ -2818,9 +2818,9 @@
             "message": {
               {% if p_patterned_text_message_field %}
               "type": "patterned_text"
-              {% else % }
+              {% else %}
               "type": "match_only_text"
-              {% endif % }
+              {% endif %}
             },
             "type": {
               "ignore_above": 1024,
@@ -5796,9 +5796,9 @@
         "message": {
           {% if p_patterned_text_message_field %}
           "type": "patterned_text"
-          {% else % }
+          {% else %}
           "type": "match_only_text"
-          {% endif % }
+          {% endif %}
         },
         "url": {
           "properties": {

--- a/elastic/logs/templates/component/auditbeat-mappings.json
+++ b/elastic/logs/templates/component/auditbeat-mappings.json
@@ -2816,7 +2816,7 @@
               "type": "wildcard"
             },
             "message": {
-              {% if p_patterned_text_message_field %}
+              {% if patterned_text_message_field | default(false) is true %}
               "type": "patterned_text"
               {% else %}
               "type": "match_only_text"
@@ -5794,7 +5794,7 @@
           }
         },
         "message": {
-          {% if p_patterned_text_message_field %}
+          {% if patterned_text_message_field | default(false) is true %}
           "type": "patterned_text"
           {% else %}
           "type": "match_only_text"

--- a/elastic/logs/templates/component/auditbeat-mappings.json
+++ b/elastic/logs/templates/component/auditbeat-mappings.json
@@ -2816,7 +2816,11 @@
               "type": "wildcard"
             },
             "message": {
+              {% if p_patterned_text_message_field %}
+              "type": "patterned_text"
+              {% else % }
               "type": "match_only_text"
+              {% endif % }
             },
             "type": {
               "ignore_above": 1024,
@@ -5790,7 +5794,11 @@
           }
         },
         "message": {
+          {% if p_patterned_text_message_field %}
+          "type": "patterned_text"
+          {% else % }
           "type": "match_only_text"
+          {% endif % }
         },
         "url": {
           "properties": {

--- a/elastic/logs/templates/component/logs-apache.access@package.json
+++ b/elastic/logs/templates/component/logs-apache.access@package.json
@@ -243,12 +243,20 @@
           "error": {
             "properties": {
               "message": {
+                {% if p_patterned_text_message_field %}
+                "type": "patterned_text"
+                {% else % }
                 "type": "match_only_text"
+                {% endif % }
               }
             }
           },
           "message": {
+            {% if p_patterned_text_message_field %}
+            "type": "patterned_text"
+            {% else % }
             "type": "match_only_text"
+            {% endif % }
           },
           "url": {
             "properties": {

--- a/elastic/logs/templates/component/logs-apache.access@package.json
+++ b/elastic/logs/templates/component/logs-apache.access@package.json
@@ -243,7 +243,7 @@
           "error": {
             "properties": {
               "message": {
-                {% if p_patterned_text_message_field %}
+                {% if patterned_text_message_field | default(false) is true %}
                 "type": "patterned_text"
                 {% else %}
                 "type": "match_only_text"
@@ -252,7 +252,7 @@
             }
           },
           "message": {
-            {% if p_patterned_text_message_field %}
+            {% if patterned_text_message_field | default(false) is true %}
             "type": "patterned_text"
             {% else %}
             "type": "match_only_text"

--- a/elastic/logs/templates/component/logs-apache.access@package.json
+++ b/elastic/logs/templates/component/logs-apache.access@package.json
@@ -245,18 +245,18 @@
               "message": {
                 {% if p_patterned_text_message_field %}
                 "type": "patterned_text"
-                {% else % }
+                {% else %}
                 "type": "match_only_text"
-                {% endif % }
+                {% endif %}
               }
             }
           },
           "message": {
             {% if p_patterned_text_message_field %}
             "type": "patterned_text"
-            {% else % }
+            {% else %}
             "type": "match_only_text"
-            {% endif % }
+            {% endif %}
           },
           "url": {
             "properties": {

--- a/elastic/logs/templates/component/logs-apache.error@package.json
+++ b/elastic/logs/templates/component/logs-apache.error@package.json
@@ -224,7 +224,7 @@
           "error": {
             "properties": {
               "message": {
-                {% if p_patterned_text_message_field %}
+                {% if patterned_text_message_field | default(false) is true %}
                 "type": "patterned_text"
                 {% else %}
                 "type": "match_only_text"
@@ -233,7 +233,7 @@
             }
           },
           "message": {
-            {% if p_patterned_text_message_field %}
+            {% if patterned_text_message_field | default(false) is true %}
             "type": "patterned_text"
             {% else %}
             "type": "match_only_text"

--- a/elastic/logs/templates/component/logs-apache.error@package.json
+++ b/elastic/logs/templates/component/logs-apache.error@package.json
@@ -224,12 +224,20 @@
           "error": {
             "properties": {
               "message": {
+                {% if p_patterned_text_message_field %}
+                "type": "patterned_text"
+                {% else % }
                 "type": "match_only_text"
+                {% endif % }
               }
             }
           },
           "message": {
+            {% if p_patterned_text_message_field %}
+            "type": "patterned_text"
+            {% else % }
             "type": "match_only_text"
+            {% endif % }
           },
           "url": {
             "properties": {

--- a/elastic/logs/templates/component/logs-apache.error@package.json
+++ b/elastic/logs/templates/component/logs-apache.error@package.json
@@ -226,18 +226,18 @@
               "message": {
                 {% if p_patterned_text_message_field %}
                 "type": "patterned_text"
-                {% else % }
+                {% else %}
                 "type": "match_only_text"
-                {% endif % }
+                {% endif %}
               }
             }
           },
           "message": {
             {% if p_patterned_text_message_field %}
             "type": "patterned_text"
-            {% else % }
+            {% else %}
             "type": "match_only_text"
-            {% endif % }
+            {% endif %}
           },
           "url": {
             "properties": {

--- a/elastic/logs/templates/component/logs-kafka.log@package.json
+++ b/elastic/logs/templates/component/logs-kafka.log@package.json
@@ -340,18 +340,18 @@
           "message": {
             {% if p_patterned_text_message_field %}
             "type": "patterned_text"
-            {% else % }
+            {% else %}
             "type": "match_only_text"
-            {% endif % }
+            {% endif %}
           },
           "error": {
             "properties": {
               "message": {
                 {% if p_patterned_text_message_field %}
                 "type": "patterned_text"
-                {% else % }
+                {% else %}
                 "type": "match_only_text"
-                {% endif % }
+                {% endif %}
               }
             }
           },

--- a/elastic/logs/templates/component/logs-kafka.log@package.json
+++ b/elastic/logs/templates/component/logs-kafka.log@package.json
@@ -338,7 +338,7 @@
             }
           },
           "message": {
-            {% if p_patterned_text_message_field %}
+            {% if patterned_text_message_field | default(false) is true %}
             "type": "patterned_text"
             {% else %}
             "type": "match_only_text"
@@ -347,7 +347,7 @@
           "error": {
             "properties": {
               "message": {
-                {% if p_patterned_text_message_field %}
+                {% if patterned_text_message_field | default(false) is true %}
                 "type": "patterned_text"
                 {% else %}
                 "type": "match_only_text"

--- a/elastic/logs/templates/component/logs-kafka.log@package.json
+++ b/elastic/logs/templates/component/logs-kafka.log@package.json
@@ -338,12 +338,20 @@
             }
           },
           "message": {
+            {% if p_patterned_text_message_field %}
+            "type": "patterned_text"
+            {% else % }
             "type": "match_only_text"
+            {% endif % }
           },
           "error": {
             "properties": {
               "message": {
+                {% if p_patterned_text_message_field %}
+                "type": "patterned_text"
+                {% else % }
                 "type": "match_only_text"
+                {% endif % }
               }
             }
           },

--- a/elastic/logs/templates/component/logs-mysql.error@package.json
+++ b/elastic/logs/templates/component/logs-mysql.error@package.json
@@ -127,12 +127,20 @@
             }
           },
           "message": {
+            {% if p_patterned_text_message_field %}
+            "type": "patterned_text"
+            {% else % }
             "type": "match_only_text"
+            {% endif % }
           },
           "error": {
             "properties": {
               "message": {
+                {% if p_patterned_text_message_field %}
+                "type": "patterned_text"
+                {% else % }
                 "type": "match_only_text"
+                {% endif % }
               }
             }
           },

--- a/elastic/logs/templates/component/logs-mysql.error@package.json
+++ b/elastic/logs/templates/component/logs-mysql.error@package.json
@@ -127,7 +127,7 @@
             }
           },
           "message": {
-            {% if p_patterned_text_message_field %}
+            {% if patterned_text_message_field | default(false) is true %}
             "type": "patterned_text"
             {% else %}
             "type": "match_only_text"
@@ -136,7 +136,7 @@
           "error": {
             "properties": {
               "message": {
-                {% if p_patterned_text_message_field %}
+                {% if patterned_text_message_field | default(false) is true %}
                 "type": "patterned_text"
                 {% else %}
                 "type": "match_only_text"

--- a/elastic/logs/templates/component/logs-mysql.error@package.json
+++ b/elastic/logs/templates/component/logs-mysql.error@package.json
@@ -129,18 +129,18 @@
           "message": {
             {% if p_patterned_text_message_field %}
             "type": "patterned_text"
-            {% else % }
+            {% else %}
             "type": "match_only_text"
-            {% endif % }
+            {% endif %}
           },
           "error": {
             "properties": {
               "message": {
                 {% if p_patterned_text_message_field %}
                 "type": "patterned_text"
-                {% else % }
+                {% else %}
                 "type": "match_only_text"
-                {% endif % }
+                {% endif %}
               }
             }
           },

--- a/elastic/logs/templates/component/logs-mysql.slowlog@package.json
+++ b/elastic/logs/templates/component/logs-mysql.slowlog@package.json
@@ -138,12 +138,20 @@
           "error": {
             "properties": {
               "message": {
+                {% if p_patterned_text_message_field %}
+                "type": "patterned_text"
+                {% else % }
                 "type": "match_only_text"
+                {% endif % }
               }
             }
           },
           "message": {
+            {% if p_patterned_text_message_field %}
+            "type": "patterned_text"
+            {% else % }
             "type": "match_only_text"
+            {% endif % }
           },
           "tags": {
             "ignore_above": 1024,

--- a/elastic/logs/templates/component/logs-mysql.slowlog@package.json
+++ b/elastic/logs/templates/component/logs-mysql.slowlog@package.json
@@ -138,7 +138,7 @@
           "error": {
             "properties": {
               "message": {
-                {% if p_patterned_text_message_field %}
+                {% if patterned_text_message_field | default(false) is true %}
                 "type": "patterned_text"
                 {% else %}
                 "type": "match_only_text"
@@ -147,7 +147,7 @@
             }
           },
           "message": {
-            {% if p_patterned_text_message_field %}
+            {% if patterned_text_message_field | default(false) is true %}
             "type": "patterned_text"
             {% else %}
             "type": "match_only_text"

--- a/elastic/logs/templates/component/logs-mysql.slowlog@package.json
+++ b/elastic/logs/templates/component/logs-mysql.slowlog@package.json
@@ -140,18 +140,18 @@
               "message": {
                 {% if p_patterned_text_message_field %}
                 "type": "patterned_text"
-                {% else % }
+                {% else %}
                 "type": "match_only_text"
-                {% endif % }
+                {% endif %}
               }
             }
           },
           "message": {
             {% if p_patterned_text_message_field %}
             "type": "patterned_text"
-            {% else % }
+            {% else %}
             "type": "match_only_text"
-            {% endif % }
+            {% endif %}
           },
           "tags": {
             "ignore_above": 1024,

--- a/elastic/logs/templates/component/logs-nginx.error@package.json
+++ b/elastic/logs/templates/component/logs-nginx.error@package.json
@@ -142,9 +142,9 @@
           "message": {
             {% if p_patterned_text_message_field %}
             "type": "patterned_text"
-            {% else % }
+            {% else %}
             "type": "match_only_text"
-            {% endif % }
+            {% endif %}
           },
           "tags": {
             "ignore_above": 1024,

--- a/elastic/logs/templates/component/logs-nginx.error@package.json
+++ b/elastic/logs/templates/component/logs-nginx.error@package.json
@@ -140,7 +140,11 @@
             }
           },
           "message": {
+            {% if p_patterned_text_message_field %}
+            "type": "patterned_text"
+            {% else % }
             "type": "match_only_text"
+            {% endif % }
           },
           "tags": {
             "ignore_above": 1024,

--- a/elastic/logs/templates/component/logs-nginx.error@package.json
+++ b/elastic/logs/templates/component/logs-nginx.error@package.json
@@ -140,7 +140,7 @@
             }
           },
           "message": {
-            {% if p_patterned_text_message_field %}
+            {% if patterned_text_message_field | default(false) is true %}
             "type": "patterned_text"
             {% else %}
             "type": "match_only_text"

--- a/elastic/logs/templates/component/logs-postgresql.log@package.json
+++ b/elastic/logs/templates/component/logs-postgresql.log@package.json
@@ -138,9 +138,9 @@
           "message": {
             {% if p_patterned_text_message_field %}
             "type": "patterned_text"
-            {% else % }
+            {% else %}
             "type": "match_only_text"
-            {% endif % }
+            {% endif %}
           },
           "error": {
             "properties": {
@@ -155,9 +155,9 @@
               "message": {
                 {% if p_patterned_text_message_field %}
                 "type": "patterned_text"
-                {% else % }
+                {% else %}
                 "type": "match_only_text"
-                {% endif % }
+                {% endif %}
               }
             }
           },

--- a/elastic/logs/templates/component/logs-postgresql.log@package.json
+++ b/elastic/logs/templates/component/logs-postgresql.log@package.json
@@ -136,7 +136,7 @@
             }
           },
           "message": {
-            {% if p_patterned_text_message_field %}
+            {% if patterned_text_message_field | default(false) is true %}
             "type": "patterned_text"
             {% else %}
             "type": "match_only_text"
@@ -153,7 +153,7 @@
                 "type": "keyword"
               },
               "message": {
-                {% if p_patterned_text_message_field %}
+                {% if patterned_text_message_field | default(false) is true %}
                 "type": "patterned_text"
                 {% else %}
                 "type": "match_only_text"

--- a/elastic/logs/templates/component/logs-postgresql.log@package.json
+++ b/elastic/logs/templates/component/logs-postgresql.log@package.json
@@ -136,7 +136,11 @@
             }
           },
           "message": {
+            {% if p_patterned_text_message_field %}
+            "type": "patterned_text"
+            {% else % }
             "type": "match_only_text"
+            {% endif % }
           },
           "error": {
             "properties": {
@@ -149,7 +153,11 @@
                 "type": "keyword"
               },
               "message": {
+                {% if p_patterned_text_message_field %}
+                "type": "patterned_text"
+                {% else % }
                 "type": "match_only_text"
+                {% endif % }
               }
             }
           },

--- a/elastic/logs/templates/component/logs-redis.log@package.json
+++ b/elastic/logs/templates/component/logs-redis.log@package.json
@@ -113,12 +113,20 @@
           "error": {
             "properties": {
               "message": {
+                {% if p_patterned_text_message_field %}
+                "type": "patterned_text"
+                {% else % }
                 "type": "match_only_text"
+                {% endif % }
               }
             }
           },
           "message": {
+            {% if p_patterned_text_message_field %}
+            "type": "patterned_text"
+            {% else % }
             "type": "match_only_text"
+            {% endif % }
           },
           "redis": {
             "properties": {

--- a/elastic/logs/templates/component/logs-redis.log@package.json
+++ b/elastic/logs/templates/component/logs-redis.log@package.json
@@ -115,18 +115,18 @@
               "message": {
                 {% if p_patterned_text_message_field %}
                 "type": "patterned_text"
-                {% else % }
+                {% else %}
                 "type": "match_only_text"
-                {% endif % }
+                {% endif %}
               }
             }
           },
           "message": {
             {% if p_patterned_text_message_field %}
             "type": "patterned_text"
-            {% else % }
+            {% else %}
             "type": "match_only_text"
-            {% endif % }
+            {% endif %}
           },
           "redis": {
             "properties": {

--- a/elastic/logs/templates/component/logs-redis.log@package.json
+++ b/elastic/logs/templates/component/logs-redis.log@package.json
@@ -113,7 +113,7 @@
           "error": {
             "properties": {
               "message": {
-                {% if p_patterned_text_message_field %}
+                {% if patterned_text_message_field | default(false) is true %}
                 "type": "patterned_text"
                 {% else %}
                 "type": "match_only_text"
@@ -122,7 +122,7 @@
             }
           },
           "message": {
-            {% if p_patterned_text_message_field %}
+            {% if patterned_text_message_field | default(false) is true %}
             "type": "patterned_text"
             {% else %}
             "type": "match_only_text"

--- a/elastic/logs/templates/component/logs-system.auth@package.json
+++ b/elastic/logs/templates/component/logs-system.auth@package.json
@@ -287,7 +287,7 @@
           "error": {
             "properties": {
               "message": {
-                {% if p_patterned_text_message_field %}
+                {% if patterned_text_message_field | default(false) is true %}
                 "type": "patterned_text"
                 {% else %}
                 "type": "match_only_text"
@@ -296,7 +296,7 @@
             }
           },
           "message": {
-            {% if p_patterned_text_message_field %}
+            {% if patterned_text_message_field | default(false) is true %}
             "type": "patterned_text"
             {% else %}
             "type": "match_only_text"

--- a/elastic/logs/templates/component/logs-system.auth@package.json
+++ b/elastic/logs/templates/component/logs-system.auth@package.json
@@ -289,18 +289,18 @@
               "message": {
                 {% if p_patterned_text_message_field %}
                 "type": "patterned_text"
-                {% else % }
+                {% else %}
                 "type": "match_only_text"
-                {% endif % }
+                {% endif %}
               }
             }
           },
           "message": {
             {% if p_patterned_text_message_field %}
             "type": "patterned_text"
-            {% else % }
+            {% else %}
             "type": "match_only_text"
-            {% endif % }
+            {% endif %}
           },
           "version": {
             "ignore_above": 1024,

--- a/elastic/logs/templates/component/logs-system.auth@package.json
+++ b/elastic/logs/templates/component/logs-system.auth@package.json
@@ -287,12 +287,20 @@
           "error": {
             "properties": {
               "message": {
+                {% if p_patterned_text_message_field %}
+                "type": "patterned_text"
+                {% else % }
                 "type": "match_only_text"
+                {% endif % }
               }
             }
           },
           "message": {
+            {% if p_patterned_text_message_field %}
+            "type": "patterned_text"
+            {% else % }
             "type": "match_only_text"
+            {% endif % }
           },
           "version": {
             "ignore_above": 1024,

--- a/elastic/logs/templates/component/logs-system.syslog@package.json
+++ b/elastic/logs/templates/component/logs-system.syslog@package.json
@@ -363,7 +363,7 @@
             }
           },
           "message": {
-            {% if p_patterned_text_message_field %}
+            {% if patterned_text_message_field | default(false) is true %}
             "type": "patterned_text"
             {% else %}
             "type": "match_only_text"

--- a/elastic/logs/templates/component/logs-system.syslog@package.json
+++ b/elastic/logs/templates/component/logs-system.syslog@package.json
@@ -363,7 +363,11 @@
             }
           },
           "message": {
+            {% if p_patterned_text_message_field %}
+            "type": "patterned_text"
+            {% else % }
             "type": "match_only_text"
+            {% endif % }
           },
           "tags": {
             "ignore_above": 1024,

--- a/elastic/logs/templates/component/logs-system.syslog@package.json
+++ b/elastic/logs/templates/component/logs-system.syslog@package.json
@@ -365,9 +365,9 @@
           "message": {
             {% if p_patterned_text_message_field %}
             "type": "patterned_text"
-            {% else % }
+            {% else %}
             "type": "match_only_text"
-            {% endif % }
+            {% endif %}
           },
           "tags": {
             "ignore_above": 1024,

--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -1817,7 +1817,7 @@
           }
         },
         "message": {
-          {% if p_patterned_text_message_field %}
+          {% if patterned_text_message_field | default(false) is true %}
           "type": "patterned_text"
           {% else %}
           "type": "match_only_text"

--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -1817,7 +1817,11 @@
           }
         },
         "message": {
+          {% if p_patterned_text_message_field %}
+          "type": "patterned_text"
+          {% else % }
           "type": "match_only_text"
+          {% endif % }
         },
         "user": {
           "properties": {

--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -1819,9 +1819,9 @@
         "message": {
           {% if p_patterned_text_message_field %}
           "type": "patterned_text"
-          {% else % }
+          {% else %}
           "type": "match_only_text"
-          {% endif % }
+          {% endif %}
         },
         "user": {
           "properties": {

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -61,7 +61,6 @@
 {% set p_skip_fleet_globals = (skip_fleet_globals | default(false) ) %}
 {% set p_reindex_max_concurrent_indices = (reindex_max_concurrent_indices | default(1) ) %}
 {% set p_reindex_max_requests_per_second = (reindex_max_requests_per_second | default(1000) ) %}
-{% set p_patterned_text_message_field = (patterned_text_message_field | default(false)) %}
 
 {% set p_recovery_target = (recovery_target | default('logs-k8-application.log-default') ) %}
 {% set p_recovery_from_seq_no = (recovery_seq_no | default(0) ) %}

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -61,6 +61,7 @@
 {% set p_skip_fleet_globals = (skip_fleet_globals | default(false) ) %}
 {% set p_reindex_max_concurrent_indices = (reindex_max_concurrent_indices | default(1) ) %}
 {% set p_reindex_max_requests_per_second = (reindex_max_requests_per_second | default(1000) ) %}
+{% set p_patterned_text_message_field = (patterned_text_message_field | default(false)) %}
 
 {% set p_recovery_target = (recovery_target | default('logs-k8-application.log-default') ) %}
 {% set p_recovery_from_seq_no = (recovery_seq_no | default(0) ) %}


### PR DESCRIPTION
Add parameter `patterned_text_message_field` to logs track. If set to true, all `message` and `error.message` fields in the elastic logs track will be of type `patterned_text`. If set to false, type will be `match_only_text`. Defaults to false.