### PR TITLE
Remove routing_path from tsdb index template

### DIFF
--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -21,14 +21,6 @@
         "mode": "{{p_index_mode}}",
         {% endif %}
         {% if p_index_mode == "time_series" %}
-        "routing_path": [
-          "metricset.name",
-          "kubernetes.container.name",
-          "kubernetes.event.involved_object.uid",
-          "kubernetes.node.name",
-          "kubernetes.system.container.id",
-          "kubernetes.volume.name"
-        ],
         "time_series": {
           "start_time": "2021-04-28T00:00:00.000Z",
           "end_time": "2021-05-01T00:00:00.000Z"


### PR DESCRIPTION
Setting this is not necessary as the routing path is set automatically for data streams and this template defines `"data_stream": {}`. It would also prevent an optimization added in https://github.com/elastic/elasticsearch/pull/132566.