### PR TITLE
Set index template for ingest_mode: data_stream

### DIFF
--- a/tsdb/track.json
+++ b/tsdb/track.json
@@ -11,12 +11,28 @@
 {
   "version": 2,
   "description": "metricbeat information for elastic-app k8s cluster",
+  {%- if ingest_mode is defined and ingest_mode == "data_stream" %}
+  "composable-templates": [
+    {
+      "name": "tsdb-template",
+      "index-pattern": "k8s*",
+      "delete-matching-indices": true,
+      "template": "index-template.json"
+    }
+  ],
+  "data-streams": [
+    {
+      "name": "k8s"
+    }
+  ],
+  {%- else %}
   "indices": [
     {
       "name": "tsdb",
       "body": "index.json"
     }
   ],
+  {%- endif %}
   "corpora": [
     {
       "name": "tsdb",


### PR DESCRIPTION
Rolls back changes in https://github.com/elastic/rally-tracks/pull/722 that broke the `ingest_mode: data_stream`.

Hopefully resolves https://github.com/elastic/rally-tracks/issues/848