### PR TITLE
Clear caches between searches in serverless mode

### DIFF
--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -89,20 +89,20 @@
       "operation": "discovery-search-request-size-100",
       "clients": 1,
       "warmup-iterations": 0,
-      "iterations": 50
+      "iterations": 100
     },
     {
       "operation": "discovery-search-request-size-500",
       "clients": 1,
       "warmup-iterations": 0,
-      "iterations": 50
+      "iterations": 100
     },
 
     {
       "operation": "discovery-search-request-size-1000",
       "clients": 1,
       "warmup-iterations": 0,
-      "iterations": 50
+      "iterations": 100
     },
     {
       "name": "logging-queries",

--- a/elastic/logs/operations/search-with-source.json
+++ b/elastic/logs/operations/search-with-source.json
@@ -109,7 +109,7 @@
             "operation-type": "raw-request",
             "method": "POST",
             "path": "/_internal/blob_caches/clear",
-            "body": {}
+            "body": null
           },
           {
             {{ discovery_search_props(size) }}

--- a/elastic/logs/operations/search-with-source.json
+++ b/elastic/logs/operations/search-with-source.json
@@ -1,5 +1,4 @@
-  {
-    "name": "discovery-search-request-size-100",
+{% macro discovery_search_props(size) %}
     "operation-type": "search",
     "index": "logs-*",
     "request-params": {
@@ -76,7 +75,7 @@
           "format": "strict_date_optional_time"
         }
       ],
-      "size": 100,
+      "size": {{ size }},
       "version": true,
       "script_fields": {},
       "stored_fields": [
@@ -97,204 +96,33 @@
         "fragment_size": 2147483647
       }
     }
-  },
+{% endmacro %}
+{% for size in [100, 500, 1000] %}
+  {% if build_flavor == "serverless" %}
   {
-    "name": "discovery-search-request-size-500",
-    "operation-type": "search",
-    "index": "logs-*",
-    "request-params": {
-      "batched_reduce_size": "64",
-      "ignore_unavailable": "true",
-      "track_total_hits": "false",
-      "enable_fields_emulation": "true",
-      "preference": "1650039059666"
-    },
-    "body": {
-      "sort": [
-        {
-          "@timestamp": {
-            "order": "desc",
-            "unmapped_type": "boolean"
+    "name": "discovery-search-request-size-{{ size }}",
+    "operation-type": "composite",
+    "requests": [
+      {
+        "stream": [
+          {
+            "operation-type": "raw-request",
+            "method": "POST",
+            "path": "/_internal/blob_caches/clear",
+            "body": {}
+          },
+          {
+            {{ discovery_search_props(size) }}
           }
-        }
-      ],
-      "fields": [
-        {
-          "field": "*",
-          "include_unmapped": "true"
-        },
-        {
-          "field": "@timestamp",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "eden.created_at",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "event.created",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "event.end",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "event.ingested",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "event.start",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "file.accessed",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "file.created",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "file.ctime",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "file.mtime",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "postgresql.log.session_start_time",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "process.parent.start",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "process.start",
-          "format": "strict_date_optional_time"
-        }
-      ],
-      "size": 500,
-      "version": true,
-      "script_fields": {},
-      "stored_fields": [
-        "*"
-      ],
-      "runtime_mappings": {},
-      "_source": false,
-      "highlight": {
-        "pre_tags": [
-          "@kibana-highlighted-field@"
-        ],
-        "post_tags": [
-          "@/kibana-highlighted-field@"
-        ],
-        "fields": {
-          "*": {}
-        },
-        "fragment_size": 2147483647
+        ]
       }
-    }
-  },
-  {
-    "name": "discovery-search-request-size-1000",
-    "operation-type": "search",
-    "index": "logs-*",
-    "request-params": {
-      "batched_reduce_size": "64",
-      "ignore_unavailable": "true",
-      "track_total_hits": "false",
-      "enable_fields_emulation": "true",
-      "preference": "1650039059666"
-    },
-    "body": {
-      "sort": [
-        {
-          "@timestamp": {
-            "order": "desc",
-            "unmapped_type": "boolean"
-          }
-        }
-      ],
-      "fields": [
-        {
-          "field": "*",
-          "include_unmapped": "true"
-        },
-        {
-          "field": "@timestamp",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "eden.created_at",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "event.created",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "event.end",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "event.ingested",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "event.start",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "file.accessed",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "file.created",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "file.ctime",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "file.mtime",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "postgresql.log.session_start_time",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "process.parent.start",
-          "format": "strict_date_optional_time"
-        },
-        {
-          "field": "process.start",
-          "format": "strict_date_optional_time"
-        }
-      ],
-      "size": 1000,
-      "version": true,
-      "script_fields": {},
-      "stored_fields": [
-        "*"
-      ],
-      "runtime_mappings": {},
-      "_source": false,
-      "highlight": {
-        "pre_tags": [
-          "@kibana-highlighted-field@"
-        ],
-        "post_tags": [
-          "@/kibana-highlighted-field@"
-        ],
-        "fields": {
-          "*": {}
-        },
-        "fragment_size": 2147483647
-      }
-    }
+    ]
   }
+  {% else %}
+  {
+    "name": "discovery-search-request-size-{{ size }}",
+    {{ discovery_search_props(size) }}
+  }
+  {% endif %}
+  {{ "," if not loop.last else "" }}
+{% endfor %}


### PR DESCRIPTION
Searches with returned hits don't return useful timing information in serverless because the blob cache is filled on the first query, and then all subsequent iterations are served directly from the cache.

We reimplement the discovery-search-request-size-n operations as jinja macros, which in serverless mode combine each query with a preceding cache clear request.  We also update the number of iterations to 100, so that we get 99th percentile stats.