### PR TITLE
[9.2] Validate start-date is before end-date in ProcessedCorpusParamSource (#943)

### DIFF
--- a/elastic/shared/parameter_sources/processed.py
+++ b/elastic/shared/parameter_sources/processed.py
@@ -111,9 +111,9 @@ class ProcessedCorpusParamSource:
             self._end_date.isoformat(),
         )
 
-        if self._start_date > self._end_date:
+        if self._start_date >= self._end_date:
             raise exceptions.TrackConfigError(
-                f'"start-date" cannot be greater than "end-date" for operation ' f"\"{self._params.get('operation-type')}\""
+                f'"start-date" must be earlier than "end-date" for operation ' f"\"{self._params.get('operation-type')}\""
             )
         self._number_of_days = (self._end_date - self._start_date).total_seconds() / 86400
 

--- a/elastic/tests/parameter_sources/processed_test.py
+++ b/elastic/tests/parameter_sources/processed_test.py
@@ -468,6 +468,22 @@ def test_invalid_dates():
             params={},
         )
 
+    # start equal to end
+    with pytest.raises(TrackConfigError):
+        ProcessedCorpusParamSource(
+            track=StaticTrack(
+                parameters={
+                    "bulk-size": 10,
+                    "track-id": "test_file_write",
+                    "file-cache-dir": "./tmp",
+                    "raw-data-volume-per-day": "0.001MB",
+                    "start-date": "2020-09-01:00:00:00",
+                    "end-date": "2020-09-01:00:00:00",
+                }
+            ),
+            params={},
+        )
+
 
 def test_undocumented_params():
     cwd = os.path.dirname(__file__)


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.2`:
 - [Validate start-date is before end-date in ProcessedCorpusParamSource (#943)](https://github.com/elastic/rally-tracks/pull/943)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"scaeloutSean","email":"scaleoutsean@users.noreply.github.com"},"sourceCommit":{"committedDate":"2025-12-05T10:11:12Z","message":"Validate start-date is before end-date in ProcessedCorpusParamSource (#943)","sha":"da921add100f151a37df628584fc5429623b6e7c","branchLabelMapping":{"^v(\\d{1,2})$":"$1","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.2"],"title":"Validate start-date is before end-date in ProcessedCorpusParamSource","number":943,"url":"https://github.com/elastic/rally-tracks/pull/943","mergeCommit":{"message":"Validate start-date is before end-date in ProcessedCorpusParamSource (#943)","sha":"da921add100f151a37df628584fc5429623b6e7c"}},"sourceBranch":"master","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->