### PR TITLE
Introduce track filter

### DIFF
--- a/.buildkite/it/run_serverless.sh
+++ b/.buildkite/it/run_serverless.sh
@@ -14,6 +14,7 @@ echo "\$nrconf{restart} = 'a';" | sudo tee -a /etc/needrestart/needrestart.conf 
 
 PYTHON_VERSION="$1"
 TEST_NAME="$2"
+TRACK_FILTER=$(git diff --name-only origin/master...HEAD | grep '/' | awk -F/ '{print $1}' | sort -u | paste -sd, -)
 
 echo "--- System dependencies"
 
@@ -29,7 +30,7 @@ echo "--- Python modules"
 source .venv/bin/activate
 python -m pip install .[develop]
 
-echo "--- Run IT serverless test \"$TEST_NAME\" :pytest:"
+echo "--- Run IT serverless test \"$TEST_NAME\" with track filter \"$TRACK_FILTER\" :pytest:"
 
-hatch -v -e it_serverless run $TEST_NAME
+hatch -v -e it_serverless run $TEST_NAME --track-filter="$TRACK_FILTER"
 

--- a/.github/scripts/track-filter.py
+++ b/.github/scripts/track-filter.py
@@ -2,10 +2,9 @@ import os
 
 import yaml
 
-exclude = set(os.environ.get("EXCLUDE_FOLDERS", "").split(","))
 filters = {}
 for entry in os.listdir("."):
-    if os.path.isdir(entry) and entry not in exclude:
+    if os.path.isdir(entry):
         filters[entry] = [f"{entry}/**"]
 with open(".github/filters.yml", "w") as f:
     yaml.dump(filters, f, default_flow_style=False)

--- a/.github/scripts/track-filter.py
+++ b/.github/scripts/track-filter.py
@@ -1,0 +1,12 @@
+import os
+
+import yaml
+
+exclude = set(os.environ.get("EXCLUDE_FOLDERS", "").split(","))
+filters = {}
+for entry in os.listdir("."):
+    if os.path.isdir(entry) and entry not in exclude:
+        filters[entry] = [f"{entry}/**"]
+with open(".github/filters.yml", "w") as f:
+    yaml.dump(filters, f, default_flow_style=False)
+print(f"Created .github/filters.yml with {len(filters)} track(s): {', '.join(filters.keys())}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Parse repo and create filters.yml
         run: python3 .github/scripts/track-filter.py
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
         id: changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,34 @@ jobs:
           slack_channel: ${{ secrets.SLACK_CHANNEL }}
           status: FAILED
 
+  filter-pr-changes:
+    runs-on: ubuntu-latest
+    env:
+      EXCLUDE_FOLDERS: ".github,.buildkite,.git,it_serverless"
+    outputs:
+      tracks: ${{ steps.track_filter.outputs.tracks }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse repo and create filters.yml
+        run: python3 .github/scripts/track-filter.py
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: .github/filters.yml
+      - name: Collect changed tracks for --track-filter argument
+        id: track_filter
+        run: |
+          TRACKS=$(echo '${{ toJSON(steps.changes.outputs) }}' | jq -r '
+            to_entries
+            | map(select(.value == "true"))
+            | map(.key)
+            | join(",")
+          ')
+          echo "tracks=$TRACKS" >> $GITHUB_OUTPUT
+
   test:
+    needs: filter-pr-changes
     strategy:
       fail-fast: false
       matrix:
@@ -56,7 +83,7 @@ jobs:
       - name: "Install dependencies"
         run: python -m pip install .[develop]
       - name: "Run tests"
-        run: hatch -v -e unit run test
+        run: hatch -v -e unit run test --track-filter="${{ needs.filter-pr-changes.outputs.tracks }}"
       - uses: elastic/es-perf-github-status@v2
         if: ${{ failure() && ( github.event_name == 'schedule' || ( github.event_name == 'push' && github.ref_name == env.DEFAULT_BRANCH ) ) }}
         with:
@@ -65,6 +92,7 @@ jobs:
           status: FAILED
 
   rally-tracks-compat:
+    needs: filter-pr-changes
     strategy:
       fail-fast: false
       matrix:
@@ -88,8 +116,8 @@ jobs:
       - run: echo "JAVA11_HOME=$JAVA_HOME_11_X64" >> $GITHUB_ENV
       - name: "Install dependencies"
         run: python -m pip install .[develop]
-      - name: "Run tests"
-        run: hatch -v -e it run test
+      - name: "Run tests (${{ needs.filter-pr-changes.outputs.tracks }})"
+        run: hatch -v -e it run test --track-filter="${{ needs.filter-pr-changes.outputs.tracks }}"
         timeout-minutes: 120
         env:
           # elastic/endpoint fetches assets from GitHub, authenticate to avoid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
 
   filter-pr-changes:
     runs-on: ubuntu-latest
-    env:
-      EXCLUDE_FOLDERS: ".github,.buildkite,.git,it_serverless"
     outputs:
       tracks: ${{ steps.track_filter.outputs.tracks }}
     steps:

--- a/it/logs/test_logs.py
+++ b/it/logs/test_logs.py
@@ -22,6 +22,7 @@ from it.logs import BASE_PARAMS, params
 pytest_rally = pytest.importorskip("pytest_rally")
 
 
+@pytest.mark.track("elastic/logs")
 class TestLogs:
     def test_logs_fails_if_assets_not_installed(self, es_cluster, rally, capsys):
         ret = rally.race(track="elastic/logs", exclude_tasks="tag:setup")

--- a/it/logs/test_logs_unmapped.py
+++ b/it/logs/test_logs_unmapped.py
@@ -22,6 +22,7 @@ from it.logs import BASE_PARAMS, params
 pytest_rally = pytest.importorskip("pytest_rally")
 
 
+@pytest.mark.track("elastic/logs")
 class TestLogsUnmapped:
     def test_logs_chicken(self, es_cluster, rally):
         custom = {"mapping": "unmapped"}

--- a/it/test_custom_parameters.py
+++ b/it/test_custom_parameters.py
@@ -21,6 +21,7 @@ pytest_rally = pytest.importorskip("pytest_rally")
 
 
 class TestCustomParameters:
+    @pytest.mark.track("tsdb")
     def test_tsdb_esql(self, es_cluster, rally):
         ret = rally.race(
             track="tsdb",

--- a/it/test_security.py
+++ b/it/test_security.py
@@ -21,6 +21,7 @@ import requests
 pytest_rally = pytest.importorskip("pytest_rally")
 
 
+@pytest.mark.track("elastic/security")
 class TestSecurity:
     def test_security_indexing(self, es_cluster, rally):
         ret = rally.race(track="elastic/security", challenge="security-indexing", track_params={"number_of_replicas": "0"})

--- a/it/test_synthetic_source.py
+++ b/it/test_synthetic_source.py
@@ -34,6 +34,7 @@ def params(updates=None):
 
 
 class TestSyntheticSource:
+    @pytest.mark.track("tsdb")
     def test_tsdb_default(self, es_cluster, rally):
         ret = rally.race(
             track="tsdb",
@@ -41,6 +42,7 @@ class TestSyntheticSource:
         )
         assert ret == 0
 
+    @pytest.mark.track("nyc_taxis")
     def test_nyc_taxis_default(self, es_cluster, rally):
         ret = rally.race(
             track="nyc_taxis",

--- a/it_serverless/test_logs.py
+++ b/it_serverless/test_logs.py
@@ -42,6 +42,7 @@ def params(updates=None):
         return {**base, **updates}
 
 
+@pytest.mark.track("elastic/logs")
 @pytest.mark.operator_only
 class TestLogs:
     def test_logs_fails_if_assets_not_installed(self, operator, rally, capsys, project_config: ServerlessProjectConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ exclude = [
 [tool.hatch.envs.default]
 dependencies = [
     "esrally[develop] @ git+https://github.com/elastic/rally.git@master",
-    "pytest-rally @ git+https://github.com/elastic/pytest-rally.git@main",
+    "pytest-rally @ git+https://github.com/NickDris/pytest-rally.git@main",
 ]
 
 [tool.hatch.envs.unit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,14 @@ extra-dependencies = [
 ]
 
 [tool.hatch.envs.unit.scripts]
-test = "pytest"
+test = "pytest {args}"
 
 [tool.hatch.envs.it.scripts]
-test = "pytest it --log-cli-level=INFO"
+test = "pytest it --log-cli-level=INFO {args}"
 
 [tool.hatch.envs.it_serverless.scripts]
-test_user = "pytest -s it_serverless --log-cli-level=INFO"
-test_operator = "pytest -s it_serverless --log-cli-level=INFO --operator"
+test_user = "pytest -s it_serverless --log-cli-level=INFO {args}"
+test_operator = "pytest -s it_serverless --log-cli-level=INFO --operator {args}"
 
 [tool.pytest.ini_options]
 # set to true for more verbose output of tests
@@ -60,6 +60,9 @@ addopts = "--verbose --color=yes --ignore=it --ignore=it_serverless"
 junit_family = "xunit2"
 junit_logging = "all"
 asyncio_mode = "strict"
+markers = [
+    'track(name): Optionally associate a test class, or function, with a track (Usage: @pytest.mark.track(["track1", "track2"])). When given the --track-filter option (--track-filter=track1,track3), pytest will only run the tests marked with at least one of the track names.'
+]
 
 [tool.black]
 line-length = 140

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ exclude = [
 [tool.hatch.envs.default]
 dependencies = [
     "esrally[develop] @ git+https://github.com/elastic/rally.git@master",
-    "pytest-rally @ git+https://github.com/NickDris/pytest-rally.git@main",
+    "pytest-rally @ git+https://github.com/elastic/pytest-rally.git@main",
 ]
 
 [tool.hatch.envs.unit]


### PR DESCRIPTION
- Test will now use the --track-filter options from pytest-rally plugin in order to run tests only on selected tracks of the repo based on the changes introduced by the PRs. 
- Changes are tracked on the topmost level folders. 

e.g. if big5/README.md was only changed in a PR, CI will now only run the test for big5 track in both stateful and serverless. 