### PR TITLE
[8.15] Limit CI workflow scope for pushes (#818)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [ master, '[0-9]*' ]
   pull_request:
   schedule:
     - cron: '0 14 * * *'


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.15`:
 - [Limit CI workflow scope for pushes (#818)](https://github.com/elastic/rally-tracks/pull/818)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Grzegorz Banasiak","email":"grzegorz.banasiak@elastic.co"},"sourceCommit":{"committedDate":"2025-07-11T14:09:02Z","message":"Limit CI workflow scope for pushes (#818)","sha":"571300ca0dba209afce8c9ccf861a2b0ce527c4d","branchLabelMapping":{"^backport-to-(.+)$":"$1"}},"sourcePullRequest":{"labels":["backport-to-8.15"],"title":"Limit CI workflow scope for pushes","number":818,"url":"https://github.com/elastic/rally-tracks/pull/818","mergeCommit":{"message":"Limit CI workflow scope for pushes (#818)","sha":"571300ca0dba209afce8c9ccf861a2b0ce527c4d"}},"sourceBranch":"master","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"8.15","label":"backport-to-8.15","branchLabelMappingKey":"^backport-to-(.+)$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->