### PR TITLE
Only disable sequence number in logsdb/tsdb mode

### DIFF
--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -21,7 +21,9 @@
             {% endif %}
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" -%}
             ,"use_time_series_doc_values_format_large_binary_block_size": true
+            {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true
+            {% endif %}
             {%- endif -%}{# non-serverless-index-settings-marker-end #}
         }
         {% endif %}

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -18,7 +18,9 @@
             "sort.missing": ["_first", "_last"]
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" -%}
             ,"use_time_series_doc_values_format_large_binary_block_size": true
+            {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true
+            {% endif %}
             {%- endif -%}{# non-serverless-index-settings-marker-end #}
         }
         {% endif %}


### PR DESCRIPTION
After https://github.com/elastic/rally-tracks/pull/1090 elastic/logs and elastic/security runs in standard mode are failing with the error `The setting [index.disable_sequence_numbers] is only permitted when [index.seq_no.index_options] is set to [DOC_VALUES_ONLY]. Current value: [POINTS_AND_DOC_VALUES].`. 

So this setting should only be enabled if `index.disable_sequence_numbers=DOC_VALUES_ONLY`. This only occurs if the index mode is logsdb or time_series: https://github.com/elastic/elasticsearch/blob/12e97866f8947ade6df8bbdba191eb637cf96be5/server/src/main/java/org/elasticsearch/index/IndexSettings.java#L981