### PR TITLE
Fixes hatch python package crashing because of new click release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ develop = [
     "isort==5.12.0",
     "pre-commit==3.3.3",
     "pip==22.2",
+    "click<8.3.0",
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
In the PR #861 I had problems with `hatch` executing because of this bug https://github.com/pypa/hatch/issues/2050

```
Run hatch -v -e unit run test
No config file found, creating one with default settings now...
Success! Please see `hatch config`.
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/hatch/c │
│ li/__init__.py:206 in main                                                   │
│                                                                              │

. . . 

│   153 │   if filter_json:                                                    │
│   154 │   │   import json                                                    │
│   155 │   │                                                                  │
│ ❱ 156 │   │   filter_data = json.loads(filter_json)                          │
│   157 │   │   if not isinstance(filter_data, dict):                          │
│   158 │   │   │   app.abort('The --filter/-f option must be a JSON mapping') │
│   159                                                                        │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/json/__init__.py:339  │
│ in loads                                                                     │
│                                                                              │
│   336 │   │   │   │   │   │   │   │     s, 0)                                │
│   337 │   else:                                                              │
│   338 │   │   if not isinstance(s, (bytes, bytearray)):                      │
│ ❱ 339 │   │   │   raise TypeError(f'the JSON object must be str, bytes or by │
│   340 │   │   │   │   │   │   │   f'not {s.__class__.__name__}')             │
│   341 │   │   s = s.decode(detect_encoding(s), 'surrogatepass')              │
│   342                                                                        │
╰──────────────────────────────────────────────────────────────────────────────╯
TypeError: the JSON object must be str, bytes or bytearray, not Sentinel
```

This PR forces the click dependency to be lower than the problematic version