### PR TITLE
Remove ESQL term function tests from wikipedia

### DIFF
--- a/wikipedia/challenges/common/esql-full-text-functions.json
+++ b/wikipedia/challenges/common/esql-full-text-functions.json
@@ -89,19 +89,4 @@
   "clients": {{ standalone_search_clients | default(20) | int }},
   "warmup-iterations": {{ warmup_iterations | default(100) }},
   "iterations": {{ iterations | default(1000) }}
-},
-{
-  "name": "standalone-esql-term-search",
-  "operation": "query-esql-term-search",
-  "query-type": "match",
-  "clients": {{ standalone_search_clients | default(20) | int }},
-  "warmup-iterations": {{ warmup_iterations | default(100) }},
-  "iterations": {{ iterations | default(1000) }}
-},
-{
-  "name": "standalone-query-term-search",
-  "operation": "query-term-search",
-  "clients": {{ standalone_search_clients | default(20) | int }},
-  "warmup-iterations": {{ warmup_iterations | default(100) }},
-  "iterations": {{ iterations | default(1000) }}
 }

--- a/wikipedia/operations/default.json
+++ b/wikipedia/operations/default.json
@@ -205,22 +205,6 @@
   "search-fields" : "{{ query_string_search_fields | default("*") }}"
 },
 {
-  "name": "query-term-search",
-  "operation-type": "search",
-  "param-source": "query-search",
-  "query-type": "term",
-  "size" : {{ query_string_search_page_size | default(20) | int }},
-  "search-fields" : "{{ query_string_search_fields | default("*") }}"
-},
-{
-  "name": "query-esql-term-search",
-  "operation-type": "esql",
-  "param-source": "esql-search",
-  "query-type": "term",
-  "size" : {{ query_string_search_page_size | default(20) | int }},
-  "search-fields" : "{{ query_string_search_fields | default("*") }}"
-},
-{
   "name": "retriever-search",
   "operation-type": "raw-request",
   "param-source": "retriever-search",

--- a/wikipedia/track.py
+++ b/wikipedia/track.py
@@ -232,8 +232,6 @@ class EsqlSearchParamSource(QueryIteratorParamSource):
                 query_body = f'MATCH(title, "{ query }") OR MATCH(content, "{ query }")'
             elif self._query_type == "kql":
                 query_body = f'KQL("{ self._search_fields }:{ query }")'
-            elif self._query_type == "term":
-                query_body = f'TERM(title, "{ query }") OR TERM(content, "{ query }")'
             elif self._query_type == "match_phrase":
                 query_body = f'MATCH_PHRASE(title, "{ query }") OR MATCH_PHRASE(content, "{ query }")'
             else:
@@ -266,8 +264,6 @@ class QueryParamSource(QueryIteratorParamSource):
                 query_body = {"bool": {"should": [{"match": {"title": query}}, {"match": {"content": query}}]}}
             elif self._query_type == "multi_match":
                 query_body = {"bool": {"should": [{"match": {"title": query}}, {"match": {"content": query}}]}}
-            elif self._query_type == "term":
-                query_body = {"bool": {"should": [{"term": {"title": query}}, {"term": {"content": query}}]}}
             elif self._query_type == "match_phrase":
                 query_body = {"bool": {"should": [{"match_phrase": {"title": query}}, {"match_phrase": {"content": query}}]}}
             else:


### PR DESCRIPTION
TERM ES|QL function is going to be removed. We'll remove it from Wikipedia rally track, which was the only track using it.