### PR TITLE
Switch to dedicated backport token

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -17,7 +17,7 @@ jobs:
         uses: sorenlouv/backport-github-action@ad888e978060bc1b2798690dd9d03c4036560947  # v9.5.1
         continue-on-error: true
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BACKPORT_TOKEN }}
 
       - name: Info log
         if: ${{ success() }}


### PR DESCRIPTION
This is to try a different approach to backport tool authentication using a dedicated token, instead of GH built-in `GITHUB_TOKEN`. The problem with `GITHUB_TOKEN` is PRs created by backport do not trigger CI workflow [by design](https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), to prevent an infinite loop. We're protected from infinite loop through the use of `backport` label though.

In current setup backport PR needs to be closed and re-opened to trigger CI workflow.