### PR TITLE
[9.2] Align tags in HTTP Logs and SO Vector (#890)

### DIFF
--- a/http_logs/challenges/common/default-schedule.json
+++ b/http_logs/challenges/common/default-schedule.json
@@ -1,7 +1,9 @@
         {
+          "tags": ["setup"],
           "operation": "delete-index"
         },
         {
+          "tags": ["setup"],
           "operation": {
             "operation-type": "create-index",
             "settings": {{index_settings | default({}) | tojson}}
@@ -9,6 +11,7 @@
         },
         {
           "name": "check-cluster-health",
+          "tags": ["health"],
           "operation": {
             "operation-type": "cluster-health",
             "index": "logs-*",
@@ -21,9 +24,11 @@
         },
 {%- if runtime_fields is defined %}
         {
+          "tags": ["setup"],
           "operation": "create-timestamp-pipeline"
         },
         {
+          "tags": ["index"],
           "operation": "index-append-with-timestamp-pipeline",
           "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}},
@@ -31,6 +36,7 @@
         },
 {%- else %}
         {
+          "tags": ["index"],
           "operation": "index-append",
           "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}},
@@ -39,9 +45,11 @@
 {%- endif %}
         {
           "name": "refresh-after-index",
+          "tags": ["index"],
           "operation": "refresh"
         },
         {
+          "tags": ["index"],
           "operation": {
             "operation-type": "force-merge",
             "request-timeout": 7200{%- if force_merge_max_num_segments is defined %},
@@ -51,10 +59,12 @@
         },
         {
           "name": "refresh-after-force-merge",
+          "tags": ["index"],
           "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
+          "tags": ["index"],
           "operation": {
             "operation-type": "index-stats",
             "index": "_all",
@@ -69,6 +79,7 @@
         {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
         {
           "name": "post-ingest-sleep",
+          "tags": ["index"],
           "operation": {
             "operation-type": "sleep",
             "duration": {{ post_ingest_sleep_duration|default(30) }}
@@ -76,24 +87,26 @@
         },
         {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
+          "tags": ["search"],
           "operation": "default",
           "warmup-iterations": 500,
           "iterations": 100,
           "target-throughput": 20
         },
 {%- if runtime_fields is defined %}
-        { "operation": "term", "name": "term-from-source-using-grok",       "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["term", "from-source",   "using-grok"] },
-        { "operation": "term", "name": "term-from-keyword-using-grok",      "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["term", "from-keyword",  "using-grok"] },
-        { "operation": "term", "name": "term-from-wildcard-using-grok",     "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["term", "from-wildcard", "using-grok"] },
-        { "operation": "term", "name": "term-from-source-using-dissect",    "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["term", "from-source",   "using-dissect"] },
-        { "operation": "term", "name": "term-from-keyword-using-dissect",   "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["term", "from-wildcard", "using-dissect"] },
-        { "operation": "term", "name": "term-from-wildcard-using-dissect",  "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["term", "from-wildcard", "using-dissect"] },
-        { "operation": "term", "name": "term-from-source-using-index-of",   "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["term", "from-source",   "using-index-of"] },
-        { "operation": "term", "name": "term-from-keyword-using-index-of",  "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["term", "from-keyword",  "using-index-of"] },
-        { "operation": "term", "name": "term-from-wildcard-using-index-of", "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["term", "from-wildcard", "using-index-of"] },
+        { "operation": "term", "name": "term-from-source-using-grok",       "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["search", "term", "from-source",   "using-grok"] },
+        { "operation": "term", "name": "term-from-keyword-using-grok",      "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["search", "term", "from-keyword",  "using-grok"] },
+        { "operation": "term", "name": "term-from-wildcard-using-grok",     "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["search", "term", "from-wildcard", "using-grok"] },
+        { "operation": "term", "name": "term-from-source-using-dissect",    "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["search", "term", "from-source",   "using-dissect"] },
+        { "operation": "term", "name": "term-from-keyword-using-dissect",   "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["search", "term", "from-wildcard", "using-dissect"] },
+        { "operation": "term", "name": "term-from-wildcard-using-dissect",  "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["search", "term", "from-wildcard", "using-dissect"] },
+        { "operation": "term", "name": "term-from-source-using-index-of",   "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["search", "term", "from-source",   "using-index-of"] },
+        { "operation": "term", "name": "term-from-keyword-using-index-of",  "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["search", "term", "from-keyword",  "using-index-of"] },
+        { "operation": "term", "name": "term-from-wildcard-using-index-of", "warmup-iterations": 50, "iterations": 10, "target-throughput": 0.01, "tags": ["search", "term", "from-wildcard", "using-index-of"] },
 {%- else %}
         {
           "name": "term",
+          "tags": ["search"],
           "operation": "term",
           "warmup-iterations": 500,
           "iterations": 100,
@@ -102,44 +115,48 @@
 {%- endif %}
         {
           "name": "terms_enum",
+          "tags": ["search"],
           "operation": "terms_enum",
           "warmup-iterations": 500,
           "iterations": 100,
           "target-throughput": 50
         },  
         {
+          "tags": ["search"],
           "operation": "range",
           "warmup-iterations": 100,
           "iterations": 100,
           "target-throughput": 25
         },
 {%- if runtime_fields is defined %}
-        { "operation": "200s-in-range", "name": "200s-in-range-from-source-using-grok",       "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-source",   "using-grok"] },
-        { "operation": "200s-in-range", "name": "200s-in-range-from-keyword-using-grok",      "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-keyword",  "using-grok"] },
-        { "operation": "200s-in-range", "name": "200s-in-range-from-wildcard-using-grok",     "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-wildcard", "using-grok"] },
-        { "operation": "200s-in-range", "name": "200s-in-range-from-source-using-dissect",    "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-source",   "using-dissect"] },
-        { "operation": "200s-in-range", "name": "200s-in-range-from-keyword-using-dissect",   "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-wildcard", "using-dissect"] },
-        { "operation": "200s-in-range", "name": "200s-in-range-from-wildcard-using-dissect",  "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-wildcard", "using-dissect"] },
-        { "operation": "200s-in-range", "name": "200s-in-range-from-source-using-index-of",   "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-source",   "using-index-of"] },
-        { "operation": "200s-in-range", "name": "200s-in-range-from-keyword-using-index-of",  "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-keyword",  "using-index-of"] },
-        { "operation": "200s-in-range", "name": "200s-in-range-from-wildcard-using-index-of", "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["200s-in-range", "from-wildcard", "using-index-of"] },
-        { "operation": "400s-in-range", "name": "400s-in-range-from-source-using-grok",       "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.2, "tags": ["400s-in-range", "from-source",   "using-grok"] },
-        { "operation": "400s-in-range", "name": "400s-in-range-from-keyword-using-grok",      "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.3, "tags": ["400s-in-range", "from-keyword",  "using-grok"] },
-        { "operation": "400s-in-range", "name": "400s-in-range-from-wildcard-using-grok",     "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.3, "tags": ["400s-in-range", "from-wildcard", "using-grok"] },
-        { "operation": "400s-in-range", "name": "400s-in-range-from-source-using-dissect",    "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.5, "tags": ["400s-in-range", "from-source",   "using-dissect"] },
-        { "operation": "400s-in-range", "name": "400s-in-range-from-keyword-using-dissect",   "warmup-iterations": 100, "iterations": 100, "target-throughput": 1,   "tags": ["400s-in-range", "from-wildcard", "using-dissect"] },
-        { "operation": "400s-in-range", "name": "400s-in-range-from-wildcard-using-dissect",  "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.3, "tags": ["400s-in-range", "from-wildcard", "using-dissect"] },
-        { "operation": "400s-in-range", "name": "400s-in-range-from-source-using-index-of",   "warmup-iterations": 100, "iterations": 100, "target-throughput": 1,   "tags": ["400s-in-range", "from-source",   "using-index-of"] },
-        { "operation": "400s-in-range", "name": "400s-in-range-from-keyword-using-index-of",  "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.3, "tags": ["400s-in-range", "from-keyword",  "using-index-of"] },
-        { "operation": "400s-in-range", "name": "400s-in-range-from-wildcard-using-index-of", "warmup-iterations": 100, "iterations": 100, "target-throughput": 4,   "tags": ["400s-in-range", "from-wildcard", "using-index-of"] },
+        { "operation": "200s-in-range", "name": "200s-in-range-from-source-using-grok",       "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["search", "200s-in-range", "from-source",   "using-grok"] },
+        { "operation": "200s-in-range", "name": "200s-in-range-from-keyword-using-grok",      "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["search", "200s-in-range", "from-keyword",  "using-grok"] },
+        { "operation": "200s-in-range", "name": "200s-in-range-from-wildcard-using-grok",     "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["search", "200s-in-range", "from-wildcard", "using-grok"] },
+        { "operation": "200s-in-range", "name": "200s-in-range-from-source-using-dissect",    "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["search", "200s-in-range", "from-source",   "using-dissect"] },
+        { "operation": "200s-in-range", "name": "200s-in-range-from-keyword-using-dissect",   "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["search", "200s-in-range", "from-wildcard", "using-dissect"] },
+        { "operation": "200s-in-range", "name": "200s-in-range-from-wildcard-using-dissect",  "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["search", "200s-in-range", "from-wildcard", "using-dissect"] },
+        { "operation": "200s-in-range", "name": "200s-in-range-from-source-using-index-of",   "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["search", "200s-in-range", "from-source",   "using-index-of"] },
+        { "operation": "200s-in-range", "name": "200s-in-range-from-keyword-using-index-of",  "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["search", "200s-in-range", "from-keyword",  "using-index-of"] },
+        { "operation": "200s-in-range", "name": "200s-in-range-from-wildcard-using-index-of", "warmup-iterations": 100, "iterations": 100, "target-throughput": 5,   "tags": ["search", "200s-in-range", "from-wildcard", "using-index-of"] },
+        { "operation": "400s-in-range", "name": "400s-in-range-from-source-using-grok",       "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.2, "tags": ["search", "400s-in-range", "from-source",   "using-grok"] },
+        { "operation": "400s-in-range", "name": "400s-in-range-from-keyword-using-grok",      "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.3, "tags": ["search", "400s-in-range", "from-keyword",  "using-grok"] },
+        { "operation": "400s-in-range", "name": "400s-in-range-from-wildcard-using-grok",     "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.3, "tags": ["search", "400s-in-range", "from-wildcard", "using-grok"] },
+        { "operation": "400s-in-range", "name": "400s-in-range-from-source-using-dissect",    "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.5, "tags": ["search", "400s-in-range", "from-source",   "using-dissect"] },
+        { "operation": "400s-in-range", "name": "400s-in-range-from-keyword-using-dissect",   "warmup-iterations": 100, "iterations": 100, "target-throughput": 1,   "tags": ["search", "400s-in-range", "from-wildcard", "using-dissect"] },
+        { "operation": "400s-in-range", "name": "400s-in-range-from-wildcard-using-dissect",  "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.3, "tags": ["search", "400s-in-range", "from-wildcard", "using-dissect"] },
+        { "operation": "400s-in-range", "name": "400s-in-range-from-source-using-index-of",   "warmup-iterations": 100, "iterations": 100, "target-throughput": 1,   "tags": ["search", "400s-in-range", "from-source",   "using-index-of"] },
+        { "operation": "400s-in-range", "name": "400s-in-range-from-keyword-using-index-of",  "warmup-iterations": 100, "iterations": 100, "target-throughput": 0.3, "tags": ["search", "400s-in-range", "from-keyword",  "using-index-of"] },
+        { "operation": "400s-in-range", "name": "400s-in-range-from-wildcard-using-index-of", "warmup-iterations": 100, "iterations": 100, "target-throughput": 4,   "tags": ["search", "400s-in-range", "from-wildcard", "using-index-of"] },
 {%- else %}
         {
+          "tags": ["search"],
           "operation": "200s-in-range",
           "warmup-iterations": 500,
           "iterations": 100,
           "target-throughput": 25
         },
         {
+          "tags": ["search"],
           "operation": "400s-in-range",
           "warmup-iterations": 500,
           "iterations": 100,
@@ -147,12 +164,14 @@
         },
 {%- endif %}
         {
+          "tags": ["search"],
           "operation": "hourly_agg",
           "warmup-iterations": 100,
           "iterations": 100,
           "target-throughput": 0.2
         },
         {
+          "tags": ["search"],
           "operation": "scroll",
           "warmup-iterations": 100,
           "iterations": 200,
@@ -160,36 +179,42 @@
           "target-throughput": 1
         },
         {
+          "tags": ["search"],
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
         },
         {
+          "tags": ["search"],
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2.7
         },
         {
+          "tags": ["search"],
           "operation": "desc_sort_with_after_timestamp",
           "warmup-iterations": 10,
           "iterations": 100,
           "target-throughput": 0.6
         },
         {
+          "tags": ["search"],
           "operation": "asc_sort_with_after_timestamp",
           "warmup-iterations": 10,
           "iterations": 100,
           "target-throughput": 0.5
         },
         {
+          "tags": ["search"],
           "operation": "desc_sort_timestamp_can_match_shortcut",
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
         },
         {
+          "tags": ["search"],
           "operation": "desc_sort_timestamp_no_can_match_shortcut",
           "warmup-iterations": 200,
           "iterations": 100,
@@ -197,44 +222,52 @@
         },
 {%- if not runtime_fields is defined %}
         {
+          "tags": ["search"],
           "operation": "sort_size_desc",
           "warmup-iterations": 200,
           "iterations": 100
         },
         {
+          "tags": ["search"],
           "operation": "sort_size_asc",
           "warmup-iterations": 200,
           "iterations": 100
         },
         {
+          "tags": ["search"],
           "operation": "sort_status_desc",
           "warmup-iterations": 200,
           "iterations": 100
         },
         {
+          "tags": ["search"],
           "operation": "sort_status_asc",
           "warmup-iterations": 200,
           "iterations": 100
         },
         {
+          "tags": ["search"],
           "operation": "sort_keyword_can_match_shortcut",
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
         },
         {
+          "tags": ["search"],
           "operation": "sort_keyword_no_can_match_shortcut",
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
         },
         {
+          "tags": ["search"],
           "operation": "sort_numeric_can_match_shortcut",
           "warmup-iterations": 200,
           "iterations": 100,
           "target-throughput": 2
         },
         {
+          "tags": ["search"],
           "operation": "sort_numeric_no_can_match_shortcut",
           "warmup-iterations": 200,
           "iterations": 100,
@@ -243,6 +276,7 @@
 {%- endif %}
         {
           "name": "force-merge-1-seg",
+          "tags": ["force-merge-1-seg"],
           "operation": {
             "operation-type": "force-merge",
             "max-num-segments": 1,
@@ -251,10 +285,12 @@
         },
         {
           "name": "refresh-after-force-merge-1-seg",
+          "tags": ["force-merge-1-seg"],
           "operation": "refresh"
         },
         {
           "name": "wait-until-merges-1-seg-finish",
+          "tags": ["force-merge-1-seg"],
           "operation": {
             "operation-type": "index-stats",
             "index": "_all",
@@ -268,6 +304,7 @@
         },
         {
           "name": "desc-sort-timestamp-after-force-merge-1-seg",
+          "tags": ["search-after-force-merge-1-seg"],
           "operation": "desc_sort_timestamp",
           "warmup-iterations": 200,
           "iterations": 100,
@@ -275,6 +312,7 @@
         },
         {
           "name": "asc-sort-timestamp-after-force-merge-1-seg",
+          "tags": ["search-after-force-merge-1-seg"],
           "operation": "asc_sort_timestamp",
           "warmup-iterations": 200,
           "iterations": 100,
@@ -282,6 +320,7 @@
         },
         {
           "name": "desc-sort-with-after-timestamp-after-force-merge-1-seg",
+          "tags": ["search-after-force-merge-1-seg"],
           "operation": "desc_sort_with_after_timestamp",
           "warmup-iterations": 10,
           "iterations": 100,
@@ -289,6 +328,7 @@
         },       
         {
           "name": "asc-sort-with-after-timestamp-after-force-merge-1-seg",
+          "tags": ["search-after-force-merge-1-seg"],
           "operation": "asc_sort_with_after_timestamp",
           "warmup-iterations": 10,
           "iterations": 100,
@@ -297,24 +337,28 @@
 {%- if not runtime_fields is defined %},         
         {
           "name": "sort-size-desc-after-force-merge-1-seg",
+          "tags": ["search-after-force-merge-1-seg"],
           "operation": "sort_size_desc",
           "warmup-iterations": 200,
           "iterations": 100
         },
         {
           "name": "sort-size-asc-after-force-merge-1-seg",
+          "tags": ["search-after-force-merge-1-seg"],
           "operation": "sort_size_asc",
           "warmup-iterations": 200,
           "iterations": 100
         },
         {
           "name": "sort-status-desc-after-force-merge-1-seg",
+          "tags": ["search-after-force-merge-1-seg"],
           "operation": "sort_status_desc",
           "warmup-iterations": 200,
           "iterations": 100
         },
         {
           "name": "sort-status-asc-after-force-merge-1-seg",
+          "tags": ["search-after-force-merge-1-seg"],
           "operation": "sort_status_asc",
           "warmup-iterations": 200,
           "iterations": 100

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -18,9 +18,11 @@
       "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
       "schedule": [
         {
+          "tags": ["setup"],
           "operation": "delete-index"
         },
         {
+          "tags": ["setup"],
           "operation": {
             "operation-type": "create-index",
             "settings": {{index_settings | default({}) | tojson}}
@@ -28,6 +30,7 @@
         },
         {
           "name": "check-cluster-health",
+          "tags": ["health"],
           "operation": {
             "operation-type": "cluster-health",
             "index": "logs-*",
@@ -39,6 +42,7 @@
           }
         },
         {
+          "tags": ["index"],
           "operation": "index-append",
           "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}},
@@ -46,9 +50,11 @@
         },
         {
           "name": "refresh-after-index",
+          "tags": ["index"],
           "operation": "refresh"
         },
         {
+          "tags": ["index"],
           "operation": {
             "operation-type": "force-merge",
             "request-timeout": 7200
@@ -56,10 +62,12 @@
         },
         {
           "name": "refresh-after-force-merge",
+          "tags": ["index"],
           "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
+          "tags": ["index"],
           "operation": {
             "operation-type": "index-stats",
             "index": "_all",
@@ -78,9 +86,11 @@
       "description": "Indexes the whole document corpus in an index sorted by timestamp field in descending order (most recent first) and using a setup that will lead to a lower indexing throughput than the default settings. Document ids are unique so all index operations are append only.",
       "schedule": [
         {
+          "tags": ["setup"],
           "operation": "delete-index"
         },
         {
+          "tags": ["setup"],
           "operation": {
             "operation-type": "create-index",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
@@ -91,6 +101,7 @@
         },
         {
           "name": "check-cluster-health",
+          "tags": ["health"],
           "operation": {
             "operation-type": "cluster-health",
             "index": "logs-*",
@@ -102,6 +113,7 @@
           }
         },
         {
+          "tags": ["index"],
           "operation": "index-append",
           "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}},
@@ -109,9 +121,11 @@
         },
         {
           "name": "refresh-after-index",
+          "tags": ["index"],
           "operation": "refresh"
         },
         {
+          "tags": ["index"],
           "operation": {
             "operation-type": "force-merge",
             "request-timeout": 7200
@@ -119,10 +133,12 @@
         },
         {
           "name": "refresh-after-force-merge",
+          "tags": ["index"],
           "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
+          "tags": ["index"],
           "operation": {
             "operation-type": "index-stats",
             "index": "_all",
@@ -141,9 +157,11 @@
       "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. Runs the documents through an ingest node pipeline to parse the http logs. May require --elasticsearch-plugins='ingest-geoip' ",
       "schedule": [
         {
+          "tags": ["setup"],
           "operation": "delete-index"
         },
         {
+          "tags": ["setup"],
           "operation": {
             "operation-type": "create-index",
             "settings": {{index_settings | default({}) | tojson}}
@@ -151,6 +169,7 @@
         },
         {
           "name": "check-cluster-health",
+          "tags": ["health"],
           "operation": {
             "operation-type": "cluster-health",
             "index": "logs-*",
@@ -162,9 +181,11 @@
           }
         },
         {
-        "operation": "create-http-log-{{ingest_pipeline | default('baseline')}}-pipeline"
+          "tags": ["setup"],
+          "operation": "create-http-log-{{ingest_pipeline | default('baseline')}}-pipeline"
         },
         {
+          "tags": ["index"],
           "operation": "index-append-with-ingest-{{ingest_pipeline | default('baseline')}}-pipeline",
           "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}},
@@ -172,20 +193,24 @@
         },
         {
           "name": "refresh-after-index",
+          "tags": ["index"],
           "operation": "refresh"
         },
         {
+          "tags": ["index"],
           "operation": {
             "operation-type": "force-merge",
             "request-timeout": 7200
           }
         },
         {
+          "tags": ["index"],
           "name": "refresh-after-force-merge",
           "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
+          "tags": ["index"],
           "operation": {
             "operation-type": "index-stats",
             "index": "_all",
@@ -203,9 +228,11 @@
       "name": "update",
       "schedule": [
         {
+          "tags": ["setup"],
           "operation": "delete-index"
         },
         {
+          "tags": ["setup"],
           "operation": {
             "operation-type": "create-index",
             "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
@@ -219,6 +246,7 @@
         },
         {
           "name": "check-cluster-health",
+          "tags": ["health"],
           "operation": {
             "operation-type": "cluster-health",
             "index": "logs-*",
@@ -230,6 +258,7 @@
           }
         },
         {
+          "tags": ["index"],
           "operation": "update",
           "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}},
@@ -237,9 +266,11 @@
         },
         {
           "name": "refresh-after-index",
+          "tags": ["index"],
           "operation": "refresh"
         },
         {
+          "tags": ["index"],
           "operation": {
             "operation-type": "force-merge",
             "request-timeout": 7200
@@ -247,10 +278,12 @@
         },
         {
           "name": "refresh-after-force-merge",
+          "tags": ["index"],
           "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
+          "tags": ["index"],
           "operation": {
             "operation-type": "index-stats",
             "index": "_all",
@@ -269,9 +302,11 @@
       "description": "Indexes the whole document corpus using Elasticsearch default settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After indexing, same data are reindexed.",
       "schedule": [
         {
+          "tags": ["setup"],
           "operation": "delete-index"
         },
         {
+          "tags": ["setup"],
           "operation": {
             "operation-type": "create-index",
             "settings": {{index_settings | default({}) | tojson}}
@@ -279,6 +314,7 @@
         },
         {
           "name": "check-cluster-health",
+          "tags": ["health"],
           "operation": {
             "operation-type": "cluster-health",
             "index": "logs-*",
@@ -290,6 +326,7 @@
           }
         },
         {
+          "tags": ["index"],
           "operation": "index-append",
           "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}},
@@ -297,9 +334,11 @@
         },
         {
           "name": "refresh-after-index",
+          "tags": ["index"],
           "operation": "refresh"
         },
         {
+          "tags": ["index"],
           "operation": {
             "operation-type": "force-merge",
             "request-timeout": 7200
@@ -307,10 +346,12 @@
         },
         {
           "name": "refresh-after-force-merge",
+          "tags": ["index"],
           "operation": "refresh"
         },
         {
           "name": "wait-until-merges-finish",
+          "tags": ["index"],
           "operation": {
             "operation-type": "index-stats",
             "index": "_all",
@@ -325,6 +366,7 @@
         {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
         {
           "name": "post-ingest-sleep",
+          "tags": ["index"],
           "operation": {
             "operation-type": "sleep",
             "duration": {{ post_ingest_sleep_duration|default(30) }}
@@ -333,6 +375,7 @@
         {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
         {
           "name": "reindex",
+          "tags": ["index"],
           "operation": {
             "operation-type": "reindex",
             "body": {

--- a/so_vector/challenges/default.json
+++ b/so_vector/challenges/default.json
@@ -6,16 +6,19 @@
   "default": true,
   "schedule": [
     {
+      "tags": ["setup"],
       "operation": {
         "operation-type": "delete-index"
       }
     },
     {
+      "tags": ["setup"],
       "operation": {
         "operation-type": "create-index"
       }
     },
     {
+      "tags": ["health"],
       "operation": {
         "operation-type": "cluster-health",
         "request-params": {
@@ -26,6 +29,7 @@
     },
     {
       "name": "index-append",
+      "tags": ["index"],
       "operation": {
         "operation-type": "bulk",
         "bulk-size": {{bulk_size | default(500)}},
@@ -36,6 +40,7 @@
     },
     {
       "name": "refresh-after-index",
+      "tags": ["index"],
       "operation": {
         "operation-type": "refresh",
         "request-timeout": 1000,
@@ -44,6 +49,7 @@
     },
     {
       "name": "knn-search-default-match-all",
+      "tags": ["search"],
       "operation": "knn-search-default-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -51,6 +57,7 @@
     },
     {
       "name": "knn-recall-default-match-all",
+      "tags": ["search"],
       "operation": "knn-recall-default-match-all",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -58,6 +65,7 @@
     },
     {
       "name": "knn-search-10-50-match-all",
+      "tags": ["search"],
       "operation": "knn-search-10-50-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -65,6 +73,7 @@
     },
     {
       "name": "knn-recall-10-50-match-all",
+      "tags": ["search"],
       "operation": "knn-recall-10-50-match-all",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -72,6 +81,7 @@
     },
     {
       "name": "knn-search-100-300-match-all",
+      "tags": ["search"],
       "operation": "knn-search-100-300-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -79,6 +89,7 @@
     },
     {
       "name": "knn-recall-100-300-match-all",
+      "tags": ["search"],
       "operation": "knn-recall-100-300-match-all",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -86,6 +97,7 @@
     },
     {
       "name": "script-score-query-match-all",
+      "tags": ["search"],
       "operation": "script-score-query-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -93,6 +105,7 @@
     },
     {
       "name": "knn-search-10-50-acceptedAnswerId",
+      "tags": ["search"],
       "operation": "knn-search-10-50-acceptedAnswerId",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -100,6 +113,7 @@
     },
     {
       "name": "knn-recall-10-50-acceptedAnswerId",
+      "tags": ["search"],
       "operation": "knn-recall-10-50-acceptedAnswerId",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -107,6 +121,7 @@
     },
     {
       "name": "script-score-query-acceptedAnswerId",
+      "tags": ["search"],
       "operation": "script-score-query-acceptedAnswerId",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -114,6 +129,7 @@
     },
     {
       "name": "knn-search-10-50-java",
+      "tags": ["search"],
       "operation": "knn-search-10-50-java",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -121,6 +137,7 @@
     },
     {
       "name": "knn-recall-10-50-java",
+      "tags": ["search"],
       "operation": "knn-recall-10-50-java",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -128,6 +145,7 @@
     },
     {
       "name": "script-score-query-java",
+      "tags": ["search"],
       "operation": "script-score-query-java",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -135,6 +153,7 @@
     },
     {
       "name": "script-score-query-javascript",
+      "tags": ["search"],
       "operation": "script-score-query-javascript",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -142,6 +161,7 @@
     },
     {
       "name": "knn-search-10-50-css",
+      "tags": ["search"],
       "operation": "knn-search-10-50-css",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -149,6 +169,7 @@
     },
     {
       "name": "knn-recall-10-50-css",
+      "tags": ["search"],
       "operation": "knn-recall-10-50-css",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -156,6 +177,7 @@
     },
     {
       "name": "script-score-query-css",
+      "tags": ["search"],
       "operation": "script-score-query-css",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -163,6 +185,7 @@
     },
     {
       "name": "knn-search-10-50-concurrency",
+      "tags": ["search"],
       "operation": "knn-search-10-50-concurrency",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -170,6 +193,7 @@
     },
     {
       "name": "knn-recall-10-50-concurrency",
+      "tags": ["search"],
       "operation": "knn-recall-10-50-concurrency",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -177,6 +201,7 @@
     },
     {
       "name": "script-score-query-concurrency",
+      "tags": ["search"],
       "operation": "script-score-query-concurrency",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -184,6 +209,7 @@
     },
     {
       "name": "knn-search-10-50-random-10-percent",
+      "tags": ["search"],
       "operation": "knn-search-10-50-random-10-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -191,6 +217,7 @@
     },
     {
       "name": "knn-recall-10-50-random-10-percent",
+      "tags": ["search"],
       "operation": "knn-recall-10-50-random-10-percent",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -198,6 +225,7 @@
     },
     {
       "name": "knn-search-default-random-20-percent",
+      "tags": ["search"],
       "operation": "knn-search-default-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -205,6 +233,7 @@
     },
     {
       "name": "knn-recall-default-random-20-percent",
+      "tags": ["search"],
       "operation": "knn-recall-default-random-20-percent",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -212,6 +241,7 @@
     },
     {
       "name": "knn-search-10-50-random-20-percent",
+      "tags": ["search"],
       "operation": "knn-search-10-50-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -219,6 +249,7 @@
     },
     {
       "name": "knn-recall-10-50-random-20-percent",
+      "tags": ["search"],
       "operation": "knn-recall-10-50-random-20-percent",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -226,6 +257,7 @@
     },
     {
       "name": "knn-search-100-300-random-10-percent",
+      "tags": ["search"],
       "operation": "knn-search-100-300-random-10-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -233,6 +265,7 @@
     },
     {
       "name": "knn-recall-100-300-random-10-percent",
+      "tags": ["search"],
       "operation": "knn-recall-100-300-random-10-percent",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -240,6 +273,7 @@
     },
     {
       "name": "knn-search-100-300-random-20-percent",
+      "tags": ["search"],
       "operation": "knn-search-100-300-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -247,6 +281,7 @@
     },
     {
       "name": "knn-recall-100-300-random-20-percent",
+      "tags": ["search"],
       "operation": "knn-recall-100-300-random-20-percent",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -255,6 +290,7 @@
 {% if is_esql_enabled %}
     ,{
       "name": "esql-knn-search-default-match-all",
+      "tags": ["search"],
       "operation": "esql-knn-search-default-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -262,6 +298,7 @@
     },
     {
       "name": "esql-knn-search-10-50-match-all",
+      "tags": ["search"],
       "operation": "esql-knn-search-10-50-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -269,6 +306,7 @@
     },
     {
       "name": "esql-knn-search-100-300-match-all",
+      "tags": ["search"],
       "operation": "esql-knn-search-100-300-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -276,6 +314,7 @@
     },
     {
       "name": "esql-script-score-query-match-all",
+      "tags": ["search"],
       "operation": "esql-script-score-query-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -283,6 +322,7 @@
     },
     {
       "name": "esql-knn-search-10-50-acceptedAnswerId",
+      "tags": ["search"],
       "operation": "esql-knn-search-10-50-acceptedAnswerId",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -290,6 +330,7 @@
     },
     {
       "name": "esql-script-score-query-acceptedAnswerId",
+      "tags": ["search"],
       "operation": "esql-script-score-query-acceptedAnswerId",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -297,6 +338,7 @@
     },
     {
       "name": "esql-knn-search-10-50-java",
+      "tags": ["search"],
       "operation": "esql-knn-search-10-50-java",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -304,6 +346,7 @@
     },
     {
       "name": "esql-script-score-query-java",
+      "tags": ["search"],
       "operation": "esql-script-score-query-java",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -311,6 +354,7 @@
     },
     {
       "name": "esql-script-score-query-javascript",
+      "tags": ["search"],
       "operation": "esql-script-score-query-javascript",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -318,6 +362,7 @@
     },
     {
       "name": "esql-knn-search-10-50-css",
+      "tags": ["search"],
       "operation": "esql-knn-search-10-50-css",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -325,6 +370,7 @@
     },
     {
       "name": "esql-script-score-query-css",
+      "tags": ["search"],
       "operation": "esql-script-score-query-css",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -332,6 +378,7 @@
     },
     {
       "name": "esql-knn-search-10-50-concurrency",
+      "tags": ["search"],
       "operation": "esql-knn-search-10-50-concurrency",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -339,6 +386,7 @@
     },
     {
       "name": "esql-script-score-query-concurrency",
+      "tags": ["search"],
       "operation": "esql-script-score-query-concurrency",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -346,6 +394,7 @@
     },
     {
       "name": "esql-knn-search-10-50-random-10-percent",
+      "tags": ["search"],
       "operation": "esql-knn-search-10-50-random-10-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -353,6 +402,7 @@
     },
     {
       "name": "esql-knn-search-default-random-20-percent",
+      "tags": ["search"],
       "operation": "esql-knn-search-default-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -360,6 +410,7 @@
     },
     {
       "name": "esql-knn-search-10-50-random-20-percent",
+      "tags": ["search"],
       "operation": "esql-knn-search-10-50-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -367,6 +418,7 @@
     },
     {
       "name": "esql-knn-search-100-300-random-10-percent",
+      "tags": ["search"],
       "operation": "esql-knn-search-100-300-random-10-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -374,6 +426,7 @@
     },
     {
       "name": "esql-knn-search-100-300-random-20-percent",
+      "tags": ["search"],
       "operation": "esql-knn-search-100-300-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -384,6 +437,7 @@
       {% if p_include_force_merge %}
    ,
     {
+      "tags": ["force-merge"],
       "operation": {
         "operation-type": "force-merge",
         "max-num-segments": {{max_num_segments | default(1)}},
@@ -393,10 +447,12 @@
     },
     {
       "name": "refresh-after-force-merge",
+      "tags": ["force-merge"],
       "operation": "refresh"
     },
     {
       "name": "knn-search-default-match-all-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-default-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -404,6 +460,7 @@
     },
     {
       "name": "knn-recall-default-match-all-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-default-match-all",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -411,6 +468,7 @@
     },
     {
       "name": "knn-search-10-50-match-all-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -418,6 +476,7 @@
     },
     {
       "name": "knn-recall-10-50-match-all-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-10-50-match-all",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -425,6 +484,7 @@
     },
     {
       "name": "knn-search-100-300-match-all-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-100-300-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -432,6 +492,7 @@
     },
     {
       "name": "knn-recall-100-300-match-all-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-100-300-match-all",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -439,6 +500,7 @@
     },
     {
       "name": "knn-search-10-50-acceptedAnswerId-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-acceptedAnswerId",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -446,6 +508,7 @@
     },
     {
       "name": "knn-recall-10-50-acceptedAnswerId-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-10-50-acceptedAnswerId",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -453,6 +516,7 @@
     },
     {
       "name": "knn-search-10-50-java-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-java",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -460,6 +524,7 @@
     },
     {
       "name": "knn-recall-10-50-java-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-10-50-java",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -467,6 +532,7 @@
     },
     {
       "name": "knn-search-10-50-css-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-css",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -474,6 +540,7 @@
     },
     {
       "name": "knn-recall-10-50-css-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-10-50-css",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -481,6 +548,7 @@
     },
     {
       "name": "knn-recall-10-50-concurrency-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-10-50-concurrency",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -488,6 +556,7 @@
     },
     {
       "name": "knn-search-10-50-concurrency-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-concurrency",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -495,6 +564,7 @@
     },
     {
       "name": "knn-search-10-50-random-10-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-random-10-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -502,6 +572,7 @@
     },
     {
       "name": "knn-recall-10-50-random-10-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-10-50-random-10-percent",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -509,6 +580,7 @@
     },
     {
       "name": "knn-search-default-random-20-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-default-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -516,6 +588,7 @@
     },
     {
       "name": "knn-recall-default-random-20-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-default-random-20-percent",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -523,6 +596,7 @@
     },
     {
       "name": "knn-search-10-50-random-20-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-10-50-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -530,6 +604,7 @@
     },
     {
       "name": "knn-recall-10-50-random-20-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-10-50-random-20-percent",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -537,6 +612,7 @@
     },
     {
       "name": "knn-search-100-300-random-10-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-100-300-random-10-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -544,6 +620,7 @@
     },
     {
       "name": "knn-recall-100-300-random-10-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-100-300-random-10-percent",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -551,6 +628,7 @@
     },
     {
       "name": "knn-search-100-300-random-20-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-search-100-300-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -558,6 +636,7 @@
     },
     {
       "name": "knn-recall-100-300-random-20-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "knn-recall-100-300-random-20-percent",
       "warmup-iterations": 0,
       "iterations": 1,
@@ -566,6 +645,7 @@
 {% if is_esql_enabled %}
     ,{
       "name": "esql-knn-search-default-match-all-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-default-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -573,6 +653,7 @@
     },
     {
       "name": "esql-knn-search-10-50-match-all-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -580,6 +661,7 @@
     },
     {
       "name": "esql-knn-search-100-300-match-all-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-100-300-match-all",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -587,6 +669,7 @@
     },
     {
       "name": "esql-knn-search-10-50-acceptedAnswerId-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-acceptedAnswerId",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -594,6 +677,7 @@
     },
     {
       "name": "esql-knn-search-10-50-java-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-java",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -601,6 +685,7 @@
     },
     {
       "name": "esql-knn-search-10-50-css-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-css",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -608,6 +693,7 @@
     },
     {
       "name": "esql-knn-search-10-50-concurrency-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-concurrency",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -615,6 +701,7 @@
     },
     {
       "name": "esql-knn-search-10-50-random-10-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-random-10-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -622,6 +709,7 @@
     },
     {
       "name": "esq-knn-search-default-random-20-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-default-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -629,6 +717,7 @@
     },
     {
       "name": "esql-knn-search-10-50-random-20-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-10-50-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -636,6 +725,7 @@
     },
     {
       "name": "esql-knn-search-100-300-random-10-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-100-300-random-10-percent",
       "warmup-iterations": 100,
       "iterations": 100,
@@ -643,6 +733,7 @@
     },
     {
       "name": "esql-knn-search-100-300-random-20-percent-force-merge",
+      "tags": ["search-after-force-merge"],
       "operation": "esql-knn-search-100-300-random-20-percent",
       "warmup-iterations": 100,
       "iterations": 100,


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.2`:
 - [Align tags in HTTP Logs and SO Vector (#890)](https://github.com/elastic/rally-tracks/pull/890)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Grzegorz Banasiak","email":"grzegorz.banasiak@elastic.co"},"sourceCommit":{"committedDate":"2025-10-20T09:29:19Z","message":"Align tags in HTTP Logs and SO Vector (#890)","sha":"064a659e2a75062d6507240241a5bb29ca825edd","branchLabelMapping":{"^v(\\d{1,2})$":"$1","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.2"],"title":"[ES-12574] Align tags in HTTP Logs and SO Vector","number":890,"url":"https://github.com/elastic/rally-tracks/pull/890","mergeCommit":{"message":"Align tags in HTTP Logs and SO Vector (#890)","sha":"064a659e2a75062d6507240241a5bb29ca825edd"}},"sourceBranch":"master","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->