### PR TITLE
[9.2] Add the ability to override track data source url (#899)

### DIFF
--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -64,6 +64,7 @@ $ python _tools/parse_queries.py -r
 ### Parameters
 
 This track accepts the following parameters with Rally 0.8.0+ using `--track-params`:
+ - `base_url` (default: `https://rally-tracks.elastic.co/cohere-msmarco-v2-embed-english-v3`): Specifies the bucket path from where to download the data set.
  - `vector_index_type` (default: bbq_hnsw)
  - `aggressive_merge_policy` (default: false): Whether to apply a more aggressive merge strategy.
  - `index_refresh_interval` (default: unset): The index refresh interval.

--- a/msmarco-v2-vector/track.json
+++ b/msmarco-v2-vector/track.json
@@ -1,5 +1,5 @@
 {% import "rally.helpers" as rally with context %}
-
+{% set _base_url = (base_url | default("https://rally-tracks.elastic.co/cohere-msmarco-v2-embed-english-v3")) %}
 {
   "version": 2,
   "description": "Benchmark for vector search with msmarco-v2 passage data",
@@ -16,7 +16,7 @@
   "corpora": [
     {
       "name": "msmarco-v2-initial-indexing",
-      "base-url": "https://rally-tracks.elastic.co/cohere-msmarco-v2-embed-english-v3",
+      "base-url": "{{_base_url}}",
       "documents": [
         {
           "source-file": "cohere-documents-01.json.bz2",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.2`:
 - [Add the ability to override track data source url (#899)](https://github.com/elastic/rally-tracks/pull/899)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Evgenia Badiyanova","email":"evgenia.badiyanova@elastic.co"},"sourceCommit":{"committedDate":"2025-11-05T16:40:12Z","message":"Add the ability to override track data source url (#899)","sha":"192a7ca53e074f9efb3e62dadbbf4f0c58e97f23","branchLabelMapping":{"^v(\\d{1,2})$":"$1","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["backport pending","v9.2"],"title":"Add the ability to override track data source url","number":899,"url":"https://github.com/elastic/rally-tracks/pull/899","mergeCommit":{"message":"Add the ability to override track data source url (#899)","sha":"192a7ca53e074f9efb3e62dadbbf4f0c58e97f23"}},"sourceBranch":"master","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->