### PR TITLE
[8.15] Remove unnecessary dependency (#821)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -21,7 +21,6 @@ spec:
   owner: group:es-perf
   lifecycle: production
   dependsOn: 
-    - "resource:rally-tracks-it"
     - "resource:rally-tracks-it-serverless"
 
 
@@ -48,8 +47,6 @@ spec:
       name: Rally Tracks - IT Serverless
     spec:
       pipeline_file: .buildkite/it/serverless-pipeline.yml
-      provider_settings:
-        trigger_mode: none
       repository: elastic/rally-tracks
       schedules:
         Daily:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.15`:
 - [Remove unnecessary dependency (#821)](https://github.com/elastic/rally-tracks/pull/821)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Grzegorz Banasiak","email":"grzegorz.banasiak@elastic.co"},"sourceCommit":{"committedDate":"2025-07-16T20:11:50Z","message":"Remove unnecessary dependency (#821)","sha":"37a20a8d46a131f5a2000f2bf813d807843a2cff","branchLabelMapping":{"^backport-to-(.+)$":"$1"}},"sourcePullRequest":{"labels":["backport-to-8.15"],"title":"Remove unnecessary dependency","number":821,"url":"https://github.com/elastic/rally-tracks/pull/821","mergeCommit":{"message":"Remove unnecessary dependency (#821)","sha":"37a20a8d46a131f5a2000f2bf813d807843a2cff"}},"sourceBranch":"master","suggestedTargetBranches":["8.15"],"targetPullRequestStates":[{"branch":"8.15","label":"backport-to-8.15","branchLabelMappingKey":"^backport-to-(.+)$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->