### PR TITLE
[9.2] Restore the continue on error to avoid workflow errors (#917)

### DIFF
--- a/.github/workflows/backport.action.yml
+++ b/.github/workflows/backport.action.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - name: Backport Action
         uses: sorenlouv/backport-github-action@ad888e978060bc1b2798690dd9d03c4036560947  # v9.5.1
+        continue-on-error: true
         with:
           github_token: $BACKPORT_TOKEN
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.2`:
 - [Restore the continue on error to avoid workflow errors (#917)](https://github.com/elastic/rally-tracks/pull/917)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Dris","email":"nick.dris@elastic.co"},"sourceCommit":{"committedDate":"2025-11-17T15:34:42Z","message":"Restore the continue on error to avoid workflow errors (#917)","sha":"81cf5db4b2e3d8095033ca2fa500d0c2ca884f69","branchLabelMapping":{"^v(\\d{1,2})$":"$1","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.2"],"title":"Restore continue-on-error in backporting job to avoid total workflow errors","number":917,"url":"https://github.com/elastic/rally-tracks/pull/917","mergeCommit":{"message":"Restore the continue on error to avoid workflow errors (#917)","sha":"81cf5db4b2e3d8095033ca2fa500d0c2ca884f69"}},"sourceBranch":"master","suggestedTargetBranches":["9.2"],"targetPullRequestStates":[{"branch":"9.2","label":"v9.2","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->