### PR TITLE
msmarco-v2-vector track: only allow explicit configuration of shards …

### DIFF
--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -92,6 +92,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - `vector_index_type` (default: "int8_hnsw"): The index kind for storing the vectors.
  - `vector_index_element_type` (default: "float"): Sets the dense_vector element type.
  - `enable_experimental_features` (default: false): Enables experimental dense vector features that may break backward compatibility.
+ - `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
 
 For running with Base64 encoded strings, use a parameter file like:
 

--- a/msmarco-v2-vector/index-vectors-only-mapping.json
+++ b/msmarco-v2-vector/index-vectors-only-mapping.json
@@ -1,21 +1,28 @@
 {% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 
 {
+{%- set comma = joiner(",") -%}
   "settings": {
     "index": {
       {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {%- if index_refresh_interval is defined %}
-      "refresh_interval": {{ index_refresh_interval | tojson }},
+      {{comma()}}
+      "refresh_interval": {{ index_refresh_interval | tojson }}
       {%- endif %}
       {% if preload_pagecache %}
+      {{comma()}}
       "store.preload": [ "vec", "vex", "vem"]
       {% endif %}
-      {% if p_include_non_serverless_index_settings %},
+      {% if p_include_non_serverless_index_settings %}
+      {{comma()}}
       "number_of_shards": {{number_of_shards | default(1)}},
       "number_of_replicas": {{number_of_replicas | default(0)}}
-      {% endif %}{% if enable_experimental_features | default(false) %},
+      {% endif %}
+      {% if enable_experimental_features | default(false) %}
+      {{comma()}}
       "dense_vector.experimental_features": true{% endif %}
-      {% if aggressive_merge_policy %},
+      {% if aggressive_merge_policy %}
+      {{comma()}}
       "merge": {
         "policy": {
           "max_merged_segment": "25gb",

--- a/msmarco-v2-vector/index-vectors-only-mapping.json
+++ b/msmarco-v2-vector/index-vectors-only-mapping.json
@@ -1,3 +1,5 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+
 {
   "settings": {
     "index": {
@@ -6,10 +8,12 @@
       "refresh_interval": {{ index_refresh_interval | tojson }},
       {%- endif %}
       {% if preload_pagecache %}
-      "store.preload": [ "vec", "vex", "vem"],
+      "store.preload": [ "vec", "vex", "vem"]
       {% endif %}
+      {% if p_include_non_serverless_index_settings %},
       "number_of_shards": {{number_of_shards | default(1)}},
-      "number_of_replicas": {{number_of_replicas | default(0)}}{% if enable_experimental_features | default(false) %},
+      "number_of_replicas": {{number_of_replicas | default(0)}}
+      {% endif %}{% if enable_experimental_features | default(false) %},
       "dense_vector.experimental_features": true{% endif %}
       {% if aggressive_merge_policy %},
       "merge": {

--- a/msmarco-v2-vector/index-vectors-with-text-mapping.json
+++ b/msmarco-v2-vector/index-vectors-with-text-mapping.json
@@ -1,17 +1,25 @@
 {% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 
 {
+  {%- set comma = joiner(",") -%}
   "settings": {
-    {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-      {% if preload_pagecache %}
+    {# non-serverless-index-settings-marker-start #}
+    {%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {% if preload_pagecache %}
+    {{comma()}}
     "index.store.preload": [ "vec", "vex", "vem"]
-      {% endif %}
-      {% if p_include_non_serverless_index_settings %},
+    {% endif %}
+    {% if p_include_non_serverless_index_settings %}
+    {{comma()}}
     "index.number_of_shards": {{number_of_shards | default(1)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}}
-      {% endif %}{% if enable_experimental_features | default(false) %},
-    "index.dense_vector.experimental_features": true{% endif %}
-    {%- endif -%}{# non-serverless-index-settings-marker-end #}
+    {% endif %}
+    {% if enable_experimental_features | default(false) %}
+    {{comma()}}
+    "index.dense_vector.experimental_features": true
+    {% endif %}
+    {%- endif -%}
+    {# non-serverless-index-settings-marker-end #}
   },
   "mappings": {
     "properties": {

--- a/msmarco-v2-vector/index-vectors-with-text-mapping.json
+++ b/msmarco-v2-vector/index-vectors-with-text-mapping.json
@@ -1,11 +1,15 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
+
 {
   "settings": {
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {% if preload_pagecache %}
-    "index.store.preload": [ "vec", "vex", "vem"],
+    "index.store.preload": [ "vec", "vex", "vem"]
       {% endif %}
+      {% if p_include_non_serverless_index_settings %},
     "index.number_of_shards": {{number_of_shards | default(1)}},
-    "index.number_of_replicas": {{number_of_replicas | default(0)}}{% if enable_experimental_features | default(false) %},
+    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+      {% endif %}{% if enable_experimental_features | default(false) %},
     "index.dense_vector.experimental_features": true{% endif %}
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },


### PR DESCRIPTION
…and replicas in serverless mode.

Depending on how its invoked, rally could be talking to serverless cluster with operator credentials, in which case the track today sets the replicas count to 0 (which is not allowed in serverless)
Discussion: https://elastic.slack.com/archives/C045BMYS12M/p1772148299789509

Refactoring this track to not set shard and replica count unless explicitly set, following same pattern as `geonames`