### PR TITLE
Dont enable `use_time_series_doc_values_format_large_binary_block_size` in serverless

### DIFF
--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -19,7 +19,7 @@
             {% if use_doc_values_skipper | default(true) %}
             ,"mapping.use_doc_values_skipper": true
             {% endif %}
-            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" -%}
             ,"use_time_series_doc_values_format_large_binary_block_size": true
             {%- endif -%}{# non-serverless-index-settings-marker-end #}
         }

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -16,7 +16,7 @@
             "sort.field": [ "host.id", "@timestamp" ],
             "sort.order": [ "asc", "desc" ],
             "sort.missing": ["_first", "_last"]
-            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" -%}
             ,"use_time_series_doc_values_format_large_binary_block_size": true
             {%- endif -%}{# non-serverless-index-settings-marker-end #}
         }


### PR DESCRIPTION
the index option `use_time_series_doc_values_format_large_binary_block_size` isnt recognised in serverless at the moment, so we should not try and use it, even with operator permissions