### PR TITLE
chore: add iterations to so_vector

### DIFF
--- a/so_vector/README.md
+++ b/so_vector/README.md
@@ -72,6 +72,8 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `include_force_merge` (default: true for non-serverless clusters, false for serverless clusters): Whether to include force merge operation.
 * `vector_index_type` (default: "bbq_hnsw"): The index kind for storing the vectors.
 * `corpora` (default: "so_vector_float"): The dataset to use. The default data set represents vectors as float arrays. Use "so_vector_base64" for the same dataset with vectors encoded as base64 strings.
+* `warmup_iterations` (default: 100) - Number of iterations that each client should execute to warmup the benchmark candidate.
+* `iterations` (default: 100) - Number of measurement iterations that each client executes.
 
 ### License
 We use the same license for the data as the original data: [CC-SA-4.0](http://creativecommons.org/licenses/by-sa/4.0/).

--- a/so_vector/challenges/default.json
+++ b/so_vector/challenges/default.json
@@ -66,8 +66,8 @@
       "name": "knn-search-default-match-all",
       "tags": ["search"],
       "operation": "knn-search-default-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -82,8 +82,8 @@
       "name": "knn-search-10-50-match-all",
       "tags": ["search"],
       "operation": "knn-search-10-50-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -98,8 +98,8 @@
       "name": "knn-search-100-300-match-all",
       "tags": ["search"],
       "operation": "knn-search-100-300-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -114,16 +114,16 @@
       "name": "script-score-query-match-all",
       "tags": ["search"],
       "operation": "script-score-query-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "knn-search-10-50-acceptedAnswerId",
       "tags": ["search"],
       "operation": "knn-search-10-50-acceptedAnswerId",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -138,16 +138,16 @@
       "name": "script-score-query-acceptedAnswerId",
       "tags": ["search"],
       "operation": "script-score-query-acceptedAnswerId",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "knn-search-10-50-java",
       "tags": ["search"],
       "operation": "knn-search-10-50-java",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -162,24 +162,24 @@
       "name": "script-score-query-java",
       "tags": ["search"],
       "operation": "script-score-query-java",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "script-score-query-javascript",
       "tags": ["search"],
       "operation": "script-score-query-javascript",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "knn-search-10-50-css",
       "tags": ["search"],
       "operation": "knn-search-10-50-css",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -194,16 +194,16 @@
       "name": "script-score-query-css",
       "tags": ["search"],
       "operation": "script-score-query-css",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "knn-search-10-50-concurrency",
       "tags": ["search"],
       "operation": "knn-search-10-50-concurrency",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -218,16 +218,16 @@
       "name": "script-score-query-concurrency",
       "tags": ["search"],
       "operation": "script-score-query-concurrency",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "knn-search-10-50-random-10-percent",
       "tags": ["search"],
       "operation": "knn-search-10-50-random-10-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -242,8 +242,8 @@
       "name": "knn-search-default-random-20-percent",
       "tags": ["search"],
       "operation": "knn-search-default-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -258,8 +258,8 @@
       "name": "knn-search-10-50-random-20-percent",
       "tags": ["search"],
       "operation": "knn-search-10-50-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -274,8 +274,8 @@
       "name": "knn-search-100-300-random-10-percent",
       "tags": ["search"],
       "operation": "knn-search-100-300-random-10-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -290,8 +290,8 @@
       "name": "knn-search-100-300-random-20-percent",
       "tags": ["search"],
       "operation": "knn-search-100-300-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -307,144 +307,144 @@
       "name": "esql-knn-search-default-match-all",
       "tags": ["search"],
       "operation": "esql-knn-search-default-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-match-all",
       "tags": ["search"],
       "operation": "esql-knn-search-10-50-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-100-300-match-all",
       "tags": ["search"],
       "operation": "esql-knn-search-100-300-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-script-score-query-match-all",
       "tags": ["search"],
       "operation": "esql-script-score-query-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-acceptedAnswerId",
       "tags": ["search"],
       "operation": "esql-knn-search-10-50-acceptedAnswerId",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-script-score-query-acceptedAnswerId",
       "tags": ["search"],
       "operation": "esql-script-score-query-acceptedAnswerId",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-java",
       "tags": ["search"],
       "operation": "esql-knn-search-10-50-java",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-script-score-query-java",
       "tags": ["search"],
       "operation": "esql-script-score-query-java",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-script-score-query-javascript",
       "tags": ["search"],
       "operation": "esql-script-score-query-javascript",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-css",
       "tags": ["search"],
       "operation": "esql-knn-search-10-50-css",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-script-score-query-css",
       "tags": ["search"],
       "operation": "esql-script-score-query-css",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-concurrency",
       "tags": ["search"],
       "operation": "esql-knn-search-10-50-concurrency",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-script-score-query-concurrency",
       "tags": ["search"],
       "operation": "esql-script-score-query-concurrency",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-random-10-percent",
       "tags": ["search"],
       "operation": "esql-knn-search-10-50-random-10-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-default-random-20-percent",
       "tags": ["search"],
       "operation": "esql-knn-search-default-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-random-20-percent",
       "tags": ["search"],
       "operation": "esql-knn-search-10-50-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-100-300-random-10-percent",
       "tags": ["search"],
       "operation": "esql-knn-search-100-300-random-10-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-100-300-random-20-percent",
       "tags": ["search"],
       "operation": "esql-knn-search-100-300-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     }
 {% endif %}
@@ -483,8 +483,8 @@
       "name": "knn-search-default-match-all-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-default-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -499,8 +499,8 @@
       "name": "knn-search-10-50-match-all-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -515,8 +515,8 @@
       "name": "knn-search-100-300-match-all-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-100-300-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -531,8 +531,8 @@
       "name": "knn-search-10-50-acceptedAnswerId-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-acceptedAnswerId",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -547,8 +547,8 @@
       "name": "knn-search-10-50-java-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-java",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -563,8 +563,8 @@
       "name": "knn-search-10-50-css-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-css",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -587,16 +587,16 @@
       "name": "knn-search-10-50-concurrency-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-concurrency",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "knn-search-10-50-random-10-percent-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-random-10-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -611,8 +611,8 @@
       "name": "knn-search-default-random-20-percent-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-default-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -627,8 +627,8 @@
       "name": "knn-search-10-50-random-20-percent-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -643,8 +643,8 @@
       "name": "knn-search-100-300-random-10-percent-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-100-300-random-10-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -659,8 +659,8 @@
       "name": "knn-search-100-300-random-20-percent-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "knn-search-100-300-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
@@ -676,96 +676,96 @@
       "name": "esql-knn-search-default-match-all-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-default-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-match-all-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-100-300-match-all-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-100-300-match-all",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-acceptedAnswerId-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-acceptedAnswerId",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-java-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-java",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-css-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-css",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-concurrency-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-concurrency",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-random-10-percent-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-random-10-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esq-knn-search-default-random-20-percent-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-default-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-10-50-random-20-percent-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-100-300-random-10-percent-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-100-300-random-10-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     },
     {
       "name": "esql-knn-search-100-300-random-20-percent-force-merge",
       "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-100-300-random-20-percent",
-      "warmup-iterations": 100,
-      "iterations": 100,
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(100) }},
       "clients": 1
     }
 {% endif %}

--- a/wikipedia/README.md
+++ b/wikipedia/README.md
@@ -122,6 +122,20 @@ When `as_search_target_throughputs` is a positive number, the search throughput 
 When `as_ingest_target_throughputs` is a positive number, the ingest throughput formula in documents per second is `ingest_bulk_size * as_ingest_target_throughputs`.
 When `as_search_target_throughputs` is a positive number, the search throughput formula in documents per second is `search_size * as_search_target_throughputs`.
 
+### Parameters for esql-full-text-functions challenge 
+
+- Initial indexing:
+  - `initial_indexing_bulk_clients` (default: `5`)
+  - `initial_indexing_bulk_size` (default: `500`)
+  - `initial_indexing_ingest_percentage` (default: `100`)
+  - `initial_indexing_bulk_warmup_time_period` (default: `40` )
+
+- Search Operations:
+  - `standalone_search_clients` (default: `20`)
+  - `warmup_iterations` (default: 100) - Number of iterations that each client should execute to warmup the benchmark candidate.
+  - `iterations` (default: 100) - Number of measurement iterations that each client executes.
+
+
 ### License
 
 We use the same license for the data as the original data: [CC-SA-3.0](http://creativecommons.org/licenses/by-sa/3.0/).


### PR DESCRIPTION
This PR
- makes iterations in the so_vector track configurable via `--track-params`
- updates Wikipedia README.md file to include iterations for the ES|QL challenges