### PR TITLE
Use default logsdb message template sort

### DIFF
--- a/elastic/logs/templates/component/auditbeat-mappings.json
+++ b/elastic/logs/templates/component/auditbeat-mappings.json
@@ -15,10 +15,7 @@
         "logsdb.route_on_sort_fields": true,
         {% endif %}
         {% if patterned_text_message_field | default(false) is true %}
-        "sort": {
-          "field": [ "host.name", "message.template_id", "@timestamp" ],
-          "order": [ "asc", "asc", "desc" ]
-        },
+        "logsdb.default_sort_on_message_template": true,
         {% endif %}
         {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
         "max_docvalue_fields_search": 200,

--- a/elastic/logs/templates/component/logs-apache.access@package.json
+++ b/elastic/logs/templates/component/logs-apache.access@package.json
@@ -15,10 +15,7 @@
           "logsdb.route_on_sort_fields": true,
           {% endif %}
           {% if patterned_text_message_field | default(false) is true %}
-          "sort": {
-            "field": [ "host.name", "message.template_id", "@timestamp" ],
-            "order": [ "asc", "asc", "desc" ]
-          },
+          "logsdb.default_sort_on_message_template": true,
           {% endif %}
           "mapping": {
             "total_fields": {

--- a/elastic/logs/templates/component/logs-apache.error@package.json
+++ b/elastic/logs/templates/component/logs-apache.error@package.json
@@ -15,10 +15,7 @@
           "logsdb.route_on_sort_fields": true,
           {% endif %}
           {% if patterned_text_message_field | default(false) is true %}
-          "sort": {
-            "field": [ "host.name", "message.template_id", "@timestamp" ],
-            "order": [ "asc", "asc", "desc" ]
-          },
+          "logsdb.default_sort_on_message_template": true,
           {% endif %}
           "mapping": {
             "total_fields": {

--- a/elastic/logs/templates/component/logs-kafka.log@package.json
+++ b/elastic/logs/templates/component/logs-kafka.log@package.json
@@ -15,10 +15,7 @@
           "logsdb.route_on_sort_fields": true,
           {% endif %}
           {% if patterned_text_message_field | default(false) is true %}
-          "sort": {
-            "field": [ "host.name", "message.template_id", "@timestamp" ],
-            "order": [ "asc", "asc", "desc" ]
-          },
+          "logsdb.default_sort_on_message_template": true,
           {% endif %}
           "mapping": {
             "total_fields": {

--- a/elastic/logs/templates/component/logs-mysql.error@package.json
+++ b/elastic/logs/templates/component/logs-mysql.error@package.json
@@ -15,10 +15,7 @@
           "logsdb.route_on_sort_fields": true,
           {% endif %}
           {% if patterned_text_message_field | default(false) is true %}
-          "sort": {
-            "field": [ "host.name", "message.template_id", "@timestamp" ],
-            "order": [ "asc", "asc", "desc" ]
-          },
+          "logsdb.default_sort_on_message_template": true,
           {% endif %}
           "mapping": {
             "total_fields": {

--- a/elastic/logs/templates/component/logs-mysql.slowlog@package.json
+++ b/elastic/logs/templates/component/logs-mysql.slowlog@package.json
@@ -15,10 +15,7 @@
           "logsdb.route_on_sort_fields": true,
           {% endif %}
           {% if patterned_text_message_field | default(false) is true %}
-          "sort": {
-            "field": [ "host.name", "message.template_id", "@timestamp" ],
-            "order": [ "asc", "asc", "desc" ]
-          },
+          "logsdb.default_sort_on_message_template": true,
           {% endif %}
           "mapping": {
             "total_fields": {

--- a/elastic/logs/templates/component/logs-nginx.error@package.json
+++ b/elastic/logs/templates/component/logs-nginx.error@package.json
@@ -15,10 +15,7 @@
           "logsdb.route_on_sort_fields": true,
           {% endif %}
           {% if patterned_text_message_field | default(false) is true %}
-          "sort": {
-            "field": [ "host.name", "message.template_id", "@timestamp" ],
-            "order": [ "asc", "asc", "desc" ]
-          },
+          "logsdb.default_sort_on_message_template": true,
           {% endif %}
           "mapping": {
             "total_fields": {

--- a/elastic/logs/templates/component/logs-postgresql.log@package.json
+++ b/elastic/logs/templates/component/logs-postgresql.log@package.json
@@ -15,10 +15,7 @@
           "logsdb.route_on_sort_fields": true,
           {% endif %}
           {% if patterned_text_message_field | default(false) is true %}
-          "sort": {
-            "field": [ "host.name", "message.template_id", "@timestamp" ],
-            "order": [ "asc", "asc", "desc" ]
-          },
+          "logsdb.default_sort_on_message_template": true,
           {% endif %}
           "mapping": {
             "total_fields": {

--- a/elastic/logs/templates/component/logs-redis.log@package.json
+++ b/elastic/logs/templates/component/logs-redis.log@package.json
@@ -15,10 +15,7 @@
           "logsdb.route_on_sort_fields": true,
           {% endif %}
           {% if patterned_text_message_field | default(false) is true %}
-          "sort": {
-            "field": [ "host.name", "message.template_id", "@timestamp" ],
-            "order": [ "asc", "asc", "desc" ]
-          },
+          "logsdb.default_sort_on_message_template": true,
           {% endif %}
           "mapping": {
             "total_fields": {

--- a/elastic/logs/templates/component/logs-redis.slowlog@package.json
+++ b/elastic/logs/templates/component/logs-redis.slowlog@package.json
@@ -15,10 +15,7 @@
           "logsdb.route_on_sort_fields": true,
           {% endif %}
           {% if patterned_text_message_field | default(false) is true %}
-          "sort": {
-            "field": [ "host.name", "message.template_id", "@timestamp" ],
-            "order": [ "asc", "asc", "desc" ]
-          },
+          "logsdb.default_sort_on_message_template": true,
           {% endif %}
           "mapping": {
             "total_fields": {

--- a/elastic/logs/templates/component/logs-system.auth@package.json
+++ b/elastic/logs/templates/component/logs-system.auth@package.json
@@ -15,10 +15,7 @@
           "logsdb.route_on_sort_fields": true,
           {% endif %}
           {% if patterned_text_message_field | default(false) is true %}
-          "sort": {
-            "field": [ "host.name", "message.template_id", "@timestamp" ],
-            "order": [ "asc", "asc", "desc" ]
-          },
+          "logsdb.default_sort_on_message_template": true,
           {% endif %}
           "mapping": {
             "total_fields": {

--- a/elastic/logs/templates/component/logs-system.syslog@package.json
+++ b/elastic/logs/templates/component/logs-system.syslog@package.json
@@ -15,10 +15,7 @@
           "logsdb.route_on_sort_fields": true,
           {% endif %}
           {% if patterned_text_message_field | default(false) is true %}
-          "sort": {
-            "field": [ "host.name", "message.template_id", "@timestamp" ],
-            "order": [ "asc", "asc", "desc" ]
-          },
+          "logsdb.default_sort_on_message_template": true,
           {% endif %}
           "mapping": {
             "total_fields": {

--- a/elastic/logs/templates/composable/logs-k8-application.log.json
+++ b/elastic/logs/templates/composable/logs-k8-application.log.json
@@ -31,10 +31,7 @@
         "logsdb.route_on_sort_fields": true
         {% endif %}
         {% if patterned_text_message_field | default(false) is true %},
-        "sort": {
-          "field": [ "host.name", "message.template_id", "@timestamp" ],
-          "order": [ "asc", "asc", "desc" ]
-        }
+        "logsdb.default_sort_on_message_template": true,
         {% endif %}
       }
     },


### PR DESCRIPTION
Use the mapping parameter added in elastic/elasticsearch#136571 to sort on `message.template_id` instead of manually specifying with `index.sort.fields`.

Relates to #825.