### PR TITLE
Reduce iteration slow queries

### DIFF
--- a/geoshape/challenges/default.json
+++ b/geoshape/challenges/default.json
@@ -297,74 +297,74 @@
         },
         {
           "operation": "polygon-centroid",
-          "warmup-iterations": 100,
-          "iterations": 50,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["polygon", "centroid"]
         },
         {
           "operation": "polygon-centroid-esql",
-          "warmup-iterations": 100,
-          "iterations": 50,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["polygon", "centroid", "esql"]
         },
         {
           "operation": "polygon-bounds-centroid",
-          "warmup-iterations": 100,
-          "iterations": 50,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["polygon", "bounds", "centroid"]
         },
         {
           "operation": "polygon-bounds-centroid-esql",
-          "warmup-iterations": 100,
-          "iterations": 50,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["polygon", "bounds", "centroid", "esql"]
         },
         {
           "operation": "polygon-bounds",
-          "warmup-iterations": 100,
-          "iterations": 50,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["polygon", "bounds"]
         },
         {
           "operation": "polygon-bounds-esql",
-          "warmup-iterations": 100,
-          "iterations": 50,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["polygon", "bounds", "esql"]
         },
         {
           "operation": "bounds",
-          "warmup-iterations": 100,
-          "iterations": 50,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["bounds"]
         },
         {
           "operation": "bounds-esql",
-          "warmup-iterations": 100,
-          "iterations": 50,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["esql", "bounds"]
         },
         {
           "operation": "bounds-centroid",
-          "warmup-iterations": 100,
-          "iterations": 50,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["bounds", "centroid"]
         },
         {
           "operation": "bounds-centroid-esql",
-          "warmup-iterations": 100,
-          "iterations": 50,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["esql", "bounds", "centroid"]
         },
         {
           "operation": "centroid",
-          "warmup-iterations": 20,
-          "iterations": 20,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["centroid"]
         },
         {
           "operation": "centroid-esql",
-          "warmup-iterations": 20,
-          "iterations": 20,
+          "warmup-iterations": 10,
+          "iterations": 10,
           "tags": ["centroid", "esql"]
         },
         {


### PR DESCRIPTION
These benchmarks take about 10s for each iteration. Cut the iteration count down a lot.