### PR TITLE
Fix click to <8.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,11 @@ build-backend = "hatchling.build"
 develop = [
     "hatch==1.7.0",
     "hatchling==1.18.0",
-    "click<8.3.0", #fix to a pre 8.3.0 version until fixed upstream
+    "click<8.3.0", # fix to a pre 8.3.0 version until https://github.com/pypa/hatch/issues/2050 resolved
     "black==23.3.0",
     "isort==5.12.0",
     "pre-commit==3.3.3",
-    "pip==22.2",
+    "pip==25.2",
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
We pull in click via black, there's a breaking change in 8.3.0. Fixing to <8.3.0 until there is either a fix, or we can work around
Ref: https://github.com/pallets/click/issues/3065