### PR TITLE
Fix issue introduced by #858

### DIFF
--- a/.buildkite/it/run_serverless.sh
+++ b/.buildkite/it/run_serverless.sh
@@ -32,7 +32,7 @@ python -m pip install .[develop]
 
 echo "--- Track filter modification"
 
-CHANGED_FILES=$(git diff --name-only upstream/master...HEAD)
+CHANGED_FILES=$(git diff --name-only origin/master...HEAD)
 readarray -t changed_files_arr <<< "$CHANGED_FILES"
 
 if [[ -z "$CHANGED_FILES" ]]; then
@@ -65,4 +65,4 @@ fi
 
 echo "--- Run IT serverless test \"$TEST_NAME\"$TRACK_FILTER_ARG :pytest:"
 
-# hatch -v -e it_serverless run $TEST_NAME$TRACK_FILTER_ARG
+hatch -v -e it_serverless run $TEST_NAME$TRACK_FILTER_ARG

--- a/.buildkite/it/run_serverless.sh
+++ b/.buildkite/it/run_serverless.sh
@@ -32,11 +32,12 @@ python -m pip install .[develop]
 
 echo "--- Track filter modification"
 
+CHANGED_FILES=$(git diff --name-only origin/master...HEAD)
+
 if [[ -z "$CHANGED_FILES" ]]; then
     echo "No changed files detected between origin/master and HEAD. Running full CI"
     TRACK_FILTER_ARG=""
 else
-    CHANGED_FILES=$(git diff --name-only origin/master...HEAD)
     readarray -t changed_files_arr <<< "$CHANGED_FILES"
     CHANGED_TOP_LEVEL_DIRS=$(printf '%s\n' "$CHANGED_FILES" | awk -F/ '/\//{print $1}' | sort -u | paste -sd, -)
     CHANGED_TOP_LEVEL_DIRS=${CHANGED_TOP_LEVEL_DIRS%,}

--- a/.buildkite/it/run_serverless.sh
+++ b/.buildkite/it/run_serverless.sh
@@ -32,13 +32,12 @@ python -m pip install .[develop]
 
 echo "--- Track filter modification"
 
-CHANGED_FILES=$(git diff --name-only origin/master...HEAD)
-readarray -t changed_files_arr <<< "$CHANGED_FILES"
-
 if [[ -z "$CHANGED_FILES" ]]; then
     echo "No changed files detected between origin/master and HEAD. Running full CI"
     TRACK_FILTER_ARG=""
 else
+    CHANGED_FILES=$(git diff --name-only origin/master...HEAD)
+    readarray -t changed_files_arr <<< "$CHANGED_FILES"
     CHANGED_TOP_LEVEL_DIRS=$(printf '%s\n' "$CHANGED_FILES" | awk -F/ '/\//{print $1}' | sort -u | paste -sd, -)
     CHANGED_TOP_LEVEL_DIRS=${CHANGED_TOP_LEVEL_DIRS%,}
     IFS=',' read -ra changed_dirs_arr <<< "$CHANGED_TOP_LEVEL_DIRS"

--- a/.buildkite/it/run_serverless.sh
+++ b/.buildkite/it/run_serverless.sh
@@ -37,9 +37,6 @@ readarray -t changed_files_arr <<< "$CHANGED_FILES"
 
 if [[ -z "$CHANGED_FILES" ]]; then
     echo "No changed files detected between origin/master and HEAD. Running full CI"
-    CHANGED_TOP_LEVEL_DIRS=""
-    changed_dirs_arr=()
-    all_changed_arr=()
     TRACK_FILTER_ARG=""
 else
     CHANGED_TOP_LEVEL_DIRS=$(printf '%s\n' "$CHANGED_FILES" | awk -F/ '/\//{print $1}' | sort -u | paste -sd, -)

--- a/.buildkite/it/run_serverless.sh
+++ b/.buildkite/it/run_serverless.sh
@@ -32,27 +32,37 @@ python -m pip install .[develop]
 
 echo "--- Track filter modification"
 
-CHANGED_FILES=$(git diff --name-only origin/master...HEAD)
+CHANGED_FILES=$(git diff --name-only upstream/master...HEAD)
 readarray -t changed_files_arr <<< "$CHANGED_FILES"
 
-CHANGED_TOP_LEVEL_DIRS=$(echo "$CHANGED_FILES" | grep '/' | awk -F/ '{print $1}' | sort -u | paste -sd, -)
-CHANGED_TOP_LEVEL_DIRS=${CHANGED_TOP_LEVEL_DIRS%,}
-IFS=',' read -ra changed_dirs_arr <<< "$CHANGED_TOP_LEVEL_DIRS"
+if [[ -z "$CHANGED_FILES" ]]; then
+    echo "No changed files detected between origin/master and HEAD. Running full CI"
+    CHANGED_TOP_LEVEL_DIRS=""
+    changed_dirs_arr=()
+    all_changed_arr=()
+    TRACK_FILTER_ARG=""
+else
+    CHANGED_TOP_LEVEL_DIRS=$(printf '%s\n' "$CHANGED_FILES" | awk -F/ '/\//{print $1}' | sort -u | paste -sd, -)
+    CHANGED_TOP_LEVEL_DIRS=${CHANGED_TOP_LEVEL_DIRS%,}
+    IFS=',' read -ra changed_dirs_arr <<< "$CHANGED_TOP_LEVEL_DIRS"
 
-all_changed_arr=("${changed_files_arr[@]}" "${changed_dirs_arr[@]}")
+    all_changed_arr=("${changed_files_arr[@]}" "${changed_dirs_arr[@]}")
 
-TRACK_FILTER_ARG="--track-filter=${CHANGED_TOP_LEVEL_DIRS}"
-
-# If any changes match one of the RUN_FULL_CI_WHEN_CHANGED paths, run full CI
-for static_path in "${RUN_FULL_CI_WHEN_CHANGED[@]}"; do
-    for changed in "${all_changed_arr[@]}"; do
-        if [[ "$static_path" == "$changed" ]]; then
-            echo "Matched '$static_path' in changed files/dirs. Running full CI."
-            TRACK_FILTER_ARG=""
-            break 2
-        fi
+    TRACK_FILTER_ARG=" --track-filter=${CHANGED_TOP_LEVEL_DIRS}"
+    
+    # If any changes match one of the RUN_FULL_CI_WHEN_CHANGED paths, run full CI
+    for static_path in "${RUN_FULL_CI_WHEN_CHANGED[@]}"; do
+        for changed in "${all_changed_arr[@]}"; do
+            if [[ "$static_path" == "$changed" ]]; then
+                echo "Matched '$static_path' in changed files/dirs. Running full CI."
+                TRACK_FILTER_ARG=""
+                break 2
+            fi
+        done
     done
-done
-echo "--- Run IT serverless test \"$TEST_NAME\" $TRACK_FILTER_ARG :pytest:"
+fi
 
-hatch -v -e it_serverless run $TEST_NAME $TRACK_FILTER_ARG
+
+echo "--- Run IT serverless test \"$TEST_NAME\"$TRACK_FILTER_ARG :pytest:"
+
+# hatch -v -e it_serverless run $TEST_NAME$TRACK_FILTER_ARG


### PR DESCRIPTION
#858 Introduces a bug on run_serverless.sh script.

Prevent run_serverless.sh exiting prematurely In the condition of no changes between HEAD and origin/master.
