### PR TITLE
Validate start-date is before end-date in ProcessedCorpusParamSource

### DIFF
--- a/elastic/shared/parameter_sources/processed.py
+++ b/elastic/shared/parameter_sources/processed.py
@@ -112,9 +112,9 @@ class ProcessedCorpusParamSource:
             self._end_date.isoformat(),
         )
 
-        if self._start_date > self._end_date:
+        if self._start_date >= self._end_date:
             raise exceptions.TrackConfigError(
-                f'"start-date" cannot be greater than "end-date" for operation ' f"\"{self._params.get('operation-type')}\""
+                f'"start-date" must be earlier than "end-date" for operation ' f"\"{self._params.get('operation-type')}\""
             )
         self._number_of_days = (self._end_date - self._start_date).total_seconds() / 86400
 

--- a/elastic/tests/parameter_sources/processed_test.py
+++ b/elastic/tests/parameter_sources/processed_test.py
@@ -468,6 +468,22 @@ def test_invalid_dates():
             params={},
         )
 
+    # start equal to end
+    with pytest.raises(TrackConfigError):
+        ProcessedCorpusParamSource(
+            track=StaticTrack(
+                parameters={
+                    "bulk-size": 10,
+                    "track-id": "test_file_write",
+                    "file-cache-dir": "./tmp",
+                    "raw-data-volume-per-day": "0.001MB",
+                    "start-date": "2020-09-01:00:00:00",
+                    "end-date": "2020-09-01:00:00:00",
+                }
+            ),
+            params={},
+        )
+
 
 def test_undocumented_params():
     cwd = os.path.dirname(__file__)


### PR DESCRIPTION
Originally for issue 2007 in Rally ([here](https://github.com/elastic/rally/issues/2007#issue-3690814523)).
Track params for start and end date can be set to the same value (`"start_date:2020-01-01,end_date:2020-01-01"`) which later causes division by zero (days between two identical dates).
