### PR TITLE
Backport fix reminder and target branches

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -3,9 +3,9 @@
   "repoName": "rally-tracks",
   "targetBranchChoices": [
     "9.2",
-    "8.15",
-    "8.14",
-    "8.13"
+    "9.1",
+    "9.0",
+    "8.19",
   ],
   "targetPRLabels": [
     "backport"

--- a/.github/workflows/backport.reminder.yml
+++ b/.github/workflows/backport.reminder.yml
@@ -8,20 +8,27 @@ on:
     - cron: '0 6 * * *'  # Every day at 06:00 UTC
   workflow_dispatch:
     inputs:
+      single_pr:
+        description: 'PR number to process (only for pull_request_target event)'
+        required: false
       lookback_days:
         description: 'How many days back to search merged PRs'
         required: false
         default: '7'
       pending_label_age_days:
-        description: 'Minimum age in days before reminding'
-        required: false
-        default: '14'
+          description: 'Minimum age in days before reminding'
+          required: false
+          default: '14'
 
 env:
     BACKPORT_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
 
 jobs:
+<<<<<<< HEAD
   reminder:
+=======
+  label:
+>>>>>>> 672866d3 (Attempt a fix 4 [skip ci] (#129))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -30,12 +37,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+<<<<<<< HEAD
       - name: Add Backport pending label (single PR)
         if: github.event_name == 'pull_request_target'
         run: |
           python github_ci_tools/scripts/backport.py --pr-mode label
           python github_ci_tools/scripts/backport.py --pr-mode remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
       - name: Add Backport pending label (bulk)
+=======
+      - name: Add Backport pending label & remind (single PR)
+        if: github.event_name == 'pull_request_target'
+        run: |
+          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.pull_request.number }} label
+          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.pull_request.number }} remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
+      - name: Add Backport pending label & remind (bulk)
+>>>>>>> 672866d3 (Attempt a fix 4 [skip ci] (#129))
         if: github.event_name != 'pull_request_target'
         run: |
           python github_ci_tools/scripts/backport.py label --lookback-days ${{ github.event.inputs.lookback_days || '7' }}

--- a/.github/workflows/backport.reminder.yml
+++ b/.github/workflows/backport.reminder.yml
@@ -1,4 +1,4 @@
-name: Backport reminder
+name: Backport utilities
 
 on:
   pull_request_target:
@@ -9,16 +9,16 @@ on:
   workflow_dispatch:
     inputs:
       single_pr:
-        description: 'PR number to process (only for pull_request_target event)'
+        description: 'PR number to process (single-PR run; leave empty for bulk)'
         required: false
       lookback_days:
-        description: 'How many days back to search merged PRs'
+        description: 'Lookback window for merged PRs (days)'
         required: false
         default: '7'
       pending_label_age_days:
-          description: 'Minimum age in days before reminding'
-          required: false
-          default: '14'
+        description: 'Minimum previous reminder age (days)'
+        required: false
+        default: '14'
 
 env:
     BACKPORT_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
@@ -34,12 +34,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Add Backport pending label & remind (single PR)
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' || (github.event_name == 'workflow_dispatch' && github.event.inputs.single_pr != '')
         run: |
-          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.pull_request.number }} label
-          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.pull_request.number }} remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
+          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.inputs.single_pr || github.event.pull_request.number }} label
+          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.inputs.single_pr || github.event.pull_request.number }} remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
       - name: Add Backport pending label & remind (bulk)
-        if: github.event_name != 'pull_request_target'
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.single_pr == '' || github.event.inputs.single_pr == null))
         run: |
           python github_ci_tools/scripts/backport.py label --lookback-days ${{ github.event.inputs.lookback_days || '7' }}
           python github_ci_tools/scripts/backport.py remind --lookback-days ${{ github.event.inputs.lookback_days || '7' }} --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}

--- a/.github/workflows/backport.reminder.yml
+++ b/.github/workflows/backport.reminder.yml
@@ -24,11 +24,7 @@ env:
     BACKPORT_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
 
 jobs:
-<<<<<<< HEAD
-  reminder:
-=======
-  label:
->>>>>>> 672866d3 (Attempt a fix 4 [skip ci] (#129))
+  label_and_remind:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,21 +33,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-<<<<<<< HEAD
-      - name: Add Backport pending label (single PR)
-        if: github.event_name == 'pull_request_target'
-        run: |
-          python github_ci_tools/scripts/backport.py --pr-mode label
-          python github_ci_tools/scripts/backport.py --pr-mode remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
-      - name: Add Backport pending label (bulk)
-=======
       - name: Add Backport pending label & remind (single PR)
         if: github.event_name == 'pull_request_target'
         run: |
           python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.pull_request.number }} label
           python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.pull_request.number }} remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
       - name: Add Backport pending label & remind (bulk)
->>>>>>> 672866d3 (Attempt a fix 4 [skip ci] (#129))
         if: github.event_name != 'pull_request_target'
         run: |
           python github_ci_tools/scripts/backport.py label --lookback-days ${{ github.event.inputs.lookback_days || '7' }}

--- a/.github/workflows/backport.reminder.yml
+++ b/.github/workflows/backport.reminder.yml
@@ -19,6 +19,10 @@ on:
         description: 'Minimum previous reminder age (days)'
         required: false
         default: '14'
+      remove:
+        description: 'If set to true, remove pending labels/reminders instead of adding/reminding'
+        required: false
+        default: 'false'
 
 env:
     BACKPORT_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
@@ -47,5 +51,6 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           pr_number_clause="${{ github.event.inputs.single_pr && format('--pr-number {0}', github.event.inputs.single_pr) || '' }}"
-          python github_ci_tools/scripts/backport.py $pr_number_clause label --lookback-days ${{ github.event.inputs.lookback_days || '7' }}
-          python github_ci_tools/scripts/backport.py $pr_number_clause remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
+          remove_clause="${{ github.event.inputs.remove == 'true' && '--remove' || '' }}"
+          python github_ci_tools/scripts/backport.py $pr_number_clause label --lookback-days ${{ github.event.inputs.lookback_days || '7' }} $remove_clause
+          python github_ci_tools/scripts/backport.py $pr_number_clause remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }} $remove_clause

--- a/.github/workflows/backport.reminder.yml
+++ b/.github/workflows/backport.reminder.yml
@@ -33,13 +33,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Add Backport pending label & remind (single PR)
-        if: github.event_name == 'pull_request_target' || (github.event_name == 'workflow_dispatch' && github.event.inputs.single_pr != '')
+      - name: Add Backport pending label & remind (pull request)
+        if: github.event_name == 'pull_request_target'
         run: |
-          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.inputs.single_pr || github.event.pull_request.number }} label
-          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.inputs.single_pr || github.event.pull_request.number }} remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
-      - name: Add Backport pending label & remind (bulk)
-        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.single_pr == '' || github.event.inputs.single_pr == null))
+          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.pull_request.number }} label
+          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.pull_request.number }} remind
+      - name: Add Backport pending label & remind (scheduled)
+        if: github.event_name == 'schedule'
         run: |
-          python github_ci_tools/scripts/backport.py label --lookback-days ${{ github.event.inputs.lookback_days || '7' }}
-          python github_ci_tools/scripts/backport.py remind --lookback-days ${{ github.event.inputs.lookback_days || '7' }} --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
+          python github_ci_tools/scripts/backport.py label
+          python github_ci_tools/scripts/backport.py remind
+      - name: Add Backport pending label & remind (workflow dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          pr_number_clause="${{ github.event.inputs.single_pr && format('--pr-number {0}', github.event.inputs.single_pr) || '' }}"
+          python github_ci_tools/scripts/backport.py $pr_number_clause label --lookback-days ${{ github.event.inputs.lookback_days || '7' }}
+          python github_ci_tools/scripts/backport.py $pr_number_clause remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}

--- a/github_ci_tools/scripts/backport.py
+++ b/github_ci_tools/scripts/backport.py
@@ -174,14 +174,10 @@ def load_event() -> dict:
     return data
 
 
-def list_prs(q_filter: str, since: dt.datetime, number: int | None = None) -> Iterable[dict[str, Any]]:
-    """Query the GH API with a filter to iterate over PRs updated after a given timestamp.
-
-    Optionally restrict to a specific PR number when `number` is provided.
-    """
+def list_prs(q_filter: str, since: dt.datetime) -> Iterable[dict[str, Any]]:
+    """Query the GH API with a filter to iterate over PRs updated after a given timestamp."""
     q_date = since.strftime("%Y-%m-%d")
-    num_clause = f" number:{number}" if number is not None else ""
-    q = f"{q_filter}{num_clause} updated:>={q_date}"
+    q = f"{q_filter} updated:>={q_date}"
     LOG.debug(f"Fetch PRs with filter '{q}'")
     params = {"q": f"{q}", "per_page": "100"}
     for page in itertools.count(1):
@@ -394,10 +390,30 @@ def configure(args: argparse.Namespace) -> None:
 
 
 def prefetch_prs(pr_number: int | None, lookback_days: int) -> list[dict[str, Any]]:
+    if pr_number is not None:
+        q_path = f"repos/{CONFIG.repo}/pulls/{pr_number}"
+        pr_data = gh_request(path=q_path)
+        # Ensure PR is merged.
+        merged_flag = pr_data.get("merged")
+        merged_at = pr_data.get("merged_at")
+        if not merged_flag and not merged_at:
+            raise RuntimeError(f"PR #{pr_data.get('number','?')} not merged yet; skipping.")
+        try:
+            merged_dt = dt.datetime.strptime(merged_at, ISO_FORMAT).replace(tzinfo=dt.timezone.utc)
+        except ValueError as e:
+            raise RuntimeError(f"Invalid merged_at format: {merged_at}") from e
+        now = dt.datetime.now(dt.timezone.utc)
+        age_days = (now - merged_dt).days
+        if age_days >= lookback_days + 1:
+            LOG.info(
+                f"PR #{pr_data.get('number','?')} merged_at {merged_at} age={age_days}d "
+                f"exceeds lookback_days={lookback_days}; filtering out."
+            )
+            return []
+        return [pr_data]
     now = dt.datetime.now(dt.timezone.utc)
     since = now - dt.timedelta(days=lookback_days)
-    if pr_number is not None:
-        return list(list_prs(f"repo:{CONFIG.repo} is:pr is:merged", since, number=pr_number))
+    # Note that we rely on is:merged to filter out unmerged PRs.
     return list(list_prs(f"repo:{CONFIG.repo} is:pr is:merged", since))
 
 

--- a/github_ci_tools/tests/conftest.py
+++ b/github_ci_tools/tests/conftest.py
@@ -268,12 +268,3 @@ def gh_mock(backport_mod, monkeypatch: pytest.MonkeyPatch) -> GitHubMock:
     mock = GitHubMock()
     monkeypatch.setattr(backport_mod, "gh_request", mock)
     return mock
-
-
-# --------------------------- Event Payload ---------------------------
-@pytest.fixture()
-def event_file(tmp_path, monkeypatch) -> Path:
-    """Create a temporary GitHub event JSON."""
-    path = tmp_path / "event.json"
-    monkeypatch.setenv("GITHUB_EVENT_PATH", str(path))
-    return path

--- a/github_ci_tools/tests/resources/cases.py
+++ b/github_ci_tools/tests/resources/cases.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from typing import Any, Callable, TypeVar
 
 import pytest

--- a/github_ci_tools/tests/resources/cases.py
+++ b/github_ci_tools/tests/resources/cases.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from typing import Any, Callable, TypeVar
 
 import pytest
@@ -95,8 +95,12 @@ class RepoCase:
                 gh_mock.add(
                     static_create_pending_label.method, static_create_pending_label.path, response=static_create_pending_label.response
                 )
-
-        pass
+        for pr in self.prs:
+            gh_mock.add(
+                "GET",
+                f"/repos/{self.name}/pulls/{pr.number}",
+                response=asdict(pr),
+            )
 
 
 # ---------------- Unified Interaction Case -----------------

--- a/github_ci_tools/tests/test_backport_cli.py
+++ b/github_ci_tools/tests/test_backport_cli.py
@@ -232,7 +232,7 @@ def test_backport_run(backport_mod, gh_mock, monkeypatch, case: BackportCliCase)
                 result = backport_mod.run_remind(
                     prefetched,
                     args.pending_reminder_age_days,
-                    args.lookback_days,
+                    args.remove,
                 )
                 for pr in prefetched:
                     if pr.get("needs_pending", False) is False:


### PR DESCRIPTION
This change is being introduced because in the event of merging a PR to master, both `remind` and `label` commands execute in `--pr-mode` which fetches the PR data from the `github.event` inside the workflow. In which case `github.event` is the same in both commands, so even if `label` was successful, `remind` has the initial `github.event` so no reminder is posted. 

Another solution was to break up the workflows to `label` and `remind` but this results in flooding the github actions, so this current approach is more preferrable.

Changes:
- `--pr-mode` argument to `--pr-number` which enforces backport cli to fetch data of a single PR from github API, instead of getting it through github event from actions. 
- PR number argument added to the workflow_dispatch manual mode and if given backport ci
- Unit tests for `--pr-mode` removed
- Unit tests for `--pr-number` added