### PR TITLE
[8.19] Run serverless CI only on PRs targeting master (#859)

### DIFF
--- a/.buildkite/it/serverless-pipeline.yml
+++ b/.buildkite/it/serverless-pipeline.yml
@@ -22,12 +22,14 @@ agents:
 
 steps:
   - label: "Run IT serverless tests with user privileges"
+    if: build.pull_request.base_branch == "master" || build.source == "schedule"
     plugins:
       - elastic/vault-secrets#v0.0.2: *vault-base_url
       - elastic/vault-secrets#v0.0.2: *vault-get_credentials_endpoint
       - elastic/vault-secrets#v0.0.2: *vault-api_key
     command: bash .buildkite/it/run_serverless.sh 3.13 test_user $RUN_FULL_CI_WHEN_CHANGED
   - label: "Run IT Serverless tests with operator privileges"
+    if: build.pull_request.base_branch == "master" || build.source == "schedule"
     plugins:
       - elastic/vault-secrets#v0.0.2: *vault-base_url
       - elastic/vault-secrets#v0.0.2: *vault-get_credentials_endpoint


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.19`:
 - [Run serverless CI only on PRs targeting master (#859)](https://github.com/elastic/rally-tracks/pull/859)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Dris","email":"nick.dris@elastic.co"},"sourceCommit":{"committedDate":"2025-09-19T14:40:29Z","message":"Run serverless CI only on PRs targeting master (#859)\n\nServerless CI tests will be now tested only in PRs targetting master branch, or on scheduled runs","sha":"4cf6c476d5317b633b4e92233917e3ba31fb0708","branchLabelMapping":{"^backport-to-(.+)$":"$1"}},"sourcePullRequest":{"labels":["v8.15","v8.19","v9.0"],"title":"Run serverless CI only on PRs targeting master","number":859,"url":"https://github.com/elastic/rally-tracks/pull/859","mergeCommit":{"message":"Run serverless CI only on PRs targeting master (#859)\n\nServerless CI tests will be now tested only in PRs targetting master branch, or on scheduled runs","sha":"4cf6c476d5317b633b4e92233917e3ba31fb0708"}},"sourceBranch":"master","suggestedTargetBranches":["8.19","9.0"],"targetPullRequestStates":[{"url":"https://github.com/elastic/rally-tracks/pull/958","number":958,"branch":"8.15","state":"MERGED","mergeCommit":{"sha":"d2f7da22c782704a5253fd85098a3459b647c2d9","message":"Run serverless CI only on PRs targeting master (#859) (#958)\n\nServerless CI tests will be now tested only in PRs targetting master branch, or on scheduled runs\n\n(cherry picked from commit 4cf6c476d5317b633b4e92233917e3ba31fb0708)\n\nCo-authored-by: Nick Dris <nick.dris@elastic.co>"}}]}] BACKPORT-->