### PR TITLE
Add queries for LOOKUP JOIN with filters on lookup table attributes

### DIFF
--- a/joins/challenges/default.json
+++ b/joins/challenges/default.json
@@ -139,6 +139,48 @@
           "warmup-iterations": 5,
           "iterations": 20
         },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_few_matching_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_few_matching_concat_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_all_matching_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_all_matching_concat_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_not_matching_equals",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_one_matching_equals",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
 
         {
           "operation": "esql_lookup_join_1k_100k_200k_500k",

--- a/joins/challenges/large.json
+++ b/joins/challenges/large.json
@@ -113,6 +113,48 @@
           "iterations": 20
         },
         {
+          "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_few_matching_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+        "warmup-iterations": 5,
+        "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_few_matching_concat_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+        "warmup-iterations": 5,
+        "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_all_matching_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+        "warmup-iterations": 5,
+        "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_all_matching_concat_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+        "warmup-iterations": 5,
+        "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_not_matching_equals",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+        "warmup-iterations": 5,
+        "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_one_matching_equals",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+        "warmup-iterations": 5,
+        "iterations": 20
+        },
+        {
           "operation": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_limit1000",
           "tags": ["lookup", "join", "limit1000"],
           "clients":  {{query_clients | default(1)}},

--- a/joins/challenges/nightly.json
+++ b/joins/challenges/nightly.json
@@ -101,7 +101,48 @@
           "clients":  {{query_clients | default(1)}},
           "warmup-iterations": 5,
           "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_where_few_matching_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_where_few_matching_concat_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_where_all_matching_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_where_all_matching_concat_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_where_not_matching_equals",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_100k_keys_where_one_matching_equals",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
         }
-
       ]
     }

--- a/joins/challenges/small.json
+++ b/joins/challenges/small.json
@@ -135,6 +135,48 @@
           "warmup-iterations": 5,
           "iterations": 20
         },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_few_matching_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_few_matching_concat_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_all_matching_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_all_matching_concat_like_limit1000",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_not_matching_equals",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
+        {
+          "operation": "esql_lookup_join_1k_keys_where_one_matching_equals",
+          "tags": ["lookup", "join"],
+          "clients":  {{query_clients | default(1)}},
+          "warmup-iterations": 5,
+          "iterations": 20
+        },
 
         {
           "operation": "esql_lookup_join_1k_100k_200k_500k",

--- a/joins/operations/default.json
+++ b/joins/operations/default.json
@@ -97,9 +97,45 @@
       "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
+      "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_few_matching_like_limit1000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val 249*\" | limit 1000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
+    },
+    {
+      "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_few_matching_concat_like_limit1000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where concat(\"x\", lookup_keyword_0) like \"xval 249*\" | limit 1000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
+    },
+    {
+      "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_all_matching_like_limit1000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val *\" | limit 1000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
+    },
+    {
+      "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_all_matching_concat_like_limit1000",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where concat(\"x\", lookup_keyword_0) like \"xval *\" | limit 1000",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
+    },
+    {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_no_match",
       "operation-type": "esql",
       "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where concat(lookup_keyword_0, \"foo\") == \"bar\"",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
+    },
+    {
+      "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_not_matching_equals",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 == \"non existing\"",
+      "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
+    },
+    {
+      "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_one_matching_equals",
+      "operation-type": "esql",
+      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 == \"val 10 rep 0\"",
       "body": { "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
 {% endfor %}


### PR DESCRIPTION
Adding some queries to ES|QL LOOKUP JOIN tracks, to test WHERE filters on attributes coming from the lookup tables, eg.

```
FROM join_base_idx 
| lookup join lookup_idx 
| where lookup_keyword == "foo"
```