### PR TITLE
Limit on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
+    branches: [ master, '[0-9]*' ]
   pull_request:
   schedule:
     - cron: '0 14 * * *'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron: '0 14 * * *'


### PR DESCRIPTION
https://github.com/elastic/rally-tracks/pull/811 worked as expected and now backported PRs are automatically tested. 

However this showed another problem. There is a duplication of workflows, one is raised for a branch push, and another for PR activity. To eliminate this duplication, I am limiting on push triggers to `master` and `[0-9]*` branches. The latter is supposed to match `<major>`, `<major>.<minor>` and `<major>.<minor>.<patch>` notation supported by Rally. 

Unfortunately GH does not support regexes but a _subset_ of [fnmatch](https://ruby-doc.org/core-2.5.1/File.html#method-c-fnmatch) syntax.