### PR TITLE
Adjust openai_vector benchmark for gpu indexing 9.3

### DIFF
--- a/openai_vector/challenges/default.json
+++ b/openai_vector/challenges/default.json
@@ -31,16 +31,11 @@
       }
     },
     {
-      "name": "wait-until-merges-finish-after-index",
       "operation": {
-        "operation-type": "index-stats",
-        "index": "_all",
-        "condition": {
-          "path": "_all.total.merges.current",
-          "expected-value": 0
-        },
-        "retry-until-success": true,
-        "include-in-reporting": false
+        "operation-type": "force-merge",
+        "max-num-segments": {{max_num_segments | default(1)}},
+        "request-timeout": {{force_merge_timeout | default(7200)}},
+        "include-in-reporting": true
       }
     }
     {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
@@ -76,29 +71,7 @@
       "clients": {{ standalone_search_clients | default(8) | int }},
       "iterations": {{ standalone_search_iterations | default(10000) | int }}
     }
-    {%- endfor %},
-    {
-      "parallel": {
-        "completed-by": "parallel-documents-indexing-bulk",
-        "tasks": [
-          {
-            "name": "parallel-documents-indexing-bulk",
-            "operation": "parallel-documents-indexing",
-            "warmup-time-period": 60,
-            "clients": {{ parallel_indexing_bulk_clients | default(1) | int }},
-            "time-period": {{ parallel_indexing_time_period | default(1800) | int }},
-            "target-throughput": {{ parallel_indexing_bulk_target_throughput | default(1) | int }}
-          },
-          {
-            "name": "parallel-documents-indexing-search-knn-10-100",
-            "operation": "knn-search-10-100",
-            "warmup-time-period": 60,
-            "clients": {{ parallel_indexing_search_clients | default(3) | int }},
-            "target-throughput": {{ parallel_indexing_search_target_throughput | default(100) | int }}
-          }
-        ]
-      }
-    }
+    {%- endfor %}
     {%- for i in range(p_search_ops|length) %},
     {
       {%- if p_search_ops[i][2] > 0 -%}

--- a/openai_vector/index-vectors-only-with-docid-mapping.json
+++ b/openai_vector/index-vectors-only-with-docid-mapping.json
@@ -5,6 +5,8 @@
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],
       {% endif %}
     "index.number_of_shards": {{number_of_shards | default(1)}},
+    "index.refresh_interval": -1,
+    "index.merge.scheduler.auto_throttle" : false,
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },


### PR DESCRIPTION
  - Replaces the merge-wait polling with an explicit force-merge operation
  - Removes parallel search and indexing
  - Optimizes indexing performance by disabling merge throttling and refresh intervals

---

For GPU indexing pass the following `params.json` file  to a rally run:

params.json
```js
{
  "vector_index_type" : "hnsw",   
  "initial_indexing_bulk_indexing_clients" : 8,
  "mapping_type" : "vectors-only-with-docid",
  "initial_indexing_corpora" : "openai_initial_indexing_base64",  
  "parallel_indexing_corpora": "openai_parallel_indexing_base64"
}
```

Run with:

./rally race ...--runtime-jdk=25 --track-params=params.json  --on-error=abort


---
### Rally setup

vim ~/.rally/rally.ini
```bashrc
...
[system]
env.name = local
passenv = PATH,LD_LIBRARY_PATH

```

---

### An example of running openai_vector track

params.json
```js
{
  "vector_index_type" : "hnsw",   
  "initial_indexing_bulk_indexing_clients" : 8,
  "initial_indexing_corpora" : "openai_initial_indexing_base64",  
  "parallel_indexing_corpora": "openai_parallel_indexing_base64"
}
```

```
./rally race --track-path /home/ubuntu/elastic/rally-tracks/openai_vector \
--pipeline from-sources \
--revision current \
--car "16gheap" \
--user-tags "tag:openai_vector_gpu" \
--report-file /home/ubuntu/elastic/benchmarks/rally_results/openai_vector_gpu.md \
--runtime-jdk=25   \
--track-params=/home/ubuntu/elastic/benchmarks/rally/params.json \
--on-error=abort
```

To compare with CPU based index **disable gpu indexing** with --car-params="additional_cluster_settings:{'vectors.indexing.use_gpu':true}": 


```
./rally race --track-path /home/ubuntu/elastic/rally-tracks/openai_vector \
      --pipeline from-sources \
      --revision current \
      --car "16gheap" \
      --user-tags "tag:openai_vector_cpu" \
      --report-file /home/ubuntu/elastic/benchmarks/rally_results/openai_vector_cpu.md \
      --runtime-jdk=25 \
      --track-params=/home/ubuntu/elastic/benchmarks/rally/params.json \
      --car-params='{"additional_cluster_settings": {"vectors.indexing.use_gpu": false}}' \
      --on-error=abort
```

---

### Troubleshoot
- Check ~/.rally/benchmarks/races/<raceID> /rally-node-0/logs/server/rally-benchmark.log. If you see similar output in the elasticsearch server logs:
[o.e.x.g.GPUSupport       ] [elasticsearch-0] Found compatible GPU [NVIDIA L4] (id: [0])

it means your setup is successful, and Elasticsearch can use GPU. If you don’t see this line from GPUSupport, you should see an explanation why elasticsearch can’t use your GPU device.
