### PR TITLE
[9.2] CI builds ES revision from sources based on es-version file (#875)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,23 @@ jobs:
           slack_channel: ${{ secrets.SLACK_CHANNEL }}
           status: FAILED
 
+  determine-revision:
+    runs-on: ubuntu-22.04
+    outputs:
+      revision: ${{ steps.revision-argument.outputs.revision }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Determine ES version"
+        id: es-version
+        run: |
+          ES_VERSION=$(cat es-version)
+          echo "Determined es-version: $ES_VERSION"
+          echo "version=$ES_VERSION" >> $GITHUB_OUTPUT
+      - name: "Determine --revision argument"
+        id: revision-argument
+        run: |
+          echo "revision= --revision=${{ steps.es-version.outputs.version }}" >> $GITHUB_OUTPUT
+
   filter-pr-changes:
     runs-on: ubuntu-22.04
     outputs:
@@ -62,11 +79,13 @@ jobs:
             if echo "$TRACKS" | grep -qw "full_ci"; then
             echo 'track_filter=' >> $GITHUB_OUTPUT
             else
-            echo "track_filter=--track-filter=$TRACKS" >> $GITHUB_OUTPUT
+            echo "track_filter= --track-filter=$TRACKS" >> $GITHUB_OUTPUT
             fi
 
   test:
-    needs: filter-pr-changes
+    needs: 
+      - filter-pr-changes
+      - determine-revision
     strategy:
       fail-fast: false
       matrix:
@@ -86,8 +105,8 @@ jobs:
           cache-dependency-path: pyproject.toml
       - name: "Install dependencies"
         run: python -m pip install .[develop]
-      - name: "Run tests ${{ needs.filter-pr-changes.outputs.track_filter }}"
-        run: hatch -v -e unit run test ${{ needs.filter-pr-changes.outputs.track_filter }}
+      - name: "Run tests${{ needs.filter-pr-changes.outputs.track_filter }}${{ needs.determine-revision.outputs.revision }}"
+        run: hatch -v -e unit run test${{ needs.filter-pr-changes.outputs.track_filter }}${{ needs.determine-revision.outputs.revision }}
       - uses: elastic/es-perf-github-status@v2
         if: ${{ failure() && ( github.event_name == 'schedule' || ( github.event_name == 'push' && github.ref_name == env.DEFAULT_BRANCH ) ) }}
         with:
@@ -96,7 +115,10 @@ jobs:
           status: FAILED
 
   rally-tracks-compat:
-    needs: filter-pr-changes
+    needs: 
+      - filter-pr-changes
+      - determine-revision
+
     strategy:
       fail-fast: false
       matrix:
@@ -120,8 +142,8 @@ jobs:
       - run: echo "JAVA11_HOME=$JAVA_HOME_11_X64" >> $GITHUB_ENV
       - name: "Install dependencies"
         run: python -m pip install .[develop]
-      - name: "Run tests ${{ needs.filter-pr-changes.outputs.track_filter }}"
-        run: hatch -v -e it run test ${{ needs.filter-pr-changes.outputs.track_filter }}
+      - name: "Run tests${{ needs.filter-pr-changes.outputs.track_filter }}${{ needs.determine-revision.outputs.revision }}"
+        run: hatch -v -e it run test${{ needs.filter-pr-changes.outputs.track_filter }}${{ needs.determine-revision.outputs.revision }}
         timeout-minutes: 120
         env:
           # elastic/endpoint fetches assets from GitHub, authenticate to avoid


### PR DESCRIPTION
- Github workflows now execute CI with the additional --revision option, effectively building Elasticsearch from sources using a revision SHA and according to [Rally --revision rules](https://esrally.readthedocs.io/en/stable/command_line_reference.html#revision)
- es-version added to root directory which determine what is the value of the --revision argument that will be used in CI.