### PR TITLE
Gates inlinestats queries to only execute in serverless

### DIFF
--- a/nyc_taxis/challenges/default.json
+++ b/nyc_taxis/challenges/default.json
@@ -939,6 +939,7 @@
           "iterations": 50,
           "tags": ["inlinestats"]
         },
+      {# non-serverless-inlinestats-marker-start #}{%- if build_flavor != "serverless" -%}
         {
           "operation": "one_inlinestats_sum_esql",
           "clients": 1,
@@ -960,6 +961,7 @@
           "iterations": 50,
           "tags": ["inlinestats"]
         },
+      {%- endif -%}{# non-serverless-inlinestats-marker-end #}
       {# non-serverless-doc-partitioning-marker-start #}{%- if build_flavor != "serverless" -%}
         {
           "operation": "avg_passenger_count_esql_doc_partitioning",
@@ -1194,7 +1196,275 @@
           "warmup-iterations": 10,
           "iterations": 20
         },
+        {
+          "operation": "inlinestats_avg_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_count_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_median_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 10,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_max_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_sum_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_top_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_count_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_median_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 10,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_max_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_sum_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_top_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_avg_passenger_count_filtered_esql_doc_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
       {%- endif -%}{# non-serverless-doc-partitioning-marker-end #}
+      {# non-serverless-inlinestats-marker-start #}{%- if build_flavor != "serverless" -%}
+        {
+          "operation": "inlinestats_avg_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_count_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_median_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 10,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_max_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_sum_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_top_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_count_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_median_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 5,
+          "iterations": 10,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_max_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_sum_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_top_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_count_comparison_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_count_comparison_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_avg_comparison_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_avg_comparison_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_max_comparison_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_max_comparison_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_avg_passenger_count_filtered_esql_segment_partitioning",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_then_stats_count_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_then_inlinestats_count_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_then_stats_sum_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_then_inlinestats_sum_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "inlinestats_then_stats_avg_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "stats_then_inlinestats_avg_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 20,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "multiple_stats_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+        {
+          "operation": "multiple_inlinestats_esql",
+          "clients": 1,
+          "warmup-iterations": 10,
+          "iterations": 50,
+          "tags": ["inlinestats"]
+        },
+      {%- endif -%}{# non-serverless-inlinestats-marker-end #}
         {
           "operation": "esql_enrich_control",
           "tags": ["enrich"],
@@ -1488,274 +1758,6 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
-        },
-      {# non-serverless-doc-partitioning-marker-start #}{%- if build_flavor != "serverless" -%}
-        {
-          "operation": "inlinestats_avg_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_count_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_median_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 5,
-          "iterations": 10,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_max_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_sum_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_top_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_count_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_median_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 5,
-          "iterations": 10,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_max_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_sum_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_top_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_avg_passenger_count_filtered_esql_doc_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-      {%- endif -%}{# non-serverless-doc-partitioning-marker-end #}
-        {
-          "operation": "inlinestats_avg_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_count_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_median_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 5,
-          "iterations": 10,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_max_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_sum_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_top_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_count_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_median_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 5,
-          "iterations": 10,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_max_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_sum_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_top_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_count_comparison_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_count_comparison_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_avg_comparison_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_avg_comparison_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_max_comparison_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_max_comparison_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_avg_passenger_count_filtered_esql_segment_partitioning",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_then_stats_count_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_then_inlinestats_count_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_then_stats_sum_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_then_inlinestats_sum_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "inlinestats_then_stats_avg_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "stats_then_inlinestats_avg_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 20,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "multiple_stats_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
-        },
-        {
-          "operation": "multiple_inlinestats_esql",
-          "clients": 1,
-          "warmup-iterations": 10,
-          "iterations": 50,
-          "tags": ["inlinestats"]
         }
       ]
     },


### PR DESCRIPTION
The diff looks quite messy, but fundamentally this PR only encloses `inlinestats` queries in a `{# non-serverless-inlinestats-marker-start #}` block. 

The reason why the diff looks messy is because I had to move the end queries to the middle of the file, the last query must always have no comma at the end, so if we enclose that in and `if / endif` block there could be problems