### PR TITLE
Use the _base_url variable in M

### DIFF
--- a/msmarco-v2-vector/track.json
+++ b/msmarco-v2-vector/track.json
@@ -58,7 +58,7 @@
     },
     {
       "name": "msmarco-v2-initial-indexing-2",
-      "base-url": "{{base_url}}",
+      "base-url": "{{_base_url}}",
       "documents": [
         {
           "source-file": "cohere-documents-07.json.zst",
@@ -100,7 +100,7 @@
     },
     {
       "name": "msmarco-v2-initial-indexing-3",
-      "base-url": "{{base_url}}",
+      "base-url": "{{_base_url}}",
       "documents": [
         {
           "source-file": "cohere-documents-13.json.zst",
@@ -142,7 +142,7 @@
     },
     {
       "name": "msmarco-v2-initial-indexing-4",
-      "base-url": "{{base_url}}",
+      "base-url": "{{_base_url}}",
       "documents": [
         {
           "source-file": "cohere-documents-19.json.zst",
@@ -184,7 +184,7 @@
     },
     {
       "name": "msmarco-v2-initial-indexing-5",
-      "base-url": "{{base_url}}",
+      "base-url": "{{_base_url}}",
       "documents": [
         {
           "source-file": "cohere-documents-25.json.zst",
@@ -226,7 +226,7 @@
     },
     {
       "name": "msmarco-v2-initial-indexing-6",
-      "base-url": "{{base_url}}",
+      "base-url": "{{_base_url}}",
       "documents": [
         {
           "source-file": "cohere-documents-31.json.zst",
@@ -268,7 +268,7 @@
     },
     {
       "name": "msmarco-v2-initial-indexing-7",
-      "base-url": "{{base_url}}",
+      "base-url": "{{_base_url}}",
       "documents": [
         {
           "source-file": "cohere-documents-37.json.zst",
@@ -310,7 +310,7 @@
     },
     {
         "name": "msmarco-v2-initial-indexing-8",
-        "base-url": "{{base_url}}",
+        "base-url": "{{_base_url}}",
         "documents": [
         {
           "source-file": "cohere-documents-43.json.zst",


### PR DESCRIPTION
`_base_url` is set [here](https://github.com/elastic/rally-tracks/blob/master/msmarco-v2-vector/track.json#L2) from the default or track-param but is not used consistently in the track. In many places `base_url` without the leading underscore is used but `base_url` may not be set leading to a download error. 

```
esrally.exceptions.DataError: Cannot download data because no base URL is provided.
```

This change uses the `_base_url` variable as that is always set or default correctly. 