### PR TITLE
Restore continue-on-error in backporting job to avoid total workflow errors

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@ad888e978060bc1b2798690dd9d03c4036560947  # v9.5.1
+        continue-on-error: true
         with:
           github_token: ${{ secrets.BACKPORT_TOKEN }}
 


### PR DESCRIPTION
Reapplying [continue-on-error](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepscontinue-on-error) property to avoid job and workflow failure on cases where backporting is expected to trigger and fail. In these cases, Backport worfklow should not mark the total CI as failed.

We removed it for accessing debug logs of the backport action, which are obfuscated by this property. Enabling debug logs on failure cannot happen at the moment this PR merges and this needs to be fixed in the future