### PR TITLE
[9.3] Add more params to MS Marco v2 to turn on and off tests (#1040)

### DIFF
--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -71,9 +71,13 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - `index_refresh_interval` (default: unset): The index refresh interval.
  - `corpora` (default: ["msmarco-v2_float-initial-indexing-1", ..., "msmarco-v2_float-initial-indexing-8"])
  - `initial_indexing_bulk_indexing_clients` (default: 5)
- - `initial_indexing_ingest_percentage` (default: 100)
  - `initial_indexing_bulk_size` (default: 500)
  - `initial_indexing_bulk_warmup` (default: 40)
+ - `initial_indexing_ingest_doc_count` (default: unset) The absolute number of docs to ingest. Incompatible with `initial_indexing_ingest_percentage`  
+ - `initial_indexing_ingest_percentage` (default: 100)
+ - `include_initial_indexing` (default: true) If `true` run the initial indexing and post index sleep steps. If `false` the data should have been pre-ingested
+ - `include_parallel_indexing` (default: true) Include the parallel indexing benchmark
+ - `include_recall` (default: true) Include the recall benchmark
  - `number_of_shards` (default: 1)
  - `number_of_replicas` (default: 0)
  - `parallel_corpora` (default:"msmarco-v2_float-parallel-indexing")

--- a/msmarco-v2-vector/challenges/default.json
+++ b/msmarco-v2-vector/challenges/default.json
@@ -3,6 +3,7 @@
   "description": "",
   "default": true,
   "schedule": [
+    {# include-initial-indexing-marker-start #}{%- if include_initial_indexing|default(true) -%}
     {
       "operation": {
         "operation-type": "delete-index"
@@ -42,17 +43,18 @@
         "retry-until-success": true,
         "include-in-reporting": false
       }
-    }
-    {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%},
+    },
+    {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
     {
       "name": "post-ingest-sleep",
       "operation": {
         "operation-type": "sleep",
         "duration": {{ post_ingest_sleep_duration|default(30) }}
       }
-    }
+    },
     {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
-    {%- for i in range(p_search_ops|length) %},
+    {%- endif -%}{# include-initial-indexing-marker-end #}
+    {%- for i in range(p_search_ops|length) %}
     {
       {%- if p_search_ops[i][2] > 0 -%}
         "name": "standalone-search-knn-{{p_search_ops[i][0]}}-{{p_search_ops[i][1]}}-{{p_search_ops[i][2]}}-single-client",
@@ -61,7 +63,7 @@
         "name": "standalone-search-knn-{{p_search_ops[i][0]}}-{{p_search_ops[i][1]}}-single-client",
         "operation": "knn-search-{{p_search_ops[i][0]}}-{{p_search_ops[i][1]}}"
       {%- endif -%},
-      "warmup-iterations": 1000,
+      "warmup-iterations": {{ standalone_search_warmup_iterations | default(1000) | int }},
       "iterations": {{ standalone_search_iterations | default(10000) | int }}
     },
     {
@@ -72,11 +74,12 @@
         "name": "standalone-search-knn-{{p_search_ops[i][0]}}-{{p_search_ops[i][1]}}-multiple-clients",
         "operation": "knn-search-{{p_search_ops[i][0]}}-{{p_search_ops[i][1]}}"
       {%- endif -%},
-      "warmup-iterations": 1000,
+      "warmup-iterations": {{ standalone_search_warmup_iterations | default(1000) | int }},
       "clients": {{ standalone_search_clients | default(8) | int }},
       "iterations": {{ standalone_search_iterations | default(10000) | int }}
-    }
-    {%- endfor %},
+    }{%- if not loop.last %},{%- endif %}
+    {%- endfor %}
+    {%- if include_parallel_indexing|default(true) %},
     {
       "parallel": {
         "completed-by": "parallel-documents-indexing-bulk",
@@ -97,6 +100,8 @@
         ]
       }
     }
+    {%- endif %}
+    {% if include_recall|default(true) %}
     {%- for i in range(p_search_ops|length) %},
     {
       {%- if p_search_ops[i][2] > 0 -%}
@@ -106,6 +111,7 @@
       {%- endif -%}
     }
     {%- endfor %}
+    {%- endif %}
   ]
 },
 {

--- a/msmarco-v2-vector/operations/default.json
+++ b/msmarco-v2-vector/operations/default.json
@@ -21,7 +21,11 @@
        {{ ", " if not loop.last else "" }}
    {% endfor %}],
   "bulk-size": {{initial_indexing_bulk_size | default(500)}},
+  {%- if initial_indexing_ingest_doc_count is defined %}
+  "ingest-doc-count": {{ initial_indexing_ingest_doc_count }}
+  {%- else %}
   "ingest-percentage": {{initial_indexing_ingest_percentage | default(100)}}
+  {%- endif %}   
 },
 {
   "name": "parallel-documents-indexing",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.3`:
 - [Add more params to MS Marco v2 to turn on and off tests (#1040)](https://github.com/elastic/rally-tracks/pull/1040)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"David Kyle","email":"david.kyle@elastic.co"},"sourceCommit":{"committedDate":"2026-02-10T13:13:29Z","message":"Add more params to MS Marco v2 to turn on and off tests (#1040)\n\nThe `include_parallel_indexing` and `include_recall` params control skipping \nthat part of the benchmark if not required. `include_initial_indexing` is useful for \nrunning against a pre-provisioned cluster with the data ingested.\nThe index-and-search track now supports `initial_indexing_ingest_doc_count`","sha":"a4cda501c85159de5d4b06415b1c5b1edec67ab4","branchLabelMapping":{"^v9.4$":"master","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.3"],"title":"Add more params to MS Marco V2 to turn on and off parts of the challenge","number":1040,"url":"https://github.com/elastic/rally-tracks/pull/1040","mergeCommit":{"message":"Add more params to MS Marco v2 to turn on and off tests (#1040)\n\nThe `include_parallel_indexing` and `include_recall` params control skipping \nthat part of the benchmark if not required. `include_initial_indexing` is useful for \nrunning against a pre-provisioned cluster with the data ingested.\nThe index-and-search track now supports `initial_indexing_ingest_doc_count`","sha":"a4cda501c85159de5d4b06415b1c5b1edec67ab4"}},"sourceBranch":"master","suggestedTargetBranches":["9.3"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->