### PR TITLE
[9.2] Fix an error where ci arguments were not applied properly (#928)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,10 @@ jobs:
       - name: "Determine ES release or snapshot"
         id: release-build-argument
         run: |
-          if [[ "${{ steps.es-version.outputs.version }}" != "current" && "${{ steps.es-version.outputs.version }}" != "latest" ]]; then
-            echo "release_build=" >> $GITHUB_ENV
+          if [[ "${{ steps.es-version.outputs.version }}" == "current" || "${{ steps.es-version.outputs.version }}" == "latest" ]]; then
+            echo "release_build=" >> $GITHUB_OUTPUT
           else
-            echo "release_build= --source-build-release" >> $GITHUB_ENV
+            echo "release_build= --source-build-release" >> $GITHUB_OUTPUT
           fi
       - name: "Show revision argument"
         if: ${{ steps.revision-argument.outputs.revision != '' }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.2`:
 - [Fix an error where ci arguments were not applied properly (#928)](https://github.com/elastic/rally-tracks/pull/928)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Dris","email":"nick.dris@elastic.co"},"sourceCommit":{"committedDate":"2025-11-21T13:31:20Z","message":"Fix an error where ci arguments were not applied properly (#928)\n\n* Fix an error where ci arguments were not applied properly\n\n* Test the change\n\n* Test failed retry with another fix\n\n* Previous fix failed retry\n\n* Revert es-version to current\n\n* Keep the indents if if/else","sha":"76ce30ed4f7b2aa2c75ff5a57f03a81567b260dd","branchLabelMapping":{"^v(\\d{1,2})$":"$1","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.2"],"title":"Fix an error where ci arguments were not applied properly","number":928,"url":"https://github.com/elastic/rally-tracks/pull/928","mergeCommit":{"message":"Fix an error where ci arguments were not applied properly (#928)\n\n* Fix an error where ci arguments were not applied properly\n\n* Test the change\n\n* Test failed retry with another fix\n\n* Previous fix failed retry\n\n* Revert es-version to current\n\n* Keep the indents if if/else","sha":"76ce30ed4f7b2aa2c75ff5a57f03a81567b260dd"}},"sourceBranch":"master","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->