### PR TITLE
hybrid search fix: add back top-n into fork branches

### DIFF
--- a/msmarco-v2-vector/track.py
+++ b/msmarco-v2-vector/track.py
@@ -324,7 +324,10 @@ class EsqlHybridParamSource:
 
         hybrid_query = f"FROM {self._index_name} METADATA _index, _id, _score"
         hybrid_query += (
-            f" | FORK" f" ({lexical_query} | DROP emb)" f" ({knn_query} | DROP emb)" f" | FUSE | SORT _score DESC | LIMIT {self._size}"
+            f" | FORK"
+            f" ({lexical_query} | SORT _score DESC | LIMIT {self._size} | DROP emb )"
+            f" ({knn_query} | SORT _score DESC | LIMIT {self._size} | DROP emb)"
+            f" | FUSE | SORT _score DESC"
         )
 
         if not self._keep_all:


### PR DESCRIPTION
Add `SORT` and `LIMIT` to fork branches in hybrid ESQL queries

- After merging https://github.com/elastic/rally-tracks/pull/1010 I found through testing that even though https://github.com/elastic/elasticsearch/pull/139605 is merged, the SORT and LIMIT from are not pushed down to fork branches.
- Debugging the query looks like the [query optimizer is a no-op due to the fact that an implicit limit is added to Fork](https://github.com/elastic/elasticsearch/blob/eb0eeb48cd180ea99339212c05c5e45190474fbe/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/logical/PushDownLimitAndOrderByIntoFork.java#L49).
- Noticed that the results returned are not high scoring like the ones returned by DSL.