### PR TITLE
Add a few runtime fields to insist-chicken challenge

### DIFF
--- a/elastic/logs/challenges/logging-insist-chicken.json
+++ b/elastic/logs/challenges/logging-insist-chicken.json
@@ -115,14 +115,14 @@
       "tags": ["esql", "runtime"]
     },
     {
-      "operation": "runtime_esql_basic_count_group_1_limit_0",
+      "operation": "runtime_esql_basic_count_group_1",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(3) }},
       "iterations": {{ iterations | default(5) }},
       "tags": ["esql", "runtime"]
     },
     {
-      "operation": "runtime_esql_basic_count_group_2_limit_0",
+      "operation": "runtime_esql_basic_count_group_2",
       "clients": {{ p_search_clients }},
       "warmup-iterations": {{ warmup_iterations | default(3) }},
       "iterations": {{ iterations | default(5) }},

--- a/elastic/logs/challenges/logging-insist-chicken.json
+++ b/elastic/logs/challenges/logging-insist-chicken.json
@@ -85,6 +85,48 @@
       "warmup-iterations": {{ warmup_iterations | default(3) }},
       "iterations": {{ iterations | default(5) }},
       "tags": ["esql", "insist"]
+    },
+    {
+      "operation": "runtime_esql_avg_log_offset",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(3) }},
+      "iterations": {{ iterations | default(5) }},
+      "tags": ["esql", "runtime"]
+    },
+    {
+      "operation": "runtime_esql_avg_doc_size",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(3) }},
+      "iterations": {{ iterations | default(5) }},
+      "tags": ["esql", "runtime"]
+    },
+    {
+      "operation": "runtime_esql_avg_compression",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(3) }},
+      "iterations": {{ iterations | default(5) }},
+      "tags": ["esql", "runtime"]
+    },
+    {
+      "operation": "runtime_esql_avg_amount_group_by_integer",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(3) }},
+      "iterations": {{ iterations | default(5) }},
+      "tags": ["esql", "runtime"]
+    },
+    {
+      "operation": "runtime_esql_basic_count_group_1_limit_0",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(3) }},
+      "iterations": {{ iterations | default(5) }},
+      "tags": ["esql", "runtime"]
+    },
+    {
+      "operation": "runtime_esql_basic_count_group_2_limit_0",
+      "clients": {{ p_search_clients }},
+      "warmup-iterations": {{ warmup_iterations | default(3) }},
+      "iterations": {{ iterations | default(5) }},
+      "tags": ["esql", "runtime"]
     }
   ]
 }

--- a/elastic/logs/operations/esql-chicken.json
+++ b/elastic/logs/operations/esql-chicken.json
@@ -50,12 +50,12 @@
       "query": "FROM {{p_esql_target_prefix}}logs-* | STATS AVG(rally.message_size) BY b = BUCKET(rally.doc_size, 1000.) | SORT b"
     },
     {
-      "name": "runtime_esql_basic_count_group_1_limit_0",
+      "name": "runtime_esql_basic_count_group_1",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | STATS count=count(*) BY agent.version | SORT count DESC | LIMIT 0"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | STATS count=count(*) BY agent.version | SORT count DESC | LIMIT 20"
     },
     {
-      "name": "runtime_esql_basic_count_group_2_limit_0",
+      "name": "runtime_esql_basic_count_group_2",
       "operation-type": "esql",
-      "query": "FROM {{p_esql_target_prefix}}logs-* | STATS count=count(*) BY agent.version, agent.type | SORT count DESC | LIMIT 0"
+      "query": "FROM {{p_esql_target_prefix}}logs-* | STATS count=count(*) BY agent.version, agent.type | SORT count DESC | LIMIT 20"
     }

--- a/elastic/logs/operations/esql-chicken.json
+++ b/elastic/logs/operations/esql-chicken.json
@@ -28,4 +28,34 @@
       "name": "chicken_4",
       "operation-type": "esql",
       "query": "FROM logs-* | INSIST_🐔 agent.hostname | EVAL col0 = COALESCE(agent.hostname, \"\") | WHERE col0 ==  \"elasticsearch-ci-immutable-centos-7-1599241536066250344\""
+    },
+    {
+      "name": "runtime_esql_avg_log_offset",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | STATS AVG(log.offset)"
+    },
+    {
+      "name": "runtime_esql_avg_doc_size",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | STATS AVG(rally.doc_size)"
+    },
+    {
+      "name": "runtime_esql_avg_compression",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | EVAL compression = rally.doc_size::DOUBLE / rally.message_size | STATS AVG(compression)"
+    },
+    {
+      "name": "runtime_esql_avg_amount_group_by_integer",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | STATS AVG(rally.message_size) BY b = BUCKET(rally.doc_size, 1000.) | SORT b"
+    },
+    {
+      "name": "runtime_esql_basic_count_group_1_limit_0",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | STATS count=count(*) BY agent.version | SORT count DESC | LIMIT 0"
+    },
+    {
+      "name": "runtime_esql_basic_count_group_2_limit_0",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | STATS count=count(*) BY agent.version, agent.type | SORT count DESC | LIMIT 0"
     }

--- a/elastic/logs/templates/composable/logs-dynamic-false.json
+++ b/elastic/logs/templates/composable/logs-dynamic-false.json
@@ -8,6 +8,23 @@
       "settings": {},
       "mappings": {
         "dynamic": false,
+        "runtime": {
+          "agent.version": {
+            "type": "keyword"
+          },
+          "agent.type": {
+            "type": "keyword"
+          },
+          "rally.doc_size": {
+            "type": "long"
+          },
+          "rally.message_size": {
+            "type": "long"
+          },
+          "log.offset": {
+            "type": "long"
+          }
+        },
         "properties": {
           "@timestamp": {
             "type": "date"


### PR DESCRIPTION
The new queries use runtime fields to access unmapped fields from source.