### PR TITLE
Add new corpora for openai with vectors as base64 strings

### DIFF
--- a/openai_vector/README.md
+++ b/openai_vector/README.md
@@ -35,10 +35,12 @@ To rebuild the `queries.json.bz2` file:
 
 This track accepts the following parameters with Rally 0.8.0+ using `--track-params`:
 
+- initial_indexing_corpora (default: openai_initial_indexing_floats) : Use "openai_initial_indexing_base64"  for base64 encoded vectors. 
 - initial_indexing_bulk_size (default: 500)
 - initial_indexing_bulk_warmup (default: 40)
 - initial_indexing_bulk_indexing_clients (default: 5)
 - initial_indexing_ingest_percentage (default: 100)
+- parallel_indexing_corpora (default: openai_parallel_indexing_floats) : Use "openai_parallel_indexing_base64" for base64 encoded vectors.
 - parallel_indexing_bulk_size (default: 500)
 - parallel_indexing_bulk_clients (default: 1)
 - parallel_indexing_ingest_percentage (default: 100)

--- a/openai_vector/files.txt
+++ b/openai_vector/files.txt
@@ -1,4 +1,8 @@
 open_ai_corpus-initial-indexing.json.bz2
 open_ai_corpus-initial-indexing-1k.json.bz2
+open_ai_corpus-initial-indexing_base64.json.bz2
+open_ai_corpus-initial-indexing_base64-1k.json.bz2
 open_ai_corpus-parallel-indexing.json.bz2
 open_ai_corpus-parallel-indexing-1k.json.bz2
+open_ai_corpus-parallel-indexing_base64.json.bz2
+open_ai_corpus-parallel-indexing_base64-1k.json.bz2

--- a/openai_vector/operations/default.json
+++ b/openai_vector/operations/default.json
@@ -14,14 +14,14 @@
 {
   "name": "initial-documents-indexing",
   "operation-type": "bulk",
-  "corpora": "openai-initial-indexing",
+  "corpora": {{initial_indexing_corpora | default("openai_initial_indexing_floats") | tojson}},
   "bulk-size": {{initial_indexing_bulk_size | default(500)}},
   "ingest-percentage": {{initial_indexing_ingest_percentage | default(100)}}
 },
 {
   "name": "parallel-documents-indexing",
   "operation-type": "bulk",
-  "corpora": "openai-parallel-indexing",
+  "corpora": {{parallel_indexing_corpora | default("openai_parallel_indexing_floats") | tojson}},
   "bulk-size": {{parallel_indexing_bulk_size | default(500)}},
   "ingest-percentage": {{parallel_indexing_ingest_percentage | default(100)}}
 }

--- a/openai_vector/track.json
+++ b/openai_vector/track.json
@@ -11,7 +11,7 @@
   ],
   "corpora": [
     {
-      "name": "openai-initial-indexing",
+      "name": "openai_initial_indexing_floats",
       "base-url": "https://rally-tracks.elastic.co/openai_vector",
       "documents": [
         {
@@ -23,7 +23,19 @@
       ]
     },
     {
-      "name": "openai-parallel-indexing",
+      "name": "openai_initial_indexing_base64",
+      "base-url": "https://rally-tracks.elastic.co/openai_vector",
+      "documents": [
+        {
+          "source-file": "open_ai_corpus-initial-indexing_base64.json.bz2",
+          "document-count": 2580961,
+          "compressed-bytes": 16257545529,
+          "uncompressed-bytes": 22556467788
+        }
+      ]
+    },
+    {
+      "name": "openai_parallel_indexing_floats",
       "base-url": "https://rally-tracks.elastic.co/openai_vector",
       "documents": [
         {
@@ -31,6 +43,18 @@
           "document-count": 100000,
           "compressed-bytes": 1242787434,
           "uncompressed-bytes": 3497178196
+        }
+      ]
+    },
+    {
+      "name": "openai_parallel_indexing_base64",
+      "base-url": "https://rally-tracks.elastic.co/openai_vector",
+      "documents": [
+        {
+          "source-file": "open_ai_corpus-parallel-indexing_base64.json.bz2",
+          "document-count": 100000,
+          "compressed-bytes": 629857595,
+          "uncompressed-bytes": 873838981
         }
       ]
     }


### PR DESCRIPTION
Elasticsearch has recently introduced support for sending vectors as base64 encoded strings. This commit introduces a new corpora (data files have already been added to the GCP bucket) which contains the same openai_vector data sets but with vectors encoded as base64 strings.

In addition this commit introduces the parameters called initial_indexing_corpora and  parallel_indexing_corpora that allows to switch between the two existing datasets.