### PR TITLE
Add use_doc_values_skipper param to tsdb/index.json

### DIFF
--- a/tsdb/index-template.json
+++ b/tsdb/index-template.json
@@ -32,7 +32,7 @@
           "synthetic_source_keep": "{{synthetic_source_keep}}",
           {% endif %}
           {% if use_doc_values_skipper is defined %}
-          "use_doc_values_skipper" : "{{use_doc_values_skipper}}",
+          "use_doc_values_skipper" : {{ use_doc_values_skipper | tojson }},
           {% endif %}
           "total_fields.limit": 10000
           {% if p_include_source_mode %},

--- a/tsdb/index.json
+++ b/tsdb/index.json
@@ -40,7 +40,7 @@
         "synthetic_source_keep": "{{synthetic_source_keep}}",
         {% endif %}
         {% if use_doc_values_skipper is defined %}
-        "use_doc_values_skipper": "{{use_doc_values_skipper}}",
+        "use_doc_values_skipper": {{ use_doc_values_skipper | tojson }},
         {% endif %}
         "total_fields.limit": 10000
         {% if p_include_source_mode %},


### PR DESCRIPTION
#923 added a new parameter to the index template file, but it needs
to also be defined in index.json