### PR TITLE
Setting default vector_index_type to bbq_hnsw for so_vector

### DIFF
--- a/so_vector/README.md
+++ b/so_vector/README.md
@@ -69,7 +69,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `force_merge_timeout` (default: 7200) : How long force merge should be allowed to run before aborting.
 * `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
 * `include_force_merge` (default: true for non-serverless clusters, false for serverless clusters): Whether to include force merge operation.
-* `vector_index_type` (default: "int8_hnsw"): The index kind for storing the vectors.
+* `vector_index_type` (default: "bbq_hnsw"): The index kind for storing the vectors.
 
 ### License
 We use the same license for the data as the original data: [CC-SA-4.0](http://creativecommons.org/licenses/by-sa/4.0/).

--- a/so_vector/index.json
+++ b/so_vector/index.json
@@ -37,7 +37,7 @@
         "index" : true,
         "similarity": "dot_product",
         "index_options": {
-          "type": {{ vector_index_type | default("int8_hnsw") | tojson }}
+          "type": {{ vector_index_type | default("bbq_hnsw") | tojson }}
         }
       },
       "acceptedAnswerId": {


### PR DESCRIPTION
Now that `bbq_hnsw` is our default for vectors with >= 384 dims, we can change the `so_vector` track to make use of this default as well. 

Related ES PR: https://github.com/elastic/elasticsearch/pull/129825