### PR TITLE
[9.2] [ES-13188] Update GH macOS hosted runner image (#883)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,11 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         os:
-          - macos-13
+          - macos-latest
           - ubuntu-latest
 
     runs-on: ${{ matrix.os }}
-    name: unit ${{ fromJson('{"macos-13":"macOS","ubuntu-latest":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }}
+    name: unit ${{ fromJson('{"macos-latest":"macOS","ubuntu-latest":"Ubuntu"}')[matrix.os] }} ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.2`:
 - [[ES-13188] Update GH macOS hosted runner image (#883)](https://github.com/elastic/rally-tracks/pull/883)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Grzegorz Banasiak","email":"grzegorz.banasiak@elastic.co"},"sourceCommit":{"committedDate":"2025-10-09T14:13:58Z","message":"[ES-13188] Update GH macOS hosted runner image (#883)","sha":"126a6831612845a99687d15b736182a9d7ad91e9","branchLabelMapping":{"^v(\\d{1,2})$":"$1","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.2"],"title":"[ES-13188] Update GH macOS hosted runner image","number":883,"url":"https://github.com/elastic/rally-tracks/pull/883","mergeCommit":{"message":"[ES-13188] Update GH macOS hosted runner image (#883)","sha":"126a6831612845a99687d15b736182a9d7ad91e9"}},"sourceBranch":"master","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->