### PR TITLE
Add settings for GPU vector indexing

### DIFF
--- a/dense_vector/README.md
+++ b/dense_vector/README.md
@@ -35,3 +35,5 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
 * `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
 * `vector_index_type` (default: "int8_hnsw"): The index kind for storing the vectors.
+* `use_gpu_indexing` (default: "auto"): Whether to use GPU for vector indexing. Can be set to `true` or `false`.
+* `merge_scheduler_auto_throttle` (default: false): Whether to enable automatic throttling for the merge scheduler. Can be set to `true`.

--- a/dense_vector/index.json
+++ b/dense_vector/index.json
@@ -2,6 +2,8 @@
   "settings": {
     "index": {
       {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      "vectors.indexing.use_gpu": {{ use_gpu_indexing | default("auto") | tojson }},
+      "merge.scheduler.auto_throttle" : {{ merge_scheduler_auto_throttle | default(false) | tojson }},
       "number_of_shards": {{ number_of_shards | default(2) }},
       "number_of_replicas": {{ number_of_replicas | default(0) }}
       {%- endif -%}{# non-serverless-index-settings-marker-end #}

--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -83,6 +83,8 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - `search_ops` (default: [(10, 20, 0), (10, 20, 20), (10, 50, 0), (10, 50, 20), (10, 100, 0), (10, 100, 20), (10, 200, 0), (10, 200, 20), (10, 500, 0), (10, 500, 20), (10, 1000, 0), (10, 1000, 20), (100, 120, 0), (100, 120, 120), (100, 200, 0), (100, 200, 120), (100, 500, 0), (100, 500, 120), (100, 1000, 0), (100, 1000, 120)]): The search and recall operations to run (k, ef_search, num_rescore).
  - `standalone_search_iterations` (default: 10000)
  - `vector_index_type` (default: "int8_hnsw"): The index kind for storing the vectors.
+ - `use_gpu_indexing` (default: "auto"): Whether to use GPU for vector indexing. Can be set to `true` or `false`.
+ - `merge_scheduler_auto_throttle` (default: false): Whether to enable automatic throttling for the merge scheduler. Can be set to `true`.
 
 ### Parameters for ingest-autoscale challenge
 

--- a/msmarco-v2-vector/index-vectors-only-mapping.json
+++ b/msmarco-v2-vector/index-vectors-only-mapping.json
@@ -8,6 +8,8 @@
       {% if preload_pagecache %}
       "store.preload": [ "vec", "vex", "vem"],
       {% endif %}
+      "vectors.indexing.use_gpu": {{ use_gpu_indexing | default("auto") | tojson }},
+      "merge.scheduler.auto_throttle" : {{ merge_scheduler_auto_throttle | default(false) | tojson }},
       "number_of_shards": {{number_of_shards | default(1)}},
       "number_of_replicas": {{number_of_replicas | default(0)}}
       {% if aggressive_merge_policy %},

--- a/openai_vector/README.md
+++ b/openai_vector/README.md
@@ -54,6 +54,8 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 - standalone_search_iterations (default: 10000)
 - vector_index_type (default: "hnsw"): The index kind for storing the vectors.
 - search_ops (default: [[10, 20, 0], [10, 20, 1], [10, 20, 2], [10, 50, 1], [10, 50, 2], [10, 100, 1], [100, 120, 1], [100, 120, 2], [100, 200, 1], [100, 200, 2], [100, 500, 1], [100, 500, 2]]): The vector search operations, formattied [k, num_candidates, oversample], where `oversample` indicates the ratio of extra `k` to gather and then rescore.
+- `use_gpu_indexing` (default: "auto"): Whether to use GPU for vector indexing. Can be set to `true` or `false`.
+- `merge_scheduler_auto_throttle` (default: false): Whether to enable automatic throttling for the merge scheduler. Can be set to `true`.
 
 ### License
 

--- a/openai_vector/index-vectors-only-with-docid-mapping.json
+++ b/openai_vector/index-vectors-only-with-docid-mapping.json
@@ -4,6 +4,8 @@
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],
       {% endif %}
+    "index.vectors.indexing.use_gpu": {{ use_gpu_indexing | default("auto") | tojson }},
+    "index.merge.scheduler.auto_throttle" : {{ merge_scheduler_auto_throttle | default(false) | tojson }},
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
     {%- endif -%}{# non-serverless-index-settings-marker-end #}

--- a/so_vector/README.md
+++ b/so_vector/README.md
@@ -74,6 +74,8 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `corpora` (default: "so_vector_float"): The dataset to use. The default data set represents vectors as float arrays. Use "so_vector_base64" for the same dataset with vectors encoded as base64 strings.
 * `warmup_iterations` (default: 100) - Number of iterations that each client should execute to warmup the benchmark candidate.
 * `iterations` (default: 100) - Number of measurement iterations that each client executes.
+* `use_gpu_indexing` (default: "auto"): Whether to use GPU for vector indexing. Can be set to `true` or `false`.
+* `merge_scheduler_auto_throttle` (default: false): Whether to enable automatic throttling for the merge scheduler. Can be set to `true`.
 
 ### License
 We use the same license for the data as the original data: [CC-SA-4.0](http://creativecommons.org/licenses/by-sa/4.0/).

--- a/so_vector/index.json
+++ b/so_vector/index.json
@@ -4,6 +4,8 @@
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {% if p_include_non_serverless_index_settings %}
+    "index.vectors.indexing.use_gpu": {{ use_gpu_indexing | default("auto") | tojson }},
+    "index.merge.scheduler.auto_throttle" : {{ merge_scheduler_auto_throttle | default(false) | tojson }},
     "index.number_of_shards": {{number_of_shards | default(2)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
       {% endif %}


### PR DESCRIPTION
Introduce new Rally track params for vector indexing configuration

Add `use_gpu_indexing` (default: "auto") to control "index.vectors.indexing.use_gpu" 
and `merge_scheduler_auto_throttle` (default: false) to control "index.merge.scheduler.auto_throttle" 
across dense_vector, msmarco-v2-vector, openai_vector, and so_vector tracks.

---

Draft PR for now as "index.vectors.indexing.use_gpu" is currently only enabled under Feature flag.

For GPU indexing pass the following `params.json` file  to a rally run:

params.json
```js
{
  "use_gpu_indexing" : true,
  "merge_scheduler_auto_throttle": true,
   <corpora_params> : <use base 64 encode corpora>, 
}
```

./rally race ...--runtime-jdk=25 --track-params=<.../params.json> --on-error=abort

---
### Notes
- use base64 encoded vectors for much faster indexing. For example, for `openai_vector` track, add the following params in params.json: 
```js
 "initial_indexing_corpora" : "openai_initial_indexing_base64",  
 "parallel_indexing_corpora": "openai_parallel_indexing_base64"
```

- "use_gpu_indexing" : true enforces using GPU for indexing, and if GPU and its libraries are not visible to Elasticsearch, the benchmark will fail
- runtime-jdk should be at least 22
- LD_LIBRARY_PATH should be defined and set in rally.ini

vim ~/.rally/rally.ini
```bashrc
...
[system]
env.name = local
passenv = PATH,LD_LIBRARY_PATH

```

---
#### Example running openai_vector track:

params.json
```js
{
  "use_gpu_indexing" : true,
  "merge_scheduler_auto_throttle": true,
  "initial_indexing_corpora" : "openai_initial_indexing_base64",  
  "parallel_indexing_corpora": "openai_parallel_indexing_base64",
   "mapping_type" : "vectors-only-with-docid"
}
```

```
./rally race --track-path /home/ubuntu/elastic/rally-tracks/openai_vector \
--pipeline from-sources \
--revision current \
--car "16gheap" \
--user-tags "tag:openai_vector_gpu" \
--report-file /home/ubuntu/elastic/benchmarks/rally_results/openai_vector_gpu.md \
--runtime-jdk=25   \
--track-params=/home/mayya/Elastic/benchmarks/rally/params.json \
--on-error=abort
```


---

### Troubleshoot
- Check ~/.rally/benchmarks/races/<raceID> /rally-node-0/logs/server/rally-benchmark.log. If you see similar output in the elasticsearch server logs:
[o.e.x.g.GPUSupport       ] [elasticsearch-0] Found compatible GPU [NVIDIA L4] (id: [0])

it means your setup is successful, and Elasticsearch can use GPU. If you don’t see this line from GPUSupport, you should see an explanation why elasticsearch can’t use your GPU device.




