### PR TITLE
fix(msmarco-passage-ranking): Do not apply index settings in Serverless mode

### DIFF
--- a/msmarco-passage-ranking/msmarco-passage-ranking-collection.json
+++ b/msmarco-passage-ranking/msmarco-passage-ranking-collection.json
@@ -17,8 +17,10 @@
     },
     "settings": {
         "index": {
+            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
             "number_of_replicas": "{{number_of_replicas | default(0)}}",
             "number_of_shards": "{{number_of_shards | default(1)}}"
+            {%- endif -%}{# non-serverless-index-settings-marker-end #}
         }
     }
 }


### PR DESCRIPTION
## Overview

- This track does not respect Serverless mode, resulting in an erroneous index configuration when targeting a Serverless instance and near-100% failure during `bulk`.
- Implementation is borrowed from [similar in the `wikipedia` track](https://github.com/elastic/rally-tracks/blob/c1200c9b9fb2430afdcd222a183ef53b12385d4d/wikipedia/wikipedia-minimal-mapping.json#L4-L7).
- Tested on an existing load-driver by applying the patch directly to `~/.rally/benchmarks/tracks/default`, then running `esrally` with my track configuration. Index creation now succeeds, the expected mapping is applied, and documents are ingested as expected.

## Details

Before this patch, Rally will submit `PUT /msmarco-passage-ranking-collection` with a request body that includes `settings.index.number_of_shards` and `settings.index.number_of_replicas`. These parameters are invalid in Serverless mode, so this request predictably fails; however, Rally proceeds with the rest of the track anyways.

When the first document is pushed, Elasticsearch implicitly creates the index `msmarco-passage-ranking-collection` with dynamic fields. After ingesting around 4 to 5 documents from the track, all further documents will be rejected, as there would be more fields in the index than allowed (the default, 1000). The index mapping will look similar to the following:

```http
GET /msmarco-passage-ranking-collection
```

```json
{
  "msmarco-passage-ranking-collection": {
    "aliases": {},
    "mappings": {
      "properties": {
        "id": {
          "type": "text",
          "fields": {
            "keyword": {
              "type": "keyword",
              "ignore_above": 256
            }
          }
        },
        "text": {
          "type": "text",
          "fields": {
            "keyword": {
              "type": "keyword",
              "ignore_above": 256
            }
          }
        },
        "text_expansion_elser": {
          "properties": {
            "1004": {
              "type": "float"
            },
            "1020": {
              "type": "float"
            },
            "1037": {
              "type": "float"
            },
            "etc": {}
          }
        },
        "text_expansion_splade": {
          "properties": {
            "1004": {
              "type": "float"
            },
            "1011": {
              "type": "float"
            },
            "1012": {
              "type": "float"
            },
            "etc": {}
          }
        }
      }
    },
    "settings": {}
  }
}
```

---

After this patch, the track now properly supports Serverless mode. The `create-index` step succeeds, and the expected mapping is correctly applied:

```http
GET /msmarco-passage-ranking-collection
```

```json
{
  "msmarco-passage-ranking-collection": {
    "aliases": {},
    "mappings": {
      "properties": {
        "id": {
          "type": "keyword"
        },
        "text": {
          "type": "text"
        },
        "text_expansion_elser": {
          "type": "sparse_vector"
        },
        "text_expansion_splade": {
          "type": "sparse_vector"
        }
      }
    },
    "settings": {}
  }
}
```