### PR TITLE
Backport reminders - add missing default values

### DIFF
--- a/.github/workflows/backport.reminder.yml
+++ b/.github/workflows/backport.reminder.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Add Backport pending label (single PR)
         if: github.event_name == 'pull_request_target'
         run: |
-          python github_ci_tools/scripts/backport.py label --pr-mode
-          python github_ci_tools/scripts/backport.py remind --pr-mode --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days }}
+          python github_ci_tools/scripts/backport.py --pr-mode label
+          python github_ci_tools/scripts/backport.py --pr-mode remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
       - name: Add Backport pending label (bulk)
         if: github.event_name != 'pull_request_target'
         run: |
-          python github_ci_tools/scripts/backport.py label --lookback-days ${{ github.event.inputs.lookback_days }}
-          python github_ci_tools/scripts/backport.py remind --lookback-days ${{ github.event.inputs.lookback_days }} --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days }}
+          python github_ci_tools/scripts/backport.py label --lookback-days ${{ github.event.inputs.lookback_days || '7' }}
+          python github_ci_tools/scripts/backport.py remind --lookback-days ${{ github.event.inputs.lookback_days || '7' }} --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}


### PR DESCRIPTION
After merging [backport PR](https://github.com/elastic/rally-tracks/pull/888) we noticed workflow failures because of missing values for `--lookback-days` and `--pending-reminder-age-days`. Also `--pr-mode` arg was incorrectly placed in the single PR case. This PR fixes them.