### PR TITLE
Add new corpora for dense_vector with vectors as base64 strings

### DIFF
--- a/dense_vector/README.md
+++ b/dense_vector/README.md
@@ -26,6 +26,7 @@ python3 _tools/parse.py data/learn.350M.fbin > documents.json
 
 This track accepts the following parameters with Rally 0.8.0+ using `--track-params`:
 
+* `corpora` (default :"dense_vector_floats") : Use "dense_vector_base64" for base64 encoded vectors.
 * `bulk_size` (default: 5000)
 * `bulk_indexing_clients` (default: 1): Number of clients that issue bulk indexing requests.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.

--- a/dense_vector/challenges/default.json
+++ b/dense_vector/challenges/default.json
@@ -27,6 +27,7 @@
       "name": "index-append",
       "operation": {
         "operation-type": "bulk",
+        "corpora" : {{corpora | default("dense_vector_floats") | tojson}},
         "bulk-size": {{bulk_size | default(5000)}},
         "ingest-percentage": 20
       },
@@ -72,6 +73,7 @@
             "name": "index-update-concurrent-with-searches",
             "operation": {
               "operation-type": "bulk",
+              "corpora" : {{corpora | default("dense_vector_floats") | tojson}},
               "bulk-size": 5000,
               "ingest-percentage": 5
             }

--- a/dense_vector/files.txt
+++ b/dense_vector/files.txt
@@ -1,2 +1,4 @@
 documents.json.bz2
+documents_base64.json.bz2
 documents-1k.json.bz2
+documents_base64-1k.json.bz2

--- a/dense_vector/track.json
+++ b/dense_vector/track.json
@@ -10,7 +10,7 @@
   ],
   "corpora": [
     {
-      "name": "dense-vector",
+      "name": "dense_vector_floats",
       "base-url": "https://rally-tracks.elastic.co/dense_vector",
       "documents": [
         {
@@ -18,6 +18,18 @@
           "document-count": 10000000,
           "compressed-bytes": 7689453829,
           "uncompressed-bytes": 20905226599
+        }
+      ]
+    },
+    {
+      "name": "dense_vector_base64",
+      "base-url": "https://rally-tracks.elastic.co/dense_vector",
+      "documents": [
+        {
+          "source-file": "documents_base64.json.bz2",
+          "document-count": 10000000,
+          "compressed-bytes": 3825272273,
+          "uncompressed-bytes": 5260000000
         }
       ]
     }


### PR DESCRIPTION
Elasticsearch has recently introduced support for sending vectors as base64 encoded strings. This commit introduces a new corpora (data files have already been added to the GCP bucket) which contains the same dense_vector data set but with vectors encoded as base64 strings.

In addition this commit introduces a new parameter called corpora that allows to switch between the two existing datasets.