### PR TITLE
Add missing p_index_mode param

### DIFF
--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -2,6 +2,7 @@
 {# TODO By default, source_mode should be "synthetic" if index_mode == "time_series" else "stored" #}
 {% set p_source_mode = (source_mode | default("synthetic")) %}
 {% set p_include_source_mode = (include_source_mode | default(true)) %}
+{% set p_index_mode = (index_mode | default("time_series")) %}
 {
   "index_patterns": ["k8s*"],
   "data_stream": {},


### PR DESCRIPTION
I have locally verified that the data stream is indeed created in `time_series` mode with the following command:

```
esrally race --track-path=tsdb \
  --pipeline=benchmark-only \
  --target-hosts="127.0.0.1:9200" \
  --test-mode \
  --kill-running-processes \
  --track-params="force_merge_max_num_segments:1,ingest_mode:data_stream,index_mode:time_series,source_mode:synthetic,bulk_indexing_clients:16,corpus:split16,run_esql_aggs:true"
```