### PR TITLE
Add mapping for message field in logs-redis-slowlog template

### DIFF
--- a/elastic/logs/templates/component/logs-redis.slowlog@package.json
+++ b/elastic/logs/templates/component/logs-redis.slowlog@package.json
@@ -14,6 +14,12 @@
           },
           "logsdb.route_on_sort_fields": true,
           {% endif %}
+          {% if patterned_text_message_field | default(false) is true %}
+          "sort": {
+            "field": [ "host.name", "message.template_id", "@timestamp" ],
+            "order": [ "asc", "asc", "desc" ]
+          },
+          {% endif %}
           "mapping": {
             "total_fields": {
               "limit": "10000"
@@ -258,6 +264,14 @@
                 "value": "redis.slowlog"
               }
             }
+          },
+          "message": {
+            {% if patterned_text_message_field | default(false) is true %}
+            "type": "patterned_text",
+            "index_options": {{ patterned_text_index_options | default("docs") | tojson }}
+            {% else %}
+            "type": "match_only_text"
+            {% endif %}
           },
           "redis": {
             "properties": {


### PR DESCRIPTION
Including supporting `patterned_text_message_field` track parameter.