### PR TITLE
CI determines Elasticsearch build arguments using unified job in gh workflow [stateful]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           if [[ "${{ steps.es-version.outputs.version }}" != "current" && "${{ steps.es-version.outputs.version }}" != "latest" ]]; then
             echo "release_build=" >> $GITHUB_ENV
           else
-            echo "release_build= --use-release" >> $GITHUB_ENV
+            echo "release_build= --source-build-release" >> $GITHUB_ENV
           fi
       - name: "Show revision argument"
         if: ${{ steps.revision-argument.outputs.revision != '' }}


### PR DESCRIPTION
- determine-es-revision job was changed to determine-es-build job that now configures the --source-build-release argument together with the --revision argument if the es-version file contents is equal to 'latest' or 'current'
- show determined arguments in the respective jobs for easy debug