### PR TITLE
Adjust openai_vector benchmark for gpu indexing

### DIFF
--- a/openai_vector/README.md
+++ b/openai_vector/README.md
@@ -53,6 +53,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 - standalone_search_clients (default: 8)
 - standalone_search_iterations (default: 10000)
 - vector_index_type (default: "hnsw"): The index kind for storing the vectors.
+- use_gpu_indexing (default: true): Whether to use GPU acceleration for vector indexing.
 - search_ops (default: [[10, 20, 0], [10, 20, 1], [10, 20, 2], [10, 50, 1], [10, 50, 2], [10, 100, 1], [100, 120, 1], [100, 120, 2], [100, 200, 1], [100, 200, 2], [100, 500, 1], [100, 500, 2]]): The vector search operations, formattied [k, num_candidates, oversample], where `oversample` indicates the ratio of extra `k` to gather and then rescore.
 
 ### License

--- a/openai_vector/challenges/default.json
+++ b/openai_vector/challenges/default.json
@@ -31,16 +31,11 @@
       }
     },
     {
-      "name": "wait-until-merges-finish-after-index",
       "operation": {
-        "operation-type": "index-stats",
-        "index": "_all",
-        "condition": {
-          "path": "_all.total.merges.current",
-          "expected-value": 0
-        },
-        "retry-until-success": true,
-        "include-in-reporting": false
+        "operation-type": "force-merge",
+        "max-num-segments": {{max_num_segments | default(1)}},
+        "request-timeout": {{force_merge_timeout | default(7200)}},
+        "include-in-reporting": true
       }
     }
     {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
@@ -76,14 +71,7 @@
       "clients": {{ standalone_search_clients | default(8) | int }},
       "iterations": {{ standalone_search_iterations | default(10000) | int }}
     }
-    {%- endfor %},
-    {
-      "name": "parallel-documents-indexing-bulk",
-      "operation": "parallel-documents-indexing",
-      "warmup-time-period": 60,
-      "clients": {{ parallel_indexing_bulk_clients | default(1) | int }},
-      "target-throughput": {{ parallel_indexing_bulk_target_throughput | default(1) | int }}
-    }
+    {%- endfor %}
     {%- for i in range(p_search_ops|length) %},
     {
       {%- if p_search_ops[i][2] > 0 -%}

--- a/openai_vector/index-vectors-only-with-docid-mapping.json
+++ b/openai_vector/index-vectors-only-with-docid-mapping.json
@@ -4,7 +4,10 @@
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],
       {% endif %}
+    "index.vectors.indexing.use_gpu": {{ use_gpu_indexing | default(true) | tojson }},
+    "index.merge.scheduler.auto_throttle" : false,
     "index.number_of_shards": {{number_of_shards | default(1)}},
+    "index.refresh_interval": -1, 
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },


### PR DESCRIPTION
  - Adds GPU acceleration support via the use_gpu_indexing parameter
  - Replaces the merge-wait polling with an explicit force-merge operation
  - Optimizes indexing performance by disabling merge throttling and refresh intervals

---

Draft PR for now as "index.vectors.indexing.use_gpu" is currently only enabled under Feature flag.

For GPU indexing pass the following `params.json` file  to a rally run:

params.json
```js
{
  "use_gpu_indexing" : true, 
  "vector_index_type" : "hnsw",   
  "initial_indexing_bulk_indexing_clients" : 8 
}
```

Notes: 


./rally race ...--runtime-jdk=25 --track-params=<.../params.json> --on-error=abort

---
### Notes

  - use_gpu_indexing –   supports `true` to enforce gpu indexing or `false`  to enforce CPU indexing
  - vector_index_type :  supports `hnsw` or `int8_hnsw` for GPU indexing
  - initial_indexing_bulk_indexing_clients –  we recommend to set indexing clients = number of CPU cores/2.
  -  runtime-jdk should be at least 22
  - LD_LIBRARY_PATH should be defined and set in rally.ini

From 9.3, there is a new option for using base64 encoded vectors for indexing

- use base64 encoded vectors for much faster indexing. For example, for `openai_vector` track, add the following params in params.json: 
```js
 "initial_indexing_corpora" : "openai_initial_indexing_base64",  
 "parallel_indexing_corpora": "openai_parallel_indexing_base64"
```


vim ~/.rally/rally.ini
```bashrc
...
[system]
env.name = local
passenv = PATH,LD_LIBRARY_PATH

```

---
#### Example running openai_vector track:

params_gpu.json
```js
{
  "use_gpu_indexing" : true,
  "vector_index_type" :  "int8_hnsw",
  "mapping_type" : "vectors-only-with-docid",
  "initial_indexing_bulk_indexing_clients" : 8
}

```

params_cpu.json
```js
{
  "use_gpu_indexing" : false,
  "vector_index_type" : "int8_hnsw",
  "mapping_type" : "vectors-only-with-docid",
  "initial_indexing_bulk_indexing_clients" : 8
}
```

```
./rally race --track-path /home/ubuntu/elastic/rally-tracks/openai_vector \
--pipeline from-sources \
--revision current \
--car "16gheap" \
--user-tags "tag:openai_vector_gpu" \
--report-file /home/ubuntu/elastic/benchmarks/rally_results/openai_vector_gpu.md \
--runtime-jdk=25   \
--track-params=/home/ubuntu/elastic/benchmarks/rally/params.json \
--on-error=abort
```


---

### Troubleshoot
- Check ~/.rally/benchmarks/races/<raceID> /rally-node-0/logs/server/rally-benchmark.log. If you see similar output in the elasticsearch server logs:
[o.e.x.g.GPUSupport       ] [elasticsearch-0] Found compatible GPU [NVIDIA L4] (id: [0])

it means your setup is successful, and Elasticsearch can use GPU. If you don’t see this line from GPUSupport, you should see an explanation why elasticsearch can’t use your GPU device.




