### PR TITLE
fix: so_vector wait for merges after indexing

### DIFF
--- a/so_vector/challenges/default.json
+++ b/so_vector/challenges/default.json
@@ -466,7 +466,7 @@
       "operation": "refresh"
     },
     {
-      "name": "wait-until-merges-finish",
+      "name": "wait-until-force-merges-finish",
       "operation": {
         "operation-type": "index-stats",
         "index": "_all",


### PR DESCRIPTION
Adding a wait so that potential merges from indexing as well as merges after a forcemerge have finished