### PR TITLE
Add has-privileges cached bystander mode for comparisons

### DIFF
--- a/has_privileges_bystander/README.md
+++ b/has_privileges_bystander/README.md
@@ -1,26 +1,16 @@
 # Has-Privileges Bystander Blocking Track
 
-Demonstrates Netty event-loop head-of-line blocking caused by expensive `_has_privileges` index privilege evaluation.
+Benchmarks expensive `_has_privileges` requests alongside lightweight bystander requests to measure head-of-line blocking on Netty event-loop threads.
 
 ## What This Track Shows
 
-When a `_has_privileges` request triggers expensive DFA (automaton) operations in `IndicesPermission.checkResourcePrivileges`, it blocks the Netty event loop thread synchronously. Any other HTTP request ("bystander") bound to the same event loop must wait in line, causing latency outliers unrelated to the bystander request's own cost.
+When a `_has_privileges` request triggers expensive DFA (automaton) operations in `IndicesPermission.checkResourcePrivileges`, it can block the Netty event loop thread synchronously. Any other HTTP request ("bystander") bound to the same event loop must wait in line, causing latency outliers unrelated to the bystander request's own cost.
 
-The track runs `_has_privileges` requests alongside trivial `GET /` bystander requests on a single Netty event loop, then compares their latency distributions. A successful reproduction shows bystander p100 latency approaching `has_privileges` p100.
+The track runs expensive `_has_privileges` requests alongside lightweight bystander requests, then compares their latency distributions. Head-of-line blocking manifests as bystander p100 latency approaching `has_privileges` p100.
 
 ## Cluster Prerequisites
 
-The target Elasticsearch cluster must be configured with the following **static** settings in `elasticsearch.yml` (requires node restart):
-
-```yaml
-http.netty.worker_count: 1
-```
-
-This forces all HTTP connections onto a single Netty event loop thread, making the blocking effect deterministic. Without this, blocking still occurs but only affects the ~1/N fraction of bystander requests that happen to land on the same event loop as a slow `has_privileges` request.
-
-The track validates this setting at startup and fails with a clear error if it is not configured.
-
-X-Pack Security must be enabled (default in recent ES versions).
+X-Pack Security must be enabled (default in recent ES versions). No special static settings are required.
 
 ## Parameters
 
@@ -36,7 +26,8 @@ All parameters can be configured via `--track-params`:
 | `iterations` | integer | 100 | Number of `has_privileges` requests to measure |
 | `warmup_iterations` | integer | 3 | Warmup iterations before measurement |
 | `has_privileges_clients` | integer | 1 | Concurrent `has_privileges` clients |
-| `bystander_clients` | integer | 1 | Concurrent bystander (`GET /`) clients |
+| `bystander_clients` | integer | 1 | Concurrent bystander (`GET /`) clients (used when `cached_bystander_clients` is 0) |
+| `cached_bystander_clients` | integer | 0 | Concurrent bystander clients using lightweight cached `_has_privileges` requests instead of `GET /` |
 
 ### Wildcard Modes
 
@@ -59,27 +50,75 @@ esrally race --track-path=has_privileges_bystander \
   --track-params="iterations:50"
 ```
 
-### With Rally-Provisioned Cluster
-
-Not directly supported because `http.netty.worker_count` is a static setting that must be in `elasticsearch.yml` before the node starts. You would need a custom car definition that includes this setting.
-
 ## How It Works
 
-1. **`check_netty_worker_count`** -- verifies `http.netty.worker_count: 1` on all nodes
-2. **`create_roles_and_users`** -- creates roles with randomized wildcard index patterns and assigns them to test users
-3. **Parallel phase** -- runs concurrently until `has_privileges` completes:
+1. **`create_roles_and_users`** -- creates roles with randomized wildcard index patterns and assigns them to test users. If `cached_bystander_clients > 0`, also creates a `bystander_user` with a single simple role.
+2. **Parallel phase** -- runs concurrently until `has_privileges` completes:
    - **`has_privileges`** -- sends `_has_privileges` requests with a large, unique request body (50 index expressions with wildcard patterns, 10 cluster privileges). Each body is randomized to defeat the per-role `hasPrivilegesCache`.
-   - **`cluster_info`** -- sends trivial `GET /` requests continuously as bystander traffic
+   - **`has_privileges_cached`** (when `cached_bystander_clients > 0`) -- sends lightweight `_has_privileges` requests as `bystander_user` with a simple cached role. These hit the role cache and complete quickly unless blocked.
+   - **`cluster_info`** (when `cached_bystander_clients == 0`) -- sends trivial `GET /` requests continuously as bystander traffic.
 
 ## Interpreting Results
 
 | Metric | What to look for |
 |---|---|
 | `has_privileges` p50 | Baseline cost of index privilege evaluation (~2s with defaults) |
-| `cluster_info` p50 | Should be <1ms (trivial request, no contention) |
-| `cluster_info` p100 | Should approach `has_privileges` p100 (proves blocking) |
+| bystander p50 | Should be <1ms (trivial request, no contention) |
+| bystander p100 | Approaches `has_privileges` p100 when head-of-line blocking is present |
 
-If `cluster_info` p100 is close to `has_privileges` p100, a bystander request was blocked behind a full `_has_privileges` evaluation on the shared event loop.
+If bystander p100 is close to `has_privileges` p100, a bystander request was blocked behind a full `_has_privileges` evaluation on the shared Netty event loop.
+
+## Comparison Benchmarking
+
+To compare two ES builds (e.g., a baseline release vs. a branch with a fix), run the track against each build with a tagged `--race-id`, then use `esrally compare`.
+
+### 1. Run the baseline
+
+Start the baseline ES (e.g., 9.3.3), then:
+
+```bash
+esrally race --track-path=has_privileges_bystander \
+  --pipeline=benchmark-only \
+  --target-hosts=http://localhost:9200 \
+  --client-options="basic_auth_user:'elastic',basic_auth_password:'password'" \
+  --track-params='{"cached_bystander_clients": 8, "has_privileges_clients": 2, "iterations": 10, "warmup_iterations": 1}' \
+  --on-error=abort \
+  --race-id=baseline-933 \
+  --user-tag="version:9.3.3"
+```
+
+### 2. Run the contender
+
+Stop the baseline, start the contender ES, then run the same command with a different `--race-id` and `--user-tag`:
+
+```bash
+esrally race --track-path=has_privileges_bystander \
+  --pipeline=benchmark-only \
+  --target-hosts=http://localhost:9200 \
+  --client-options="basic_auth_user:'elastic',basic_auth_password:'password'" \
+  --track-params='{"cached_bystander_clients": 8, "has_privileges_clients": 2, "iterations": 10, "warmup_iterations": 1}' \
+  --on-error=abort \
+  --race-id=contender-branch \
+  --user-tag="version:my-branch"
+```
+
+### 3. Compare
+
+```bash
+esrally compare --baseline=baseline-933 --contender=contender-branch
+```
+
+### Key metrics to watch
+
+| Metric | Indicates |
+|---|---|
+| `has_privileges` p50/p100 | Cost of the expensive authorization path |
+| `has_privileges_cached` p50 | Steady-state bystander latency (should be sub-ms) |
+| `has_privileges_cached` p100 | Worst-case bystander latency -- drops dramatically when head-of-line blocking is eliminated |
+| `has_privileges_cached` throughput | Bystander throughput under contention |
+| error rate | Non-zero on either task indicates a functional regression (e.g., auth context leak) |
+
+A successful fix for head-of-line blocking shows bystander p100 dropping from ~2s (matching `has_privileges` latency) to sub-200ms, while bystander p50 stays sub-millisecond.
 
 ## Cost Center
 

--- a/has_privileges_bystander/README.md
+++ b/has_privileges_bystander/README.md
@@ -1,0 +1,90 @@
+# Has-Privileges Bystander Blocking Track
+
+Demonstrates Netty event-loop head-of-line blocking caused by expensive `_has_privileges` index privilege evaluation.
+
+## What This Track Shows
+
+When a `_has_privileges` request triggers expensive DFA (automaton) operations in `IndicesPermission.checkResourcePrivileges`, it blocks the Netty event loop thread synchronously. Any other HTTP request ("bystander") bound to the same event loop must wait in line, causing latency outliers unrelated to the bystander request's own cost.
+
+The track runs `_has_privileges` requests alongside trivial `GET /` bystander requests on a single Netty event loop, then compares their latency distributions. A successful reproduction shows bystander p100 latency approaching `has_privileges` p100.
+
+## Cluster Prerequisites
+
+The target Elasticsearch cluster must be configured with the following **static** settings in `elasticsearch.yml` (requires node restart):
+
+```yaml
+http.netty.worker_count: 1
+```
+
+This forces all HTTP connections onto a single Netty event loop thread, making the blocking effect deterministic. Without this, blocking still occurs but only affects the ~1/N fraction of bystander requests that happen to land on the same event loop as a slow `has_privileges` request.
+
+The track validates this setting at startup and fails with a clear error if it is not configured.
+
+X-Pack Security must be enabled (default in recent ES versions).
+
+## Parameters
+
+All parameters can be configured via `--track-params`:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `num_roles` | integer | 100 | Number of roles to create (more roles = more index privilege groups to evaluate) |
+| `num_users` | integer | 1 | Number of test users |
+| `num_roles_per_user` | integer | 100 | Roles assigned per user (must be <= `num_roles`) |
+| `wildcard_mode` | string | `"both"` | Index pattern wildcards: `both`, `prefix`, `suffix`, or `none` |
+| `index_privileges_per_role` | integer | 10 | Index privilege entries per role |
+| `iterations` | integer | 100 | Number of `has_privileges` requests to measure |
+| `warmup_iterations` | integer | 3 | Warmup iterations before measurement |
+| `has_privileges_clients` | integer | 1 | Concurrent `has_privileges` clients |
+| `bystander_clients` | integer | 1 | Concurrent bystander (`GET /`) clients |
+
+### Wildcard Modes
+
+| Mode | Pattern | Description |
+|---|---|---|
+| `both` | `*abc123*` | Both prefix and suffix wildcards (most expensive) |
+| `prefix` | `*abc123` | Prefix wildcard only |
+| `suffix` | `abc123*` | Suffix wildcard only |
+| `none` | `abc123` | No wildcards (cheapest) |
+
+## Usage
+
+### With External Cluster (benchmark-only)
+
+```bash
+esrally race --track-path=has_privileges_bystander \
+  --pipeline=benchmark-only \
+  --target-hosts=http://localhost:9200 \
+  --client-options="basic_auth_user:'elastic',basic_auth_password:'password'" \
+  --track-params="iterations:50"
+```
+
+### With Rally-Provisioned Cluster
+
+Not directly supported because `http.netty.worker_count` is a static setting that must be in `elasticsearch.yml` before the node starts. You would need a custom car definition that includes this setting.
+
+## How It Works
+
+1. **`check_netty_worker_count`** -- verifies `http.netty.worker_count: 1` on all nodes
+2. **`create_roles_and_users`** -- creates roles with randomized wildcard index patterns and assigns them to test users
+3. **Parallel phase** -- runs concurrently until `has_privileges` completes:
+   - **`has_privileges`** -- sends `_has_privileges` requests with a large, unique request body (50 index expressions with wildcard patterns, 10 cluster privileges). Each body is randomized to defeat the per-role `hasPrivilegesCache`.
+   - **`cluster_info`** -- sends trivial `GET /` requests continuously as bystander traffic
+
+## Interpreting Results
+
+| Metric | What to look for |
+|---|---|
+| `has_privileges` p50 | Baseline cost of index privilege evaluation (~2s with defaults) |
+| `cluster_info` p50 | Should be <1ms (trivial request, no contention) |
+| `cluster_info` p100 | Should approach `has_privileges` p100 (proves blocking) |
+
+If `cluster_info` p100 is close to `has_privileges` p100, a bystander request was blocked behind a full `_has_privileges` evaluation on the shared event loop.
+
+## Cost Center
+
+JFR profiling confirms ~90% of CPU on `http_server_worker[T#1]` is spent in:
+
+- `Automatons.subsetOf` -- tandem DFA walk checking if requested index patterns are subsets of granted patterns (called from `IndicesPermission.checkResourcePrivileges`)
+- `Automatons.minusAndMinimize` -- DFA complement-intersection + Hopcroft minimization to compute ungrantable privileges (called from `IndicesPermission.checkResourcePrivileges`)
+- `Automaton.getSortedTransitions` -- materializing sorted transition tables consumed by `subsetOf`

--- a/has_privileges_bystander/track.json
+++ b/has_privileges_bystander/track.json
@@ -18,6 +18,15 @@
       }
     },
     {
+      "name": "warmup_has_privileges",
+      "operation": {
+        "operation-type": "has_privileges",
+        "num_users": {{num_users | default(1)}}
+      },
+      "iterations": {{warmup_iterations | default(3)}},
+      "clients": 1
+    },
+    {
       "parallel": {
         "completed-by": "has_privileges",
         "tasks": [
@@ -27,7 +36,6 @@
               "operation-type": "has_privileges",
               "num_users": {{num_users | default(1)}}
             },
-            "warmup-iterations": {{warmup_iterations | default(3)}},
             "iterations": {{iterations | default(100)}},
             "clients": {{has_privileges_clients | default(1)}}
           },

--- a/has_privileges_bystander/track.json
+++ b/has_privileges_bystander/track.json
@@ -1,12 +1,7 @@
 {
   "version": 2,
-  "description": "Demonstrates Netty event-loop head-of-line blocking caused by expensive _has_privileges requests. Requires http.netty.worker_count:1 on the target cluster.",
+  "description": "Benchmarks expensive _has_privileges requests alongside lightweight bystander requests.",
   "schedule": [
-    {
-      "operation": {
-        "operation-type": "check_netty_worker_count"
-      }
-    },
     {
       "operation": {
         "operation-type": "create_roles_and_users",
@@ -14,7 +9,8 @@
         "num_users": {{num_users | default(1)}},
         "num_roles_per_user": {{num_roles_per_user | default(100)}},
         "wildcard_mode": "{{wildcard_mode | default('both')}}",
-        "index_privileges_per_role": {{index_privileges_per_role | default(10)}}
+        "index_privileges_per_role": {{index_privileges_per_role | default(10)}},
+        "cached_bystander_clients": {{cached_bystander_clients | default(0)}}
       }
     },
     {
@@ -26,6 +22,16 @@
       "iterations": {{warmup_iterations | default(3)}},
       "clients": 1
     },
+{% if cached_bystander_clients | default(0) > 0 %}
+    {
+      "name": "warmup_has_privileges_cached",
+      "operation": {
+        "operation-type": "has_privileges_cached"
+      },
+      "iterations": 5,
+      "clients": 1
+    },
+{% endif %}
     {
       "parallel": {
         "completed-by": "has_privileges",
@@ -39,6 +45,16 @@
             "iterations": {{iterations | default(100)}},
             "clients": {{has_privileges_clients | default(1)}}
           },
+{% if cached_bystander_clients | default(0) > 0 %}
+          {
+            "name": "has_privileges_cached",
+            "operation": {
+              "operation-type": "has_privileges_cached"
+            },
+            "iterations": 10000000,
+            "clients": {{cached_bystander_clients}}
+          }
+{% else %}
           {
             "name": "cluster_info",
             "operation": {
@@ -47,6 +63,7 @@
             "iterations": 10000000,
             "clients": {{bystander_clients | default(1)}}
           }
+{% endif %}
         ]
       }
     }

--- a/has_privileges_bystander/track.json
+++ b/has_privileges_bystander/track.json
@@ -1,0 +1,46 @@
+{
+  "version": 2,
+  "description": "Demonstrates Netty event-loop head-of-line blocking caused by expensive _has_privileges requests. Requires http.netty.worker_count:1 on the target cluster.",
+  "schedule": [
+    {
+      "operation": {
+        "operation-type": "check_netty_worker_count"
+      }
+    },
+    {
+      "operation": {
+        "operation-type": "create_roles_and_users",
+        "num_roles": {{num_roles | default(100)}},
+        "num_users": {{num_users | default(1)}},
+        "num_roles_per_user": {{num_roles_per_user | default(100)}},
+        "wildcard_mode": "{{wildcard_mode | default('both')}}",
+        "index_privileges_per_role": {{index_privileges_per_role | default(10)}}
+      }
+    },
+    {
+      "parallel": {
+        "completed-by": "has_privileges",
+        "tasks": [
+          {
+            "name": "has_privileges",
+            "operation": {
+              "operation-type": "has_privileges",
+              "num_users": {{num_users | default(1)}}
+            },
+            "warmup-iterations": {{warmup_iterations | default(3)}},
+            "iterations": {{iterations | default(100)}},
+            "clients": {{has_privileges_clients | default(1)}}
+          },
+          {
+            "name": "cluster_info",
+            "operation": {
+              "operation-type": "cluster_info"
+            },
+            "iterations": 10000000,
+            "clients": {{bystander_clients | default(1)}}
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/has_privileges_bystander/track.py
+++ b/has_privileges_bystander/track.py
@@ -56,22 +56,6 @@ def build_heavy_has_privileges_body():
     return {"cluster": cluster_privs, "index": index_privs}
 
 
-async def check_netty_worker_count(es, params):
-    """Verify that the target cluster is running with http.netty.worker_count: 1.
-    This is required to deterministically reproduce event-loop head-of-line blocking."""
-    resp = await es.nodes.info(metric="settings")
-    for node_id, node in resp["nodes"].items():
-        count = node.get("settings", {}).get("http", {}).get("netty", {}).get("worker_count", None)
-        if count is None or int(count) != 1:
-            from esrally import exceptions
-
-            raise exceptions.InvalidSyntax(
-                f"Node [{node.get('name', node_id)}] has http.netty.worker_count={count}. "
-                f"This track requires http.netty.worker_count: 1 in elasticsearch.yml "
-                f"to deterministically reproduce Netty event-loop head-of-line blocking."
-            )
-
-
 async def create_roles_and_users(es, params):
     num_roles = params.get("num_roles", 100)
     num_users = params.get("num_users", 1)
@@ -107,6 +91,18 @@ async def create_roles_and_users(es, params):
             roles=random.sample(roles, k=num_roles_per_user),
         )
 
+    if params.get("cached_bystander_clients", 0) > 0:
+        await es.security.put_role(
+            name="bystander_role",
+            indices=[{"names": ["test-index"], "privileges": ["read"]}],
+            cluster=["monitor"],
+        )
+        await es.security.put_user(
+            username="bystander_user",
+            password="password",
+            roles=["bystander_role"],
+        )
+
 
 async def has_privileges(es, params):
     num_users = params.get("num_users", 1)
@@ -117,12 +113,18 @@ async def has_privileges(es, params):
     ).security.has_privileges(body=body)
 
 
+async def has_privileges_cached(es, params):
+    await es.options(
+        basic_auth=("bystander_user", "password"),
+    ).security.has_privileges(body={"cluster": ["monitor"], "index": [{"names": ["test-index"], "privileges": ["read"]}]})
+
+
 async def cluster_info(es, params):
     await es.info()
 
 
 def register(registry):
-    registry.register_runner("check_netty_worker_count", check_netty_worker_count, async_runner=True)
     registry.register_runner("create_roles_and_users", create_roles_and_users, async_runner=True)
     registry.register_runner("has_privileges", has_privileges, async_runner=True)
+    registry.register_runner("has_privileges_cached", has_privileges_cached, async_runner=True)
     registry.register_runner("cluster_info", cluster_info, async_runner=True)

--- a/has_privileges_bystander/track.py
+++ b/has_privileges_bystander/track.py
@@ -1,0 +1,105 @@
+import random
+import string
+
+
+def _random_index_expression(wildcard_mode="both"):
+    base = "".join(random.choices(string.ascii_lowercase + string.digits + "_-", k=10))
+    if wildcard_mode in ("prefix", "both"):
+        base = "*" + base
+    if wildcard_mode in ("suffix", "both"):
+        base = base + "*"
+    return base
+
+
+def build_heavy_has_privileges_body():
+    """Build a large, unique _has_privileges request body that forces expensive
+    checkPrivileges evaluation on every call.  Each invocation produces a unique
+    body so the per-role hasPrivilegesCache always misses."""
+    cluster_privs = [
+        "monitor", "manage", "manage_security", "manage_pipeline",
+        "manage_index_templates", "manage_ml", "manage_watcher",
+        "manage_transform", "manage_ccr", "manage_ilm",
+    ]
+
+    index_privs = []
+    for _ in range(50):
+        base = "".join(random.choices(string.ascii_lowercase + string.digits, k=10))
+        index_privs.append({
+            "names": [f"*{base}*" for _ in range(3)],
+            "privileges": random.sample(
+                ["read", "write", "delete", "create", "create_index", "index",
+                 "monitor", "manage", "view_index_metadata", "delete_index"], k=4),
+            "allow_restricted_indices": False,
+        })
+
+    return {"cluster": cluster_privs, "index": index_privs}
+
+
+async def check_netty_worker_count(es, params):
+    """Verify that the target cluster is running with http.netty.worker_count: 1.
+    This is required to deterministically reproduce event-loop head-of-line blocking."""
+    resp = await es.nodes.info(metric="settings")
+    for node_id, node in resp["nodes"].items():
+        count = node.get("settings", {}).get("http", {}).get("netty", {}).get("worker_count", None)
+        if count is None or int(count) != 1:
+            from esrally import exceptions
+            raise exceptions.InvalidSyntax(
+                f"Node [{node.get('name', node_id)}] has http.netty.worker_count={count}. "
+                f"This track requires http.netty.worker_count: 1 in elasticsearch.yml "
+                f"to deterministically reproduce Netty event-loop head-of-line blocking.")
+
+
+async def create_roles_and_users(es, params):
+    num_roles = params.get("num_roles", 100)
+    num_users = params.get("num_users", 1)
+    num_roles_per_user = params.get("num_roles_per_user", 100)
+    wildcard_mode = params.get("wildcard_mode", "both")
+    index_privileges_per_role = params.get("index_privileges_per_role", 10)
+
+    from esrally import exceptions
+    if num_roles_per_user > num_roles:
+        raise exceptions.InvalidSyntax(
+            f"num_roles_per_user ({num_roles_per_user}) cannot exceed num_roles ({num_roles})")
+
+    roles = [f"role_{i}" for i in range(num_roles)]
+
+    for role_name in roles:
+        indices_privileges = [
+            {
+                "names": [_random_index_expression(wildcard_mode=wildcard_mode)],
+                "privileges": random.sample(["read", "write", "delete", "create"], k=2),
+            }
+            for _ in range(index_privileges_per_role)
+        ]
+        await es.security.put_role(
+            name=role_name,
+            indices=indices_privileges,
+            cluster=random.sample(["all", "monitor", "manage"], k=2),
+        )
+
+    for i in range(num_users):
+        await es.security.put_user(
+            username=f"user_{i}",
+            password="password",
+            roles=random.sample(roles, k=num_roles_per_user),
+        )
+
+
+async def has_privileges(es, params):
+    num_users = params.get("num_users", 1)
+    user_id = random.randint(0, num_users - 1)
+    body = build_heavy_has_privileges_body()
+    await es.options(
+        basic_auth=(f"user_{user_id}", "password"),
+    ).security.has_privileges(body=body)
+
+
+async def cluster_info(es, params):
+    await es.info()
+
+
+def register(registry):
+    registry.register_runner("check_netty_worker_count", check_netty_worker_count, async_runner=True)
+    registry.register_runner("create_roles_and_users", create_roles_and_users, async_runner=True)
+    registry.register_runner("has_privileges", has_privileges, async_runner=True)
+    registry.register_runner("cluster_info", cluster_info, async_runner=True)

--- a/has_privileges_bystander/track.py
+++ b/has_privileges_bystander/track.py
@@ -16,21 +16,42 @@ def build_heavy_has_privileges_body():
     checkPrivileges evaluation on every call.  Each invocation produces a unique
     body so the per-role hasPrivilegesCache always misses."""
     cluster_privs = [
-        "monitor", "manage", "manage_security", "manage_pipeline",
-        "manage_index_templates", "manage_ml", "manage_watcher",
-        "manage_transform", "manage_ccr", "manage_ilm",
+        "monitor",
+        "manage",
+        "manage_security",
+        "manage_pipeline",
+        "manage_index_templates",
+        "manage_ml",
+        "manage_watcher",
+        "manage_transform",
+        "manage_ccr",
+        "manage_ilm",
     ]
 
     index_privs = []
     for _ in range(50):
         base = "".join(random.choices(string.ascii_lowercase + string.digits, k=10))
-        index_privs.append({
-            "names": [f"*{base}*" for _ in range(3)],
-            "privileges": random.sample(
-                ["read", "write", "delete", "create", "create_index", "index",
-                 "monitor", "manage", "view_index_metadata", "delete_index"], k=4),
-            "allow_restricted_indices": False,
-        })
+        index_privs.append(
+            {
+                "names": [f"*{base}*" for _ in range(3)],
+                "privileges": random.sample(
+                    [
+                        "read",
+                        "write",
+                        "delete",
+                        "create",
+                        "create_index",
+                        "index",
+                        "monitor",
+                        "manage",
+                        "view_index_metadata",
+                        "delete_index",
+                    ],
+                    k=4,
+                ),
+                "allow_restricted_indices": False,
+            }
+        )
 
     return {"cluster": cluster_privs, "index": index_privs}
 
@@ -43,10 +64,12 @@ async def check_netty_worker_count(es, params):
         count = node.get("settings", {}).get("http", {}).get("netty", {}).get("worker_count", None)
         if count is None or int(count) != 1:
             from esrally import exceptions
+
             raise exceptions.InvalidSyntax(
                 f"Node [{node.get('name', node_id)}] has http.netty.worker_count={count}. "
                 f"This track requires http.netty.worker_count: 1 in elasticsearch.yml "
-                f"to deterministically reproduce Netty event-loop head-of-line blocking.")
+                f"to deterministically reproduce Netty event-loop head-of-line blocking."
+            )
 
 
 async def create_roles_and_users(es, params):
@@ -57,9 +80,9 @@ async def create_roles_and_users(es, params):
     index_privileges_per_role = params.get("index_privileges_per_role", 10)
 
     from esrally import exceptions
+
     if num_roles_per_user > num_roles:
-        raise exceptions.InvalidSyntax(
-            f"num_roles_per_user ({num_roles_per_user}) cannot exceed num_roles ({num_roles})")
+        raise exceptions.InvalidSyntax(f"num_roles_per_user ({num_roles_per_user}) cannot exceed num_roles ({num_roles})")
 
     roles = [f"role_{i}" for i in range(num_roles)]
 

--- a/it_tracks/test_all_tracks_and_challenges.py
+++ b/it_tracks/test_all_tracks_and_challenges.py
@@ -31,6 +31,7 @@ class TestTrackRepository:
         "openai_vector",
         "random_vector",
         "has_privileges",
+        "has_privileges_bystander",
     ]
     disable_assertions = {
         "http_logs": ["append-no-conflicts", "runtime-fields"],


### PR DESCRIPTION
Add a Rally track that benchmarks expensive `_has_privileges` requests alongside lightweight bystander requests to measure and compare head-of-line blocking on Netty event-loop threads.

When `_has_privileges` triggers expensive DFA automaton operations (e.g., for users with many wildcard index privileges), it can block the Netty worker thread synchronously. Bystander requests on the same event loop are forced to wait, producing latency outliers unrelated to their own cost.

The track supports two bystander modes:
- **`cluster_info`** (default) — trivial `GET /` requests
- **`has_privileges_cached`** — lightweight `_has_privileges` requests from a `bystander_user` with a simple cached role, enabled via `cached_bystander_clients`

The cached mode is designed for A/B comparison benchmarking: run the same track against a baseline and a contender build, then use `esrally compare` to quantify the difference in bystander tail latency.