### PR TITLE
Fix the size params for the dsl search task of the so_vector track

### DIFF
--- a/so_vector/track.py
+++ b/so_vector/track.py
@@ -74,7 +74,7 @@ class KnnParamSource:
         return self
 
     def params(self):
-        result = {"index": self._index_name, "cache": self._params.get("cache", False), "size": self._params.get("k", 10)}
+        result = {"index": self._index_name, "cache": self._params.get("cache", False), "results-per-page": self._params.get("k", 10)}
         num_candidates: int | None = self._params.get("num_candidates", None)
         # if -1, then its unset. If set, just set it.
         oversample = self._params.get("oversample", -1)


### PR DESCRIPTION
The so_vector tracks uses the wrong parameter to modify the top n size. It should be `results-per-page` and not `size` as defined [here](https://github.com/elastic/rally/blob/3d6864db3564b44642bd507f4e87f432cc2a311f/esrally/driver/runner.py#L912)