### PR TITLE
Pass request-timeout in SO Vector knn-recall-param-source

### DIFF
--- a/so_vector/track.py
+++ b/so_vector/track.py
@@ -212,7 +212,7 @@ class KnnRecallRunner:
         max_recall = 0
 
         if request_timeout:
-            es.options(request_timeout=request_timeout)
+            es = es.options(request_timeout=request_timeout)
 
         knn_vector_store: KnnVectorStore = params["knn_vector_store"]
         for query_id, query_vector in enumerate(knn_vector_store.get_query_vectors()):


### PR DESCRIPTION
This fixes https://github.com/elastic/rally-tracks/pull/800 modification by passing `request-timeout` through custom param source.

It also switches to `Elasticsearch.options()` while setting request timeout, instead of passing it to relevant API methods, which produces shorter code and is recommended by Python ES client now.