### PR TITLE
Adding is_filtered_search meta tag to so_vector track 

### DIFF
--- a/so_vector/track.py
+++ b/so_vector/track.py
@@ -230,6 +230,7 @@ class KnnRecallRunner:
             "k": k,
             "num_candidates": num_candidates,
             "oversample": params["oversample"],
+            "is_filtered_search": filter is not None
         }
         logger.info(f"Recall results: {to_return} for filter: {filter}")
         return to_return

--- a/so_vector/track.py
+++ b/so_vector/track.py
@@ -230,7 +230,7 @@ class KnnRecallRunner:
             "k": k,
             "num_candidates": num_candidates,
             "oversample": params["oversample"],
-            "is_filtered_search": filter is not None
+            "is_filtered_search": filter is not None,
         }
         logger.info(f"Recall results: {to_return} for filter: {filter}")
         return to_return


### PR DESCRIPTION
Adding a new meta tag to distinguish between searches that also make use of a filter vs a match-all query. 

_Note_: We could add something similar to `dense_vector` however none of the challenges specify any filter yet. 