### PR TITLE
[ES|QL] Add new queries into nyc_taxis track to measure DateTrunc to RoundTo transformation

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -1104,6 +1104,24 @@
           "warmup-iterations": 10,
           "iterations": 50
         },
+        {
+          "operation": "date_histogram_calendar_interval_monthly_3months_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "date_histogram_calendar_interval_monthly_9months_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "date_histogram_calendar_interval_monthly_12months_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        }
       {# non-serverless-doc-partitioning-marker-start #}{%- if build_flavor != "serverless" -%}
         {
           "operation": "date_histogram_calendar_interval_esql_doc_partitioning",
@@ -1111,6 +1129,24 @@
           "warmup-iterations": 10,
           "iterations": 50
         },
+        {
+          "operation": "date_histogram_calendar_interval_weekly_3weeks_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "date_histogram_calendar_interval_weekly_9weeks_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        },
+        {
+          "operation": "date_histogram_calendar_interval_weekly_12weeks_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50
+        }
       {%- endif -%}{# non-serverless-doc-partitioning-marker-end #}
         {
           "operation": "date_histogram_fixed_interval",

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -1129,12 +1129,6 @@
           "warmup-iterations": 10,
           "iterations": 50
         },
-        {
-          "operation": "date_histogram_calendar_interval_weekly_12weeks_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
-        },
       {%- endif -%}{# non-serverless-doc-partitioning-marker-end #}
         {
           "operation": "date_histogram_fixed_interval",

--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -1105,12 +1105,6 @@
           "iterations": 50
         },
         {
-          "operation": "date_histogram_calendar_interval_monthly_3months_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
-        },
-        {
           "operation": "date_histogram_calendar_interval_monthly_9months_esql_segment_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
@@ -1121,7 +1115,7 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
-        }
+        },
       {# non-serverless-doc-partitioning-marker-start #}{%- if build_flavor != "serverless" -%}
         {
           "operation": "date_histogram_calendar_interval_esql_doc_partitioning",
@@ -1136,17 +1130,11 @@
           "iterations": 50
         },
         {
-          "operation": "date_histogram_calendar_interval_weekly_9weeks_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50
-        },
-        {
           "operation": "date_histogram_calendar_interval_weekly_12weeks_esql_doc_partitioning",
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
-        }
+        },
       {%- endif -%}{# non-serverless-doc-partitioning-marker-end #}
         {
           "operation": "date_histogram_fixed_interval",

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -1218,6 +1218,21 @@
       "operation-type": "esql",
       "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 week, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time"
     },
+    {
+      "name": "date_histogram_calendar_interval_monthly_3months_esql_segment_partitioning",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time"
+    },
+    {
+    "name": "date_histogram_calendar_interval_monthly_9months_esql_segment_partitioning",
+    "operation-type": "esql",
+    "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-10-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time"
+    },
+    {
+      "name": "date_histogram_calendar_interval_monthly_12months_esql_segment_partitioning",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time"
+    }
   {# non-serverless-doc-partitioning-marker-start #}{%- if build_flavor != "serverless" -%}
     {
       "name": "date_histogram_calendar_interval_esql_doc_partitioning",
@@ -1228,6 +1243,24 @@
         "pragma": { "data_partitioning": "doc" }
       }
     },
+    {
+      "name": "date_histogram_calendar_interval_weekly_3weeks_esql_doc_partitioning",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-01-19T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 week, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
+      "body": {
+        "accept_pragma_risks": true,
+        "pragma": { "data_partitioning": "doc" }
+      }
+    },
+    {
+      "name": "date_histogram_calendar_interval_weekly_12weeks_esql_doc_partitioning",
+      "operation-type": "esql",
+      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-23T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 week, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
+      "body": {
+        "accept_pragma_risks": true,
+        "pragma": { "data_partitioning": "doc" }
+      }
+    }
   {%- endif -%}{# non-serverless-doc-partitioning-marker-end #}
     {
       "name": "date_histogram_fixed_interval_esql_segment_partitioning",

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -1219,11 +1219,6 @@
       "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 week, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time"
     },
     {
-      "name": "date_histogram_calendar_interval_monthly_3months_esql_segment_partitioning",
-      "operation-type": "esql",
-      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time"
-    },
-    {
     "name": "date_histogram_calendar_interval_monthly_9months_esql_segment_partitioning",
     "operation-type": "esql",
     "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-10-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time"
@@ -1232,7 +1227,7 @@
       "name": "date_histogram_calendar_interval_monthly_12months_esql_segment_partitioning",
       "operation-type": "esql",
       "query": "FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time"
-    }
+    },
   {# non-serverless-doc-partitioning-marker-start #}{%- if build_flavor != "serverless" -%}
     {
       "name": "date_histogram_calendar_interval_esql_doc_partitioning",
@@ -1260,7 +1255,7 @@
         "accept_pragma_risks": true,
         "pragma": { "data_partitioning": "doc" }
       }
-    }
+    },
   {%- endif -%}{# non-serverless-doc-partitioning-marker-end #}
     {
       "name": "date_histogram_fixed_interval_esql_segment_partitioning",

--- a/nyc_taxis/operations/default.json
+++ b/nyc_taxis/operations/default.json
@@ -1247,15 +1247,6 @@
         "pragma": { "data_partitioning": "doc" }
       }
     },
-    {
-      "name": "date_histogram_calendar_interval_weekly_12weeks_esql_doc_partitioning",
-      "operation-type": "esql",
-      "query": "FROM nyc_taxis | where dropoff_datetime < \"2015-03-23T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 week, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time",
-      "body": {
-        "accept_pragma_risks": true,
-        "pragma": { "data_partitioning": "doc" }
-      }
-    },
   {%- endif -%}{# non-serverless-doc-partitioning-marker-end #}
     {
       "name": "date_histogram_fixed_interval_esql_segment_partitioning",


### PR DESCRIPTION
Add 3 new date_histogram queries with different calendar intervals to `nyc_taxis` track to measure performance improvements related to filter-by-filter aggregation in `ES|QL`, it is related to https://github.com/elastic/elasticsearch/pull/131341 and https://github.com/elastic/elasticsearch/pull/128639