### PR TITLE
fix(elastic): Make default query max date consistent with documentation

### DIFF
--- a/elastic/shared/parameter_sources/__init__.py
+++ b/elastic/shared/parameter_sources/__init__.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 
 DEFAULT_START_DATE = "now-1d"
 DEFAULT_END_DATE = "now"
-DEFAULT_MAX_DATE = "2020-01-01"
+DEFAULT_MAX_DATE = "2020-01-02"
 
 # this provides a universal start date for `now` if we are using it as the current time
 now = datetime.now(tz=timezone.utc)

--- a/elastic/tests/parameter_sources/workflow_selector_test.py
+++ b/elastic/tests/parameter_sources/workflow_selector_test.py
@@ -504,7 +504,7 @@ async def test_invalid_min_max():
     param_source = WorkflowSelectorParamSource(
         track=StaticTrack(
             parameters={
-                "query-min-date": "2020-01-02",
+                "query-min-date": "2020-01-03",
                 "query_max-date-start": "2020-01-01",
                 "query-average-interval": "1d",
                 "number-of-workflows": 1,
@@ -522,8 +522,8 @@ async def test_invalid_min_max():
     with pytest.raises(TrackConfigError) as err:
         param_source.params()
     assert (
-        err.value.message == "query-min-date 2020-01-02 00:00:00+00:00 cannot be larger than effective "
-        "query-max-date 2020-01-01 00:00:00+00:00"
+        err.value.message == "query-min-date 2020-01-03 00:00:00+00:00 cannot be larger than effective "
+        "query-max-date 2020-01-02 00:00:00+00:00"
     )
 
 


### PR DESCRIPTION
The places in documentation that mention the default value for this parameter shows `2020-01-02`. This has led me to spend some time chasing down the reason why the queries in `elastic/logs` seem to not do any work. In the context of testing query performance in "cold start" condition in the InfraPerf team, this meant that the working set for the queries was not large enough to saturate the available memory for page cache on the system I was targeting (8GiB ES containers, with XMS at 2GiB and XMX at 4GiB).

Claude helped me craft a script that analyzes a local run of Rally without explicitly setting `query_max_date`, with the result showing most queries had the time range collapsed to a single point in time:
```shell
Total requests with @timestamp range: 347
Unique @timestamp ranges: 6

  2020-01-01T00:00:00.000Z -> 2020-01-01T00:00:00.000Z  (342 occurrences)
  2022-04-21T18:15:30.035Z -> 2022-04-21T18:30:30.035Z  (1 occurrences)
  2022-04-20T18:30:43.135Z -> 2022-04-21T18:30:43.135Z  (1 occurrences)
  2022-04-20T18:31:09.271Z -> 2022-04-21T18:31:09.271Z  (1 occurrences)
  2022-04-18T21:18:41.356Z -> 2022-04-19T21:18:41.356Z  (1 occurrences)
  2022-04-19T23:42:11.152Z -> 2022-04-20T23:42:11.152Z  (1 occurrences)
```

After the fix, this looks like:
```shell
Found 276 Action log lines for 2026-03-03

============================================================
Total requests with @timestamp range: 353
Unique @timestamp ranges: 10

  2020-01-01T00:00:00.000Z -> 2020-01-02T00:00:00.000Z  (171 occurrences)
  2020-01-01T23:00:00.000Z -> 2020-01-02T00:00:00.000Z  (65 occurrences)
  2020-01-01T18:00:00.000Z -> 2020-01-02T00:00:00.000Z  (50 occurrences)
  2020-01-01T23:45:00.000Z -> 2020-01-02T00:00:00.000Z  (38 occurrences)
  2020-01-01T12:00:00.000Z -> 2020-01-02T00:00:00.000Z  (24 occurrences)
  2022-04-21T18:15:30.035Z -> 2022-04-21T18:30:30.035Z  (1 occurrences)
  2022-04-20T18:30:43.135Z -> 2022-04-21T18:30:43.135Z  (1 occurrences)
  2022-04-20T18:31:09.271Z -> 2022-04-21T18:31:09.271Z  (1 occurrences)
  2022-04-18T21:18:41.356Z -> 2022-04-19T21:18:41.356Z  (1 occurrences)
  2022-04-19T23:42:11.152Z -> 2022-04-20T23:42:11.152Z  (1 occurrences)
```

which is much consistent with expectation.

I also realized that this parameter is set explicitly in multiple places in ESBench, see [search results](https://github.com/search?q=repo%3Aelastic%2Felasticsearch-benchmarks%20query_max_date&type=code). This made me question if there is context I'm missing that led to the current `DEFAULT_MAX_DATE` being `2020-01-01`. Could you confirm that this is not the case?