### PR TITLE
[9.2] Drop Python 3.9 and introduce Python 3.13 in CI (#877)

### DIFF
--- a/.buildkite/it/serverless-pipeline.yml
+++ b/.buildkite/it/serverless-pipeline.yml
@@ -27,11 +27,11 @@ steps:
       - elastic/vault-secrets#v0.0.2: *vault-base_url
       - elastic/vault-secrets#v0.0.2: *vault-get_credentials_endpoint
       - elastic/vault-secrets#v0.0.2: *vault-api_key
-    command: bash .buildkite/it/run_serverless.sh 3.11 test_user $RUN_FULL_CI_WHEN_CHANGED
+    command: bash .buildkite/it/run_serverless.sh 3.13 test_user $RUN_FULL_CI_WHEN_CHANGED
   - label: "Run IT Serverless tests with operator privileges"
     if: build.pull_request.base_branch == "master" || build.source == "schedule"
     plugins:
       - elastic/vault-secrets#v0.0.2: *vault-base_url
       - elastic/vault-secrets#v0.0.2: *vault-get_credentials_endpoint
       - elastic/vault-secrets#v0.0.2: *vault-api_key
-    command: bash .buildkite/it/run_serverless.sh 3.11 test_operator $RUN_FULL_CI_WHEN_CHANGED
+    command: bash .buildkite/it/run_serverless.sh 3.13 test_operator $RUN_FULL_CI_WHEN_CHANGED

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: pyproject.toml
       - name: "Install dependencies"
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os:
           - macos-13
           - ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.13"]
 
     runs-on: ubuntu-22.04
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PYENV_REGEX = .pyenv/shims
 PY_BIN = python3
 # https://github.com/pypa/pip/issues/5599
 PIP_WRAPPER = $(PY_BIN) -m pip
-export PY38 = "3.8.13"
+export PY313 = "3.13.7"
 VIRTUAL_ENV ?= .venv
 VENV_ACTIVATE_FILE = $(VIRTUAL_ENV)/bin/activate
 VENV_ACTIVATE = . $(VENV_ACTIVATE_FILE)
@@ -31,8 +31,8 @@ PYENV_PREREQ_HELP = "\033[0;31mIMPORTANT\033[0m: please type \033[0;31mpyenv ini
 VE_MISSING_HELP = "\033[0;31mIMPORTANT\033[0m: Couldn't find $(PWD)/$(VIRTUAL_ENV); have you executed make venv-create?\033[0m\n"
 
 prereq:
-	pyenv install --skip-existing $(PY38)
-	pyenv local $(PY38)
+	pyenv install --skip-existing $(PY313)
+	pyenv local $(PY313)
 
 venv-create:
 	@if [[ ! -x $$(command -v pyenv) ]]; then \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ develop = [
     "hatch==1.7.0",
     "hatchling==1.18.0",
     "click<8.3.0", # fix to a pre 8.3.0 version until https://github.com/pypa/hatch/issues/2050 resolved
-    "black==23.3.0",
+    "black==24.10.0",
     "isort==5.12.0",
     "pre-commit==3.3.3",
     "pip==25.2",
@@ -23,7 +23,7 @@ source = "vcs"
 name = "rally-tracks"
 readme = "README.md"
 dynamic = ["version"]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 [tool.hatch.build.targets.sdist]
 exclude = [
@@ -67,7 +67,7 @@ markers = [
 
 [tool.black]
 line-length = 140
-target-version = ['py38']
+target-version = ['py310', 'py311', 'py312', 'py313']
 
 [tool.isort]
 profile = 'black'


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.2`:
 - [Drop Python 3.9 and introduce Python 3.13 in CI (#877)](https://github.com/elastic/rally-tracks/pull/877)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Grzegorz Banasiak","email":"grzegorz.banasiak@elastic.co"},"sourceCommit":{"committedDate":"2025-10-06T17:15:08Z","message":"Drop Python 3.9 and introduce Python 3.13 in CI (#877)","sha":"5889d4178c095b96e2d3b7f0c2362e7e9f174d79","branchLabelMapping":{"^backport-to-(.+)$":"$1"}},"sourcePullRequest":{"labels":["v9.2"],"title":"Drop Python 3.9 and introduce Python 3.13 in CI","number":877,"url":"https://github.com/elastic/rally-tracks/pull/877","mergeCommit":{"message":"Drop Python 3.9 and introduce Python 3.13 in CI (#877)","sha":"5889d4178c095b96e2d3b7f0c2362e7e9f174d79"}},"sourceBranch":"master","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[]}] BACKPORT-->