### PR TITLE
Add 'Backport Pending' label whenever a PR merges with master

### DIFF
--- a/.github/scripts/backport-pending.py
+++ b/.github/scripts/backport-pending.py
@@ -43,9 +43,9 @@ def needs_pending_label(info: PRInfo) -> bool:
 
 def add_label(pr_number: int, label: str) -> None:
     repo = os.environ.get("GITHUB_REPOSITORY")
-    token = os.environ.get("label_token")
+    token = os.environ.get("BACKPORT_TOKEN")
     if not repo or not token:
-        print("::error::Missing GITHUB_REPOSITORY or label_token", file=sys.stderr)
+        print("::error::Missing GITHUB_REPOSITORY or BACKPORT_TOKEN", file=sys.stderr)
         sys.exit(1)
     owner, repo_name = repo.split("/", 1)
     # First ensure the label exists (create or update color/description)
@@ -102,7 +102,7 @@ Label a PR with 'Backport pending' if it has no version label.
 Expected environment:
   GITHUB_EVENT_PATH: Path to the event JSON (GitHub sets this automatically)
   GITHUB_REPOSITORY: owner/repo
-  label_token: token with repo:issues scope (use label_token or a PAT)
+  BACKPORT_TOKEN: token with repo:issues scope (use BACKPORT_TOKEN or a PAT)
 
 This script is idempotent: if the PR already has a version label (vX.Y) or already
 has the 'Backport Pending' label, it exits without error.

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,9 @@ on:
     branches: ['master']
     types: ["labeled", "closed"]
 
+env:
+  BACKPORT_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
+
 jobs:
   backport:
     name: Backport PR
@@ -17,13 +20,11 @@ jobs:
         uses: sorenlouv/backport-github-action@ad888e978060bc1b2798690dd9d03c4036560947  # v9.5.1
         continue-on-error: true
         with:
-          github_token: ${{ secrets.BACKPORT_TOKEN }}
+          github_token: $BACKPORT_TOKEN
       
       - uses: actions/checkout@v4
       - name: Label PR if needed
         run: python .github/scripts/backport-pending.py
-        env:
-          label_token: ${{ secrets.BACKPORT_TOKEN }}
 
       - name: Info log
         if: ${{ success() }}


### PR DESCRIPTION
We are adding the 'backport pending' label in the following conditions:

1. PR merges with master.
2. Has no 'backport' label.
3. Has no version label (vX.Y or vX).
4. Has no 'backport pending' label.