### PR TITLE
Add index_disabled_by_default track param to elastic/logs and elastic/secuirty rally tracks.

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -261,6 +261,7 @@ The following parameters are available:
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use. Only supported in `logging-querying` track.
 * `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
 * `codec` (default: unset): Configured the `index.codec` index setting, which controls how stored fields get stored / compressed.
+* `index_disabled_by_default` (default: unset): Whether fields should not be indexed by default. This happens via `index.mapping.index_disabled_by_default` index setting.
 
 ### Querying parameters
 

--- a/elastic/logs/templates/component/track-custom-shared-settings.json
+++ b/elastic/logs/templates/component/track-custom-shared-settings.json
@@ -14,6 +14,9 @@
         {%- endif %}
         {%- endif %}
         {#- non-serverless-index-settings-marker-end #}
+        {%- if index_disabled_by_default -%},
+        "mapping.index_disabled_by_default": {{ index_disabled_by_default | tojson }}
+        {%- endif %}
       }
     }
   }

--- a/elastic/security/README.md
+++ b/elastic/security/README.md
@@ -92,6 +92,7 @@ The following parameters are available:
 * `recovery_poll_timeout` (default: `1m`) - The maximum time to wait for additional translog operations before returning an empty result.
 * `recovery_max_batch_size` (default: `32MB`) - The maximum estimated size for the batch of translog operations to return.
 * `recovery_max_operations_count` (default: `1048576`) - The maximum number of translog operations to return in a single batch.
+* `index_disabled_by_default` (default: unset): Whether fields should not be indexed by default. This happens via `index.mapping.index_disabled_by_default` index setting.
 
 ### Data Generation Parameters
 

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -16,6 +16,9 @@
             "sort.field": [ "host.id", "@timestamp" ],
             "sort.order": [ "asc", "desc" ],
             "sort.missing": ["_first", "_last"]
+            {%- if index_disabled_by_default -%},
+            "mapping.index_disabled_by_default": {{ index_disabled_by_default | tojson }}
+            {%- endif %}
         }
         {% endif %}
       }


### PR DESCRIPTION
This PR is run the mentioned tracks with a new index setting is being developed in elastic/elasticsearch#132525.