### PR TITLE
Enable larger block sizes for binary doc values.

### DIFF
--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -20,7 +20,7 @@
             ,"mapping.use_doc_values_skipper": true
             {% endif %}
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-            ,"index.use_time_series_doc_values_format_large_binary_block_size": true
+            ,"use_time_series_doc_values_format_large_binary_block_size": true
             {%- endif -%}{# non-serverless-index-settings-marker-end #}
         }
         {% endif %}

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -19,6 +19,7 @@
             {% if use_doc_values_skipper | default(true) %}
             ,"mapping.use_doc_values_skipper": true
             {% endif %}
+            ,"index.use_time_series_doc_values_format_large_binary_block_size": true
         }
         {% endif %}
       }

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -1,4 +1,3 @@
-{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 {
     "template": {
       "settings": {

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -1,3 +1,4 @@
+{% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 {
     "template": {
       "settings": {
@@ -19,7 +20,9 @@
             {% if use_doc_values_skipper | default(true) %}
             ,"mapping.use_doc_values_skipper": true
             {% endif %}
+            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
             ,"index.use_time_series_doc_values_format_large_binary_block_size": true
+            {%- endif -%}{# non-serverless-index-settings-marker-end #}
         }
         {% endif %}
       }

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -15,7 +15,8 @@
             {% endif %}
             "sort.field": [ "host.id", "@timestamp" ],
             "sort.order": [ "asc", "desc" ],
-            "sort.missing": ["_first", "_last"]
+            "sort.missing": ["_first", "_last"],
+            "index.use_time_series_doc_values_format_large_binary_block_size": true
         }
         {% endif %}
       }

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -17,7 +17,7 @@
             "sort.order": [ "asc", "desc" ],
             "sort.missing": ["_first", "_last"]
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-            ,"index.use_time_series_doc_values_format_large_binary_block_size": true
+            ,"use_time_series_doc_values_format_large_binary_block_size": true
             {%- endif -%}{# non-serverless-index-settings-marker-end #}
         }
         {% endif %}

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -15,8 +15,10 @@
             {% endif %}
             "sort.field": [ "host.id", "@timestamp" ],
             "sort.order": [ "asc", "desc" ],
-            "sort.missing": ["_first", "_last"],
-            "index.use_time_series_doc_values_format_large_binary_block_size": true
+            "sort.missing": ["_first", "_last"]
+            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+            ,"index.use_time_series_doc_values_format_large_binary_block_size": true
+            {%- endif -%}{# non-serverless-index-settings-marker-end #}
         }
         {% endif %}
       }


### PR DESCRIPTION
By setting to `index.use_time_series_doc_values_format_large_binary_block_size` to `true` in elastic/logs and elastic/security benchmarks. This was recently added via elastic/elasticsearch#143049.