### PR TITLE
Change branchLabelMapping to vX.Y patterns

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -10,6 +10,7 @@
     "backport"
   ],
   "branchLabelMapping": {
+    "^v(\\d{1,2})$" : "$1",
     "^v(\\d{1,2}).(\\d{1,2})$" : "$1.$2"
   },
   "autoMerge": true,

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -10,7 +10,7 @@
     "backport"
   ],
   "branchLabelMapping": {
-    "^backport-to-(.+)$": "$1"
+    "^v(\\d{1,2}).(\\d{1,2})$" : "$1.$2"
   },
   "autoMerge": true,
   "autoMergeMethod": "squash",


### PR DESCRIPTION
In the context of backporting, we have decided to follow elasticsearch as role model for branching and labeling patterns.
In this context backport labels shoul be using the vX.Y pattern not 'backport-to-x-y' 