### PR TITLE
Adjust target throughput in HTTP Logs and Percolator

### DIFF
--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -123,7 +123,7 @@
         { "operation": "200s-in-range", "name": "200s-in-range-from-source-using-index-of",   "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-source",   "using-index-of"] },
         { "operation": "200s-in-range", "name": "200s-in-range-from-keyword-using-index-of",  "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-keyword",  "using-index-of"] },
         { "operation": "200s-in-range", "name": "200s-in-range-from-wildcard-using-index-of", "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-wildcard", "using-index-of"] },
-        { "operation": "400s-in-range", "name": "400s-in-range-from-source-using-grok",       "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.3, "tags": ["400s-in-range", "from-source",   "using-grok"] },
+        { "operation": "400s-in-range", "name": "400s-in-range-from-source-using-grok",       "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.2, "tags": ["400s-in-range", "from-source",   "using-grok"] },
         { "operation": "400s-in-range", "name": "400s-in-range-from-keyword-using-grok",      "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.3, "tags": ["400s-in-range", "from-keyword",  "using-grok"] },
         { "operation": "400s-in-range", "name": "400s-in-range-from-wildcard-using-grok",     "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.3, "tags": ["400s-in-range", "from-wildcard", "using-grok"] },
         { "operation": "400s-in-range", "name": "400s-in-range-from-source-using-dissect",    "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.5, "tags": ["400s-in-range", "from-source",   "using-dissect"] },
@@ -169,13 +169,13 @@
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 20
+          "target-throughput": 2.7
         },
         {
           "operation": "desc_sort_with_after_timestamp",
           "warmup-iterations": 10,
           "iterations": 100,
-          "target-throughput": 1
+          "target-throughput": 0.6
         },
         {
           "operation": "asc_sort_with_after_timestamp",
@@ -278,21 +278,21 @@
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
           "iterations": 100,
-          "target-throughput": 50
+          "target-throughput": 1.6
         },
         {
           "name": "desc-sort-with-after-timestamp-after-force-merge-1-seg",
           "operation": "desc_sort_with_after_timestamp",
           "warmup-iterations": 10,
           "iterations": 100,
-          "target-throughput": 1
+          "target-throughput": 0.7
         },       
         {
           "name": "asc-sort-with-after-timestamp-after-force-merge-1-seg",
           "operation": "asc_sort_with_after_timestamp",
           "warmup-iterations": 10,
           "iterations": 100,
-          "target-throughput": 0.5
+          "target-throughput": 0.3
         }
 {%- if not runtime_fields is defined %},         
         {

--- a/percolator/challenges/default.json
+++ b/percolator/challenges/default.json
@@ -72,7 +72,7 @@
           "operation": "percolator_with_content_president_bush",
           "warmup-iterations": 100,
           "iterations": 100,
-          "target-throughput": 50
+          "target-throughput": 27
         },
         {
           "operation": "percolator_with_content_saddam_hussein",
@@ -90,7 +90,7 @@
           "operation": "percolator_with_content_google",
           "warmup-iterations": 100,
           "iterations": 100,
-          "target-throughput": 27
+          "target-throughput": 16
         },
         {
           "operation": "percolator_no_score_with_content_google",


### PR DESCRIPTION
Adjusts target throughput after resource scale-down from 8 core / 32 GiB RAM (legacy bare-metal) to 4 cores / 8 GiB RAM (cloud).