### PR TITLE
Fix/random vector serverless health check

### DIFF
--- a/random_vector/challenges/default.json
+++ b/random_vector/challenges/default.json
@@ -44,6 +44,10 @@
         "request-timeout": 1000,
         "include-in-reporting": true
       }
+    },
+    {
+      "name": "wait-until-cluster-is-ready",
+      "operation": "check-cluster-health"
     }{%- if small_partitions | default(100) | int > 0 %},
     {
       "name": "small-partition-search",

--- a/random_vector/challenges/default.json
+++ b/random_vector/challenges/default.json
@@ -45,6 +45,15 @@
         "include-in-reporting": true
       }
     },
+    {# serverless-post-ingest-sleep-marker-start #}{%- if post_ingest_sleep|default(false) -%}
+    {
+      "name": "post-ingest-sleep-after-index",
+      "operation": {
+        "operation-type": "sleep",
+        "duration": {{ post_ingest_sleep_duration|default(30) }}
+      }
+    },
+    {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
     {
       "name": "wait-until-cluster-is-ready",
       "operation": "check-cluster-health"


### PR DESCRIPTION
### Problem

The `random_vector` serverless benchmarks fail with 100% error rates on search tasks
(`no_shard_available_action_exception`). On serverless, data is indexed on index-tier
nodes while searches run on separate search-tier nodes. After ingestion, the search tier
needs time to receive shard copies before it can serve queries.

### Changes

Two additions to the `index-and-search` challenge in `random_vector/challenges/default.json`,
after `refresh-after-index` and before the search tasks:

1. **`wait-until-cluster-is-ready`** — a `check-cluster-health` operation that ensures
   the cluster is in a healthy state before starting searches.

2. **`post-ingest-sleep-after-index`** — a conditional sleep (default 30 s) gated by
   `post_ingest_sleep` (default `false`), giving the search tier time to allocate and
   initialize replica shards. Duration is configurable via `post_ingest_sleep_duration`.
   Follows the same pattern used by `geonames`, `dense_vector`, and `msmarco-v2-vector`.

No behavior change when `post_ingest_sleep` is not set — the sleep is skipped and only
the health check runs.

### Related

Companion change in `elastic/elasticsearch-benchmarks` adds `post_ingest_sleep: true`
and `number_of_replicas: 1` to the serverless `random_vector` benchmark configs.