### PR TITLE
Add tsdb custom param test with ingest_mode: data_stream

### DIFF
--- a/it/test_custom_parameters.py
+++ b/it/test_custom_parameters.py
@@ -27,3 +27,10 @@ class TestCustomParameters:
             track_params={"run_esql_aggs": True, "index_mode": "time_series"},
         )
         assert ret == 0
+
+    def test_tsdb_data_stream(self, es_cluster, rally):
+        ret = rally.race(
+            track="tsdb",
+            track_params={"run_esql_aggs": True, "index_mode": "time_series", "ingest_mode": "data_stream", "source_mode": "synthetic"},
+        )
+        assert ret == 0


### PR DESCRIPTION
This should avoid the data_stream scenario breaking again in the future.