### PR TITLE
Update track-shared-logsdb-mode component template for elastic/logs and elastic/security tracks

### DIFF
--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -2,26 +2,26 @@
     "template": {
       "settings": {
         "index": {
-            {% if use_doc_values_skipper | default(true) %}
-            "mapping.use_doc_values_skipper": true
-            {% endif %}
             {% if index_mode %}
-            ,"mode": {{ index_mode | tojson }}
+            "mode": {{ index_mode | tojson }}
             {% endif %}
             {% if codec %}
-            ,"codec": {{codec | tojson}}
+            {% if index_mode %},{% endif %}"codec": {{codec | tojson}}
             {% endif %}
             {% if source_mode %}
-            ,"mapping.source.mode": {{ source_mode | tojson }}
-            {% endif %}
-            {% if use_synthetic_source_recovery %}
-            ,"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
+            {% if index_mode or codec %},{% endif %}"mapping.source.mode": {{ source_mode | tojson }}
             {% endif %}
             {% if synthetic_source_keep %}
-            ,"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
+            {% if index_mode or codec or source_mode or use_synthetic_source_recovery %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
             {% endif %}
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-            ,"use_time_series_doc_values_format_large_binary_block_size": true
+            {% if use_doc_values_skipper | default(true) %}
+            {% if index_mode or codec or source_mode or use_synthetic_source_recovery or synthetic_source_keep %},{% endif %}"mapping.use_doc_values_skipper": true
+            {% endif %}
+            {% if use_synthetic_source_recovery %}
+            {% if index_mode or codec or source_mode or use_synthetic_source_recovery or synthetic_source_keep or use_doc_values_skipper %},{% endif %}"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
+            {% endif %}
+            {% if index_mode or codec or source_mode or use_synthetic_source_recovery or synthetic_source_keep or use_doc_values_skipper or use_synthetic_source_recovery %},{% endif %}"use_time_series_doc_values_format_large_binary_block_size": true
             {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true
             {% endif %}

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -2,26 +2,26 @@
     "template": {
       "settings": {
         "index": {
+            {% if use_doc_values_skipper | default(true) %}
+            "mapping.use_doc_values_skipper": true
+            {% endif %}
             {% if index_mode %}
-            "mode": {{ index_mode | tojson }}
+            ,"mode": {{ index_mode | tojson }}
             {% endif %}
             {% if codec %}
             ,"codec": {{codec | tojson}}
             {% endif %}
             {% if source_mode %}
-            {% if index_mode %},{% endif %}"mapping.source.mode": {{ source_mode | tojson }}
+            ,"mapping.source.mode": {{ source_mode | tojson }}
             {% endif %}
             {% if use_synthetic_source_recovery %}
-            {% if index_mode or source_mode %},{% endif %}"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
+            ,"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
             {% endif %}
             {% if synthetic_source_keep %}
-            {% if index_mode or source_mode or use_synthetic_source_recovery %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
-            {% endif %}
-            {% if use_doc_values_skipper | default(true) %}
-            {% if index_mode or source_mode or use_synthetic_source_recovery or synthetic_source_keep %},{% endif %}"mapping.use_doc_values_skipper": true
+            ,"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
             {% endif %}
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-            {% if index_mode or source_mode or use_synthetic_source_recovery or synthetic_source_keep or use_doc_values_skipper%},{% endif %}"use_time_series_doc_values_format_large_binary_block_size": true
+            ,"use_time_series_doc_values_format_large_binary_block_size": true
             {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true
             {% endif %}

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -14,7 +14,7 @@
             {% if synthetic_source_keep %}
             {% if index_mode or codec or source_mode %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
             {% endif %}
-            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" -%}
             {% if use_doc_values_skipper | default(true) %}
             {% if index_mode or codec or source_mode or synthetic_source_keep or synthetic_source_keep %},{% endif %}"mapping.use_doc_values_skipper": true
             {% endif %}

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -1,32 +1,32 @@
 {
     "template": {
       "settings": {
-        {% if index_mode %}
         "index": {
+            {% if index_mode %}
             "mode": {{ index_mode | tojson }}
+            {% endif %}
             {% if codec %}
             ,"codec": {{codec | tojson}}
             {% endif %}
             {% if source_mode %}
-            ,"mapping.source.mode": {{ source_mode | tojson }}
+            {% if index_mode %},{% endif %}"mapping.source.mode": {{ source_mode | tojson }}
             {% endif %}
             {% if use_synthetic_source_recovery %}
-            ,"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
+            {% if index_mode or source_mode %},{% endif %}"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
             {% endif %}
             {% if synthetic_source_keep %}
-            ,"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
+            {% if index_mode or source_mode or use_synthetic_source_recovery %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
             {% endif %}
             {% if use_doc_values_skipper | default(true) %}
-            ,"mapping.use_doc_values_skipper": true
+            {% if index_mode or source_mode or use_synthetic_source_recovery or synthetic_source_keep %},{% endif %}"mapping.use_doc_values_skipper": true
             {% endif %}
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-            ,"use_time_series_doc_values_format_large_binary_block_size": true
+            {% if index_mode or source_mode or use_synthetic_source_recovery or synthetic_source_keep or use_doc_values_skipper%},{% endif %}"use_time_series_doc_values_format_large_binary_block_size": true
             {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true
             {% endif %}
             {%- endif -%}{# non-serverless-index-settings-marker-end #}
         }
-        {% endif %}
       }
     }
   }

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -12,16 +12,16 @@
             {% if index_mode or codec %},{% endif %}"mapping.source.mode": {{ source_mode | tojson }}
             {% endif %}
             {% if synthetic_source_keep %}
-            {% if index_mode or codec or source_mode or use_synthetic_source_recovery %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
+            {% if index_mode or codec or source_mode %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson }}
             {% endif %}
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
             {% if use_doc_values_skipper | default(true) %}
-            {% if index_mode or codec or source_mode or use_synthetic_source_recovery or synthetic_source_keep %},{% endif %}"mapping.use_doc_values_skipper": true
+            {% if index_mode or codec or source_mode or synthetic_source_keep or synthetic_source_keep %},{% endif %}"mapping.use_doc_values_skipper": true
             {% endif %}
             {% if use_synthetic_source_recovery %}
-            {% if index_mode or codec or source_mode or use_synthetic_source_recovery or synthetic_source_keep or use_doc_values_skipper %},{% endif %}"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
+            ,"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
             {% endif %}
-            {% if index_mode or codec or source_mode or use_synthetic_source_recovery or synthetic_source_keep or use_doc_values_skipper or use_synthetic_source_recovery %},{% endif %}"use_time_series_doc_values_format_large_binary_block_size": true
+            ,"use_time_series_doc_values_format_large_binary_block_size": true
             {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true
             {% endif %}

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -19,7 +19,7 @@
             {% if use_doc_values_skipper | default(true) %}
             ,"mapping.use_doc_values_skipper": true
             {% endif %}
-            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" -%}
+            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
             ,"use_time_series_doc_values_format_large_binary_block_size": true
             {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -21,6 +21,9 @@
             {% if use_synthetic_source_recovery %}
             ,"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
             {% endif %}
+            {% if use_time_series_doc_values_format %}
+            ,"use_time_series_doc_values_format": {{use_time_series_doc_values_format | tojson}}
+            {% endif %}
             ,"use_time_series_doc_values_format_large_binary_block_size": true
             {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -12,10 +12,10 @@
             {% if index_mode %},{% endif %}"mapping.source.mode": {{ source_mode | tojson }}
             {% endif %}
             {% if use_synthetic_source_recovery %}
-            {% if index_mode or source_mode %},{% endif %}"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}},
+            {% if index_mode or source_mode %},{% endif %}"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
             {% endif %}
             {% if synthetic_source_keep %}
-            {% if index_mode or source_mod or use_synthetic_source_recovery %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}},
+            {% if index_mode or source_mod or use_synthetic_source_recovery %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}}
             {% endif %}
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
             {% if index_mode or source_mod or use_synthetic_source_recovery %},{% endif %}"use_time_series_doc_values_format_large_binary_block_size": true

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -14,7 +14,7 @@
             {% if synthetic_source_keep %}
             {% if index_mode or source_mode %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}}
             {% endif %}
-            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" -%}
             {% if use_synthetic_source_recovery %}
             {% if index_mode or source_mode or synthetic_source_keep %},{% endif %}"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
             {% endif %}

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -11,14 +11,14 @@
             {% if source_mode %}
             {% if index_mode %},{% endif %}"mapping.source.mode": {{ source_mode | tojson }}
             {% endif %}
-            {% if use_synthetic_source_recovery %}
-            {% if index_mode or source_mode %},{% endif %}"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
-            {% endif %}
             {% if synthetic_source_keep %}
-            {% if index_mode or source_mod or use_synthetic_source_recovery %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}}
+            {% if index_mode or source_mode %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}}
             {% endif %}
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-            {% if index_mode or source_mod or use_synthetic_source_recovery %},{% endif %}"use_time_series_doc_values_format_large_binary_block_size": true
+            {% if use_synthetic_source_recovery %}
+            {% if index_mode or source_mode or synthetic_source_keep %},{% endif %}"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
+            {% endif %}
+            {% if index_mode or source_mode or synthetic_source_keep or use_synthetic_source_recovery %},{% endif %}"use_time_series_doc_values_format_large_binary_block_size": true
             {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true
             {% endif %}

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -3,7 +3,7 @@
       "settings": {
         "index": {
             {% if index_mode %}
-            "mode": {{ index_mode | tojson }}
+            "mode": {{ index_mode | tojson }},
             "sort.field": [ "host.id", "@timestamp" ],
             "sort.order": [ "asc", "desc" ],
             "sort.missing": ["_first", "_last"]

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -19,6 +19,9 @@
             {% if index_mode or source_mode or synthetic_source_keep %},{% endif %}"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}}
             {% endif %}
             {% if index_mode or source_mode or synthetic_source_keep or use_synthetic_source_recovery %},{% endif %}"use_time_series_doc_values_format_large_binary_block_size": true
+            {% if use_time_series_doc_values_format %}
+            ,"use_time_series_doc_values_format": {{use_time_series_doc_values_format | tojson}}
+            {% endif %}
             {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true
             {% endif %}

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -1,29 +1,29 @@
 {
     "template": {
       "settings": {
-        {% if index_mode %}
         "index": {
-            "mode": {{ index_mode | tojson }},
-            {% if source_mode %}
-            "mapping.source.mode": {{ source_mode | tojson }},
-            {% endif %}
-            {% if use_synthetic_source_recovery %}
-            "recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}},
-            {% endif %}
-            {% if synthetic_source_keep %}
-            "mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}},
-            {% endif %}
+            {% if index_mode %}
+            "mode": {{ index_mode | tojson }}
             "sort.field": [ "host.id", "@timestamp" ],
             "sort.order": [ "asc", "desc" ],
             "sort.missing": ["_first", "_last"]
+            {% endif %}
+            {% if source_mode %}
+            {% if index_mode %},{% endif %}"mapping.source.mode": {{ source_mode | tojson }}
+            {% endif %}
+            {% if use_synthetic_source_recovery %}
+            {% if index_mode or source_mode %},{% endif %}"recovery.use_synthetic_source": {{use_synthetic_source_recovery | tojson}},
+            {% endif %}
+            {% if synthetic_source_keep %}
+            {% if index_mode or source_mod or use_synthetic_source_recovery %},{% endif %}"mapping.synthetic_source_keep": {{ synthetic_source_keep | tojson}},
+            {% endif %}
             {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-            ,"use_time_series_doc_values_format_large_binary_block_size": true
+            {% if index_mode or source_mod or use_synthetic_source_recovery %},{% endif %}"use_time_series_doc_values_format_large_binary_block_size": true
             {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true
             {% endif %}
             {%- endif -%}{# non-serverless-index-settings-marker-end #}
         }
-        {% endif %}
       }
     }
   }

--- a/elastic/security/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/security/templates/component/track-shared-logsdb-mode.json
@@ -16,7 +16,7 @@
             "sort.field": [ "host.id", "@timestamp" ],
             "sort.order": [ "asc", "desc" ],
             "sort.missing": ["_first", "_last"]
-            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" -%}
+            {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
             ,"use_time_series_doc_values_format_large_binary_block_size": true
             {% if index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true


### PR DESCRIPTION
1. Removed the dependency to `index_mode` track param to other track params. Which I think was never intended and is undocumented. The used track params in these files are valid outside `index_mode`.
2. ~~Allow index.use_time_series_doc_values_format_large_binary_block_size also when serverless_operator == true, so that we can see the effect in serverless.~~
3. Added `use_time_series_doc_values_format` track param.