### PR TITLE
Add documentation for backporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,29 @@ In order to backport your PR, at least one `vX.Y` label has to be added.
 - Please supply all the labels that correspond to both current and past elasticsearch versions you expect this PR to work with, but choose only from all the available ones. 
 - If the PR you are merging is using functionality from future Elasticsearch versions, please wait for the feature freeze action of Elasticsearch to create the new label in this repository and then add it. In such case, it would be useful if you kept the 'backport pending' label attached to the PR, so the backport reminder can periodically notify you.
 
-Every `vX.Y` label is triggering a new PR unless there are merge conflicts. This is the backport action, the status of which is reported through a comment.
-- In case of successful backport action, you get a link to the PR opened against the target version branch, in which you are expected to review the changes to this version branch and when approved, it will be automatically merged.
-- In case of merge conflicts a series of manual actions are necessary:
+Every `vX.Y` label is triggering a new PR unless there are merge conflicts. This is the backport action, the status of which is reported through a comment. In case of successful backport action, you get a link to the PR opened against the target version branch, which has a `backport` label and it expects a review of the changes to the corresponding version branch. When approved, it will be automatically merged.
+
+# Merge conflicts
+In case of merge conflicts get ready for some manual actions. Backporting is essential for future development and testing, so please give it a shot. 
 
 1. Go to the [Backport tool](https://github.com/sorenlouv/backport?tab=readme-ov-file#backport-cli-tool) documentation and follow the guidelines to install it in your local `rally-tracks` directory. Note that you have to add your personal access secret token locally in `~/.backport/config.json` with the [specified](https://github.com/sorenlouv/backport/blob/main/docs/config-file-options.md#global-config-backportconfigjson) repository access. At the end of this step, you should be able to execute `backport` command inside rally-tracks repo.
 2. cd in your local `rally-tracks` repository and execute `backport --pr <merged_and_conflicting_pr_number>`. This will open an interactive dialog where you are required to selected branches to backport to. You can only select the version branches that have merge conflicts. After selecting the branches, backport tool will mention a directory in a message `Please fix the conflicts in /home/<user>/.backport/repositories/elastic/rally-tracks` and you will have to go and resolve those conflicts manually for all of the selected branches. If it is not easy to tackle multiple branches in a single sweep, repeat this procedure for each target version branch separately.
 3. After resolving the merge conflicts you can execute `backport --pr` again and this time it will be successful. PRs will be opened against the target version branches and they will be ready for approval and merge.
 
 
-### Backporting Notes
+# Backporting Notes
+- CI is essential to this procedure. Whenever you commit something in a backport PR, you check the test results.
 - In case of conflicts, git blame is a wonderful tool to understand what changes need to be included in a version branch before backporting your PR. You can always check the history of the files you touch between the target backport branch and the next version branch (or master). Also, be mindful of the files that are not changed, but refer to the changed files.
 - Sometimes it is necessary to remove individual operations from a track that are not supported by earlier versions. This graceful fallback is a compromise to allow to run a subset of the track on older versions of Elasticsearch too. If this is necessary then it's best to do these changes in a separate commit. 
 - You can backport individual commits to even earlier versions if necessary by cherry-picking them into the desired version branches.
 
+# Finish line
+For wrapping up ensure the following:
+- Your merged PR has all the correct version labels.
+- Every related backport PR has the `backport` label.
+- Every related backport PR is merged to the correct version branches.
+
+Finally, remove the `backport pending` label from your PR and you're good to go.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -22,35 +22,25 @@ See all details in the [contributor guidelines](https://github.com/elastic/rally
 Backporting changes
 -------------------
 
-If you are a contributor with direct commit access to this repository then please backport your changes. This ensures that tracks do not work only for the latest `main` version of Elasticsearch but also for older versions. Apply backports with cherry-picks. Below you can find a walkthrough:
+As part of contributing to this repository, a reminder will periodically notify you that backport is pending. Backporting ensures that tracks do not work only for the latest `main` version of Elasticsearch but also for older versions, so it is important.
 
-Assume we've pushed commit `a7e0937` to master and want to backport it. This is a change to the `noaa` track. Let's check what branches are available for backporting:
+In order to backport your PR, at least one `vX.Y` label has to be added. 
+- Please supply all the labels that correspond to both current and past elasticsearch versions you expect this PR to work with, but choose only from all the available ones. 
+- If the PR you are merging is using functionality from future Elasticsearch versions, please wait for the feature freeze action of Elasticsearch to create the new label in this repository and then add it. In such case, it would be useful if you kept the 'backport pending' label attached to the PR, so the backport reminder can periodically notify you.
 
-```
-daniel@io:tracks/default ‹master›$ git branch -r
-  origin/1
-  origin/2
-  origin/5
-  origin/HEAD -> origin/master
-  origin/master
-```
+Every `vX.Y` label is triggering a new PR unless there are merge conflicts. This is the backport action, the status of which is reported through a comment.
+- In case of successful backport action, you get a link to the PR opened against the target version branch, in which you are expected to review the changes to this version branch and when approved, it will be automatically merged.
+- In case of merge conflicts a series of manual actions are necessary:
 
-We'll go backwards starting from branch `5`, then branch `2` and finally branch `1`. After applying a change, we will test whether the track works as is for an older version of Elasticsearch.
+1. Go to the [Backport tool](https://github.com/sorenlouv/backport?tab=readme-ov-file#backport-cli-tool) documentation and follow the guidelines to install it in your local `rally-tracks` directory. Note that you have to add your personal access secret token locally in `~/.backport/config.json` with the [specified](https://github.com/sorenlouv/backport/blob/main/docs/config-file-options.md#global-config-backportconfigjson) repository access. At the end of this step, you should be able to execute `backport` command inside rally-tracks repo.
+2. cd in your local `rally-tracks` repository and execute `backport --pr <merged_and_conflicting_pr_number>`. This will open an interactive dialog where you are required to selected branches to backport to. You can only select the version branches that have merge conflicts. After selecting the branches, backport tool will mention a directory in a message `Please fix the conflicts in /home/<user>/.backport/repositories/elastic/rally-tracks` and you will have to go and resolve those conflicts manually for all of the selected branches. If it is not easy to tackle multiple branches in a single sweep, repeat this procedure for each target version branch separately.
+3. After resolving the merge conflicts you can execute `backport --pr` again and this time it will be successful. PRs will be opened against the target version branches and they will be ready for approval and merge.
 
-```
-git checkout 5
-git cherry-pick a7e0937
 
-# test the change now with an Elasticsearch 5.x distribution
-esrally race --track=noaa --distribution-version=5.4.3 --test-mode
-
-# push the change
-git push origin 5
-```
-
-This particular track uses features that are only available in Elasticsearch 5 and later so we will stop here but the process continues until we've reached the earliest branch.
-
-Sometimes it is necessary to remove individual operations from a track that are not supported by earlier versions. This graceful fallback is a compromise to allow to run a subset of the track on older versions of Elasticsearch too. If this is necessary then it's best to do these changes in a separate commit. Also, don't forget to cherry-pick this separate commit too to even earlier versions if necessary.
+### Backporting Notes
+- In case of conflicts, git blame is a wonderful tool to understand what changes need to be included in a version branch before backporting your PR. You can always check the history of the files you touch between the target backport branch and the next version branch (or master). Also, be mindful of the files that are not changed, but refer to the changed files.
+- Sometimes it is necessary to remove individual operations from a track that are not supported by earlier versions. This graceful fallback is a compromise to allow to run a subset of the track on older versions of Elasticsearch too. If this is necessary then it's best to do these changes in a separate commit. 
+- You can backport individual commits to even earlier versions if necessary by cherry-picking them into the desired version branches.
 
 
 License

--- a/README.md
+++ b/README.md
@@ -33,16 +33,25 @@ Every `vX.Y` label is triggering a new PR unless there are merge conflicts. This
 # Merge conflicts
 In case of merge conflicts get ready for some manual actions. Backporting is essential for future development and testing, so please give it a shot. 
 
-1. Go to the [Backport tool](https://github.com/sorenlouv/backport?tab=readme-ov-file#backport-cli-tool) documentation and follow the guidelines to install it in your local `rally-tracks` directory. Note that you have to add your personal access secret token locally in `~/.backport/config.json` with the [specified](https://github.com/sorenlouv/backport/blob/main/docs/config-file-options.md#global-config-backportconfigjson) repository access. At the end of this step, you should be able to execute `backport` command inside rally-tracks repo.
-2. cd in your local `rally-tracks` repository and execute `backport --pr <merged_and_conflicting_pr_number>`. This will open an interactive dialog where you are required to selected branches to backport to. You can only select the version branches that have merge conflicts. After selecting the branches, backport tool will mention a directory in a message `Please fix the conflicts in /home/<user>/.backport/repositories/elastic/rally-tracks` and you will have to go and resolve those conflicts manually for all of the selected branches. If it is not easy to tackle multiple branches in a single sweep, repeat this procedure for each target version branch separately.
-3. After resolving the merge conflicts you can execute `backport --pr` again and this time it will be successful. PRs will be opened against the target version branches and they will be ready for approval and merge.
+## Fork and cherry-pick
+1. Create a rally-tracks fork, and clone it locally.
+2. Pull and checkout to the intended version branch. 
+3. Create a new local branch from this version branch.
+4. Cherry-pick the commit from the PR that will be backported.
+5. Resolve merge conflicts, commit locally and push to fork.
+6. Open a PR against the target branch, add `backport` label manually.
+7. Request for review and merge.
+8. Repeat for other version branches. 
 
+## Use backport tool (requires node)
+1. Go to the [Backport tool](https://github.com/sorenlouv/backport?tab=readme-ov-file#backport-cli-tool) documentation and follow the guidelines to install it in your local `rally-tracks` directory. Note that you have to add your personal access secret token locally in `~/.backport/config.json` with the [specified](https://github.com/sorenlouv/backport/blob/main/docs/config-file-options.md#global-config-backportconfigjson) repository access. At the end of this step, you should be able to execute `backport` command inside rally-tracks repo.
+2. cd in your local `rally-tracks` repository and execute `backport --pr <merged_pr_number>`. This will open an interactive dialog where you are required to selected branches to backport to. You can only select the version branches that have merge conflicts. After selecting the branches, backport tool will mention some directory in a message `Please fix the conflicts in /home/<user>/.backport/repositories/elastic/rally-tracks` and you will have to go and resolve those conflicts manually for all of the selected branches. If it is not easy to tackle multiple branches in a single sweep, repeat this procedure for each target version branch separately.
+3. After resolving the merge conflicts you can execute `backport --pr <merged_pr_number>` which this time it will be successful. PRs will be opened against the target version branches and they will be ready for approval and merge.
 
 # Backporting Notes
-- CI is essential to this procedure. Whenever you commit something in a backport PR, you check the test results.
-- In case of conflicts, git blame is a wonderful tool to understand what changes need to be included in a version branch before backporting your PR. You can always check the history of the files you touch between the target backport branch and the next version branch (or master). Also, be mindful of the files that are not changed, but refer to the changed files.
-- Sometimes it is necessary to remove individual operations from a track that are not supported by earlier versions. This graceful fallback is a compromise to allow to run a subset of the track on older versions of Elasticsearch too. If this is necessary then it's best to do these changes in a separate commit. 
-- You can backport individual commits to even earlier versions if necessary by cherry-picking them into the desired version branches.
+- CI is essential to this procedure. Whenever you commit something in a backport PR, check the test results.
+- In case of conflicts, git blame is a wonderful tool to understand what changes need to be included in a version branch before backporting your PR. You can always check the history of the files you touch between the target backport branch and master version branch.
+- Sometimes it is necessary to remove individual operations from a track that are not supported by earlier versions. This graceful fallback is a compromise to allow to run a subset of the track on older versions of Elasticsearch too.
 
 # Finish line
 For wrapping up ensure the following:

--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ See all details in the [contributor guidelines](https://github.com/elastic/rally
 Backporting changes
 -------------------
 
-As part of contributing to this repository, a reminder will periodically notify you that backport is pending. Backporting ensures that tracks do not work only for the latest `main` version of Elasticsearch but also for older versions, so it is important.
+Backporting ensures that tracks do not work only for the latest `main` version of Elasticsearch but also for older versions, so it is important. As part of contributing to this repository, a reminder will periodically notify you that backport is pending.
 
 In order to backport your PR, at least one `vX.Y` label has to be added. 
 - Please supply all the labels that correspond to both current and past elasticsearch versions you expect this PR to work with, but choose only from all the available ones. 
-- If the PR you are merging is using functionality from future Elasticsearch versions, please wait for the feature freeze action of Elasticsearch to create the new label in this repository and then add it. In such case, it would be useful if you kept the 'backport pending' label attached to the PR, so the backport reminder can periodically notify you.
+- If the PR being merged is using functionality from future Elasticsearch versions, please wait for the creation of new Elasticsearch `vX.Y` version branch. In such case, it would be useful if you kept the 'backport pending' label attached to the PR, so the backport reminder can periodically notify you.
 
-Every `vX.Y` label is triggering a new PR unless there are merge conflicts. This is the backport action, the status of which is reported through a comment. In case of successful backport action, you get a link to the PR opened against the target version branch, which has a `backport` label and it expects a review of the changes to the corresponding version branch. When approved, it will be automatically merged.
+When adding a `vX.Y` label, the creation of a new PR is triggered unless there are merge conflicts. Its status is reported through a comment and in case it is successfully created, you get a link to the PR opened against the target version branch. This new PR has a `backport` label and expects a review. When approved, it will be automatically merged.
 
 # Merge conflicts
-In case of merge conflicts get ready for some manual actions. Backporting is essential for future development and testing, so please give it a shot. 
+Merge conflicts need to be resolved manually. There are two ways to manually create a backport PR 
 
 ## Fork and cherry-pick
 1. Create a rally-tracks fork, and clone it locally.
@@ -40,7 +40,7 @@ In case of merge conflicts get ready for some manual actions. Backporting is ess
 4. Cherry-pick the commit from the PR that will be backported.
 5. Resolve merge conflicts, commit locally and push to fork.
 6. Open a PR against the target branch, add `backport` label manually.
-7. Request for review and merge.
+7. Request a review and merge.
 8. Repeat for other version branches. 
 
 ## Use backport tool (requires node)
@@ -59,7 +59,7 @@ For wrapping up ensure the following:
 - Every related backport PR has the `backport` label.
 - Every related backport PR is merged to the correct version branches.
 
-Finally, remove the `backport pending` label from your PR and you're good to go.
+Finally, remove the `backport pending` label from your PR.
 
 License
 -------

--- a/github_ci_tools/scripts/backport.py
+++ b/github_ci_tools/scripts/backport.py
@@ -350,7 +350,7 @@ def run_remind(prefetched_prs: list[dict[str, Any]], pending_reminder_age_days: 
                 add_comment(info.number, f"{COMMENT_MARKER_BASE}\n@{author}\n{REMINDER_BODY}")
                 LOG.info(f"PR #{info.number}: initial reminder posted")
             else:
-                LOG.info(f"PR #{info.number}: cooling period not elapsed)")
+                LOG.info(f"PR #{info.number}: skip reminder")
         except Exception as ex:
             LOG.error(f"Remind error for PR #{pr.get('number', '?')}: {ex}")
             errors += 1


### PR DESCRIPTION
Change README.md to depict the changes of backporting. New documentation, contains the correct procedure to be followed and detailed instructions in case of merge conflicts.

Also fixed a typo in backport script