### PR TITLE
Add a benchmark for an ESQL agg on LENGTH

### DIFF
--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -390,4 +390,109 @@
           }
         }
       ]
+    },
+    {
+      "name": "esql",
+      "description": "Some ESQL commands",
+      "schedule": [
+        {
+          "tags": ["setup"],
+          "operation": "delete-index"
+        },
+        {
+          "tags": ["setup"],
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "tags": ["health"],
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "logs-*",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            },
+            "retry-until-success": true
+          }
+        },
+{%- if runtime_fields is defined %}
+        {
+          "tags": ["setup"],
+          "operation": "create-timestamp-pipeline"
+        },
+        {
+          "tags": ["index"],
+          "operation": "index-append-with-timestamp-pipeline",
+          "warmup-time-period": 240,
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+        },
+{%- else %}
+        {
+          "tags": ["index"],
+          "operation": "index-append",
+          "warmup-time-period": 240,
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+        },
+{%- endif %}
+        {
+          "name": "refresh-after-index",
+          "tags": ["index"],
+          "operation": "refresh"
+        },
+        {
+          "tags": ["index"],
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "tags": ["index"],
+          "operation": "refresh"
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "tags": ["index"],
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+{%- if runtime_fields is defined %}
+        {
+          "tags": ["esql"],
+          "operation": "esql-avg-message-keyword-length",
+          "warmup-iterations": 50,
+          "iterations": 10
+        },
+        {
+          "tags": ["esql"],
+          "name": "esql-avg-message-wildcard-length",
+          "operation": "esql-avg-message-length",
+          "warmup-iterations": 50,
+          "iterations": 10
+        }
+{%- else %}
+        {
+          "tags": ["esql"],
+          "name": "esql-avg-message-no-doc-values-length",
+          "operation": "esql-avg-message-length",
+          "warmup-iterations": 50,
+          "iterations": 10
+        }
+{%- endif %}
+      ]
     }

--- a/http_logs/operations/default.json
+++ b/http_logs/operations/default.json
@@ -502,4 +502,14 @@
         "field": "request.raw",
         "string": "GET image"
       }
+    },
+    {
+      "name": "esql-avg-message-length",
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS AVG(LENGTH(message))"
+    },
+    {
+      "name": "esql-avg-message-keyword-length",
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS AVG(LENGTH(message.keyword))"
     }


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/137382 we're pushing functions into field loading and using LENGTH as an example. This adds a rally track to demonstrate the performance difference:
```
| 90th | esql-avg-message-length | 11078 | 6670 | -4407.95 | ms | -39.79% |
```