### PR TITLE
Reduce number of iterations for queries that use runtime fields.

### DIFF
--- a/elastic/logs/challenges/logging-insist-chicken.json
+++ b/elastic/logs/challenges/logging-insist-chicken.json
@@ -89,43 +89,43 @@
     {
       "operation": "runtime_esql_avg_log_offset",
       "clients": {{ p_search_clients }},
-      "warmup-iterations": {{ warmup_iterations | default(3) }},
-      "iterations": {{ iterations | default(5) }},
+      "warmup-iterations": {{ warmup_iterations | default(1) }},
+      "iterations": {{ iterations | default(1) }},
       "tags": ["esql", "runtime"]
     },
     {
       "operation": "runtime_esql_avg_doc_size",
       "clients": {{ p_search_clients }},
-      "warmup-iterations": {{ warmup_iterations | default(3) }},
-      "iterations": {{ iterations | default(5) }},
+      "warmup-iterations": {{ warmup_iterations | default(1) }},
+      "iterations": {{ iterations | default(1) }},
       "tags": ["esql", "runtime"]
     },
     {
       "operation": "runtime_esql_avg_compression",
       "clients": {{ p_search_clients }},
-      "warmup-iterations": {{ warmup_iterations | default(3) }},
-      "iterations": {{ iterations | default(5) }},
+      "warmup-iterations": {{ warmup_iterations | default(1) }},
+      "iterations": {{ iterations | default(1) }},
       "tags": ["esql", "runtime"]
     },
     {
       "operation": "runtime_esql_avg_amount_group_by_integer",
       "clients": {{ p_search_clients }},
-      "warmup-iterations": {{ warmup_iterations | default(3) }},
-      "iterations": {{ iterations | default(5) }},
+      "warmup-iterations": {{ warmup_iterations | default(1) }},
+      "iterations": {{ iterations | default(1) }},
       "tags": ["esql", "runtime"]
     },
     {
       "operation": "runtime_esql_basic_count_group_1",
       "clients": {{ p_search_clients }},
-      "warmup-iterations": {{ warmup_iterations | default(3) }},
-      "iterations": {{ iterations | default(5) }},
+      "warmup-iterations": {{ warmup_iterations | default(1) }},
+      "iterations": {{ iterations | default(1) }},
       "tags": ["esql", "runtime"]
     },
     {
       "operation": "runtime_esql_basic_count_group_2",
       "clients": {{ p_search_clients }},
-      "warmup-iterations": {{ warmup_iterations | default(3) }},
-      "iterations": {{ iterations | default(5) }},
+      "warmup-iterations": {{ warmup_iterations | default(1) }},
+      "iterations": {{ iterations | default(1) }},
       "tags": ["esql", "runtime"]
     }
   ]


### PR DESCRIPTION
This so that benchmark doesn't time out.