### PR TITLE
Add patterned_text_index_options parameter

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -230,6 +230,7 @@ The following parameters are available:
 * `recovery_large_max_batch_size` (default: `32MB`) - The maximum estimated size for the batch of translog operations to return.
 * `recovery_max_operations_count (default: `16777216`) - The maximum number of translog operations to return in a single batch.
 * `patterned_text_message_field` (default: `false`) - If true use `patterned_text` for all message fields, else `match_only_text`. 
+* `patterned_text_index_options` (default: `docs`) - If set to `positions`, includes positions in the patterned_text message field index.
 
 ### Data Download Parameters
 

--- a/elastic/logs/templates/component/auditbeat-mappings.json
+++ b/elastic/logs/templates/component/auditbeat-mappings.json
@@ -2823,7 +2823,8 @@
             },
             "message": {
               {% if patterned_text_message_field | default(false) is true %}
-              "type": "patterned_text"
+              "type": "patterned_text",
+              "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
               {% else %}
               "type": "match_only_text"
               {% endif %}
@@ -5801,7 +5802,8 @@
         },
         "message": {
           {% if patterned_text_message_field | default(false) is true %}
-          "type": "patterned_text"
+          "type": "patterned_text",
+          "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
           {% else %}
           "type": "match_only_text"
           {% endif %}

--- a/elastic/logs/templates/component/logs-apache.access@package.json
+++ b/elastic/logs/templates/component/logs-apache.access@package.json
@@ -250,7 +250,8 @@
             "properties": {
               "message": {
                 {% if patterned_text_message_field | default(false) is true %}
-                "type": "patterned_text"
+                "type": "patterned_text",
+                "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
                 {% else %}
                 "type": "match_only_text"
                 {% endif %}
@@ -259,7 +260,8 @@
           },
           "message": {
             {% if patterned_text_message_field | default(false) is true %}
-            "type": "patterned_text"
+            "type": "patterned_text",
+            "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
             {% else %}
             "type": "match_only_text"
             {% endif %}

--- a/elastic/logs/templates/component/logs-apache.error@package.json
+++ b/elastic/logs/templates/component/logs-apache.error@package.json
@@ -231,7 +231,8 @@
             "properties": {
               "message": {
                 {% if patterned_text_message_field | default(false) is true %}
-                "type": "patterned_text"
+                "type": "patterned_text",
+                "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
                 {% else %}
                 "type": "match_only_text"
                 {% endif %}
@@ -240,7 +241,8 @@
           },
           "message": {
             {% if patterned_text_message_field | default(false) is true %}
-            "type": "patterned_text"
+            "type": "patterned_text",
+            "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
             {% else %}
             "type": "match_only_text"
             {% endif %}

--- a/elastic/logs/templates/component/logs-kafka.log@package.json
+++ b/elastic/logs/templates/component/logs-kafka.log@package.json
@@ -345,7 +345,8 @@
           },
           "message": {
             {% if patterned_text_message_field | default(false) is true %}
-            "type": "patterned_text"
+            "type": "patterned_text",
+            "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
             {% else %}
             "type": "match_only_text"
             {% endif %}
@@ -354,7 +355,8 @@
             "properties": {
               "message": {
                 {% if patterned_text_message_field | default(false) is true %}
-                "type": "patterned_text"
+                "type": "patterned_text",
+                "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
                 {% else %}
                 "type": "match_only_text"
                 {% endif %}

--- a/elastic/logs/templates/component/logs-mysql.error@package.json
+++ b/elastic/logs/templates/component/logs-mysql.error@package.json
@@ -134,7 +134,8 @@
           },
           "message": {
             {% if patterned_text_message_field | default(false) is true %}
-            "type": "patterned_text"
+            "type": "patterned_text",
+            "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
             {% else %}
             "type": "match_only_text"
             {% endif %}
@@ -143,7 +144,8 @@
             "properties": {
               "message": {
                 {% if patterned_text_message_field | default(false) is true %}
-                "type": "patterned_text"
+                "type": "patterned_text",
+                "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
                 {% else %}
                 "type": "match_only_text"
                 {% endif %}

--- a/elastic/logs/templates/component/logs-mysql.slowlog@package.json
+++ b/elastic/logs/templates/component/logs-mysql.slowlog@package.json
@@ -145,7 +145,8 @@
             "properties": {
               "message": {
                 {% if patterned_text_message_field | default(false) is true %}
-                "type": "patterned_text"
+                "type": "patterned_text",
+                "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
                 {% else %}
                 "type": "match_only_text"
                 {% endif %}
@@ -154,7 +155,8 @@
           },
           "message": {
             {% if patterned_text_message_field | default(false) is true %}
-            "type": "patterned_text"
+            "type": "patterned_text",
+            "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
             {% else %}
             "type": "match_only_text"
             {% endif %}

--- a/elastic/logs/templates/component/logs-nginx.error@package.json
+++ b/elastic/logs/templates/component/logs-nginx.error@package.json
@@ -147,7 +147,8 @@
           },
           "message": {
             {% if patterned_text_message_field | default(false) is true %}
-            "type": "patterned_text"
+            "type": "patterned_text",
+            "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
             {% else %}
             "type": "match_only_text"
             {% endif %}

--- a/elastic/logs/templates/component/logs-postgresql.log@package.json
+++ b/elastic/logs/templates/component/logs-postgresql.log@package.json
@@ -143,7 +143,8 @@
           },
           "message": {
             {% if patterned_text_message_field | default(false) is true %}
-            "type": "patterned_text"
+            "type": "patterned_text",
+            "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
             {% else %}
             "type": "match_only_text"
             {% endif %}
@@ -160,7 +161,8 @@
               },
               "message": {
                 {% if patterned_text_message_field | default(false) is true %}
-                "type": "patterned_text"
+                "type": "patterned_text",
+                "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
                 {% else %}
                 "type": "match_only_text"
                 {% endif %}

--- a/elastic/logs/templates/component/logs-redis.log@package.json
+++ b/elastic/logs/templates/component/logs-redis.log@package.json
@@ -120,7 +120,8 @@
             "properties": {
               "message": {
                 {% if patterned_text_message_field | default(false) is true %}
-                "type": "patterned_text"
+                "type": "patterned_text",
+                "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
                 {% else %}
                 "type": "match_only_text"
                 {% endif %}
@@ -129,7 +130,8 @@
           },
           "message": {
             {% if patterned_text_message_field | default(false) is true %}
-            "type": "patterned_text"
+            "type": "patterned_text",
+            "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
             {% else %}
             "type": "match_only_text"
             {% endif %}

--- a/elastic/logs/templates/component/logs-system.auth@package.json
+++ b/elastic/logs/templates/component/logs-system.auth@package.json
@@ -294,7 +294,8 @@
             "properties": {
               "message": {
                 {% if patterned_text_message_field | default(false) is true %}
-                "type": "patterned_text"
+                "type": "patterned_text",
+                "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
                 {% else %}
                 "type": "match_only_text"
                 {% endif %}
@@ -303,7 +304,8 @@
           },
           "message": {
             {% if patterned_text_message_field | default(false) is true %}
-            "type": "patterned_text"
+            "type": "patterned_text",
+            "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
             {% else %}
             "type": "match_only_text"
             {% endif %}

--- a/elastic/logs/templates/component/logs-system.syslog@package.json
+++ b/elastic/logs/templates/component/logs-system.syslog@package.json
@@ -370,7 +370,8 @@
           },
           "message": {
             {% if patterned_text_message_field | default(false) is true %}
-            "type": "patterned_text"
+            "type": "patterned_text",
+            "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
             {% else %}
             "type": "match_only_text"
             {% endif %}

--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -1824,7 +1824,8 @@
         },
         "message": {
           {% if patterned_text_message_field | default(false) is true %}
-          "type": "patterned_text"
+          "type": "patterned_text",
+          "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
           {% else %}
           "type": "match_only_text"
           {% endif %}


### PR DESCRIPTION
Add `patterned_text_index_options` parameter to elastic/log tracks. Can accepts value of `docs` and `positions`, defaults to `docs`. Sets the `index_options` value of the message field in all indices. Only applies if `patterned_text_message_field` is set to true, and message fields are `patterned_text`, rather than `match_only_text`.