### PR TITLE
Add cached _has_privileges bystander mode to blocking benchmark track

### DIFF
--- a/has_privileges_bystander/README.md
+++ b/has_privileges_bystander/README.md
@@ -1,26 +1,16 @@
 # Has-Privileges Bystander Blocking Track
 
-Demonstrates Netty event-loop head-of-line blocking caused by expensive `_has_privileges` index privilege evaluation.
+Benchmarks expensive `_has_privileges` requests alongside lightweight bystander requests to measure head-of-line blocking on Netty event-loop threads.
 
 ## What This Track Shows
 
-When a `_has_privileges` request triggers expensive DFA (automaton) operations in `IndicesPermission.checkResourcePrivileges`, it blocks the Netty event loop thread synchronously. Any other HTTP request ("bystander") bound to the same event loop must wait in line, causing latency outliers unrelated to the bystander request's own cost.
+When a `_has_privileges` request triggers expensive DFA (automaton) operations in `IndicesPermission.checkResourcePrivileges`, it can block the Netty event loop thread synchronously. Any other HTTP request ("bystander") bound to the same event loop must wait in line, causing latency outliers unrelated to the bystander request's own cost.
 
-The track runs `_has_privileges` requests alongside trivial `GET /` bystander requests on a single Netty event loop, then compares their latency distributions. A successful reproduction shows bystander p100 latency approaching `has_privileges` p100.
+The track runs expensive `_has_privileges` requests alongside lightweight bystander requests, then compares their latency distributions. Head-of-line blocking manifests as bystander p100 latency approaching `has_privileges` p100.
 
 ## Cluster Prerequisites
 
-The target Elasticsearch cluster must be configured with the following **static** settings in `elasticsearch.yml` (requires node restart):
-
-```yaml
-http.netty.worker_count: 1
-```
-
-This forces all HTTP connections onto a single Netty event loop thread, making the blocking effect deterministic. Without this, blocking still occurs but only affects the ~1/N fraction of bystander requests that happen to land on the same event loop as a slow `has_privileges` request.
-
-The track validates this setting at startup and fails with a clear error if it is not configured.
-
-X-Pack Security must be enabled (default in recent ES versions).
+X-Pack Security must be enabled (default in recent ES versions). No special static settings are required.
 
 ## Parameters
 
@@ -36,7 +26,8 @@ All parameters can be configured via `--track-params`:
 | `iterations` | integer | 100 | Number of `has_privileges` requests to measure |
 | `warmup_iterations` | integer | 3 | Warmup iterations before measurement |
 | `has_privileges_clients` | integer | 1 | Concurrent `has_privileges` clients |
-| `bystander_clients` | integer | 1 | Concurrent bystander (`GET /`) clients |
+| `bystander_clients` | integer | 1 | Concurrent bystander (`GET /`) clients (used when `cached_bystander_clients` is 0) |
+| `cached_bystander_clients` | integer | 0 | Concurrent bystander clients using lightweight cached `_has_privileges` requests instead of `GET /` |
 
 ### Wildcard Modes
 
@@ -59,27 +50,75 @@ esrally race --track-path=has_privileges_bystander \
   --track-params="iterations:50"
 ```
 
-### With Rally-Provisioned Cluster
-
-Not directly supported because `http.netty.worker_count` is a static setting that must be in `elasticsearch.yml` before the node starts. You would need a custom car definition that includes this setting.
-
 ## How It Works
 
-1. **`check_netty_worker_count`** -- verifies `http.netty.worker_count: 1` on all nodes
-2. **`create_roles_and_users`** -- creates roles with randomized wildcard index patterns and assigns them to test users
-3. **Parallel phase** -- runs concurrently until `has_privileges` completes:
+1. **`create_roles_and_users`** -- creates roles with randomized wildcard index patterns and assigns them to test users. If `cached_bystander_clients > 0`, also creates a `bystander_user` with a single simple role.
+2. **Parallel phase** -- runs concurrently until `has_privileges` completes:
    - **`has_privileges`** -- sends `_has_privileges` requests with a large, unique request body (50 index expressions with wildcard patterns, 10 cluster privileges). Each body is randomized to defeat the per-role `hasPrivilegesCache`.
-   - **`cluster_info`** -- sends trivial `GET /` requests continuously as bystander traffic
+   - **`has_privileges_cached`** (when `cached_bystander_clients > 0`) -- sends lightweight `_has_privileges` requests as `bystander_user` with a simple cached role. These hit the role cache and complete quickly unless blocked.
+   - **`cluster_info`** (when `cached_bystander_clients == 0`) -- sends trivial `GET /` requests continuously as bystander traffic.
 
 ## Interpreting Results
 
 | Metric | What to look for |
 |---|---|
 | `has_privileges` p50 | Baseline cost of index privilege evaluation (~2s with defaults) |
-| `cluster_info` p50 | Should be <1ms (trivial request, no contention) |
-| `cluster_info` p100 | Should approach `has_privileges` p100 (proves blocking) |
+| bystander p50 | Should be <1ms (trivial request, no contention) |
+| bystander p100 | Approaches `has_privileges` p100 when head-of-line blocking is present |
 
-If `cluster_info` p100 is close to `has_privileges` p100, a bystander request was blocked behind a full `_has_privileges` evaluation on the shared event loop.
+If bystander p100 is close to `has_privileges` p100, a bystander request was blocked behind a full `_has_privileges` evaluation on the shared Netty event loop.
+
+## Comparison Benchmarking
+
+To compare two ES builds (e.g., a baseline release vs. a branch with a fix), run the track against each build with a tagged `--race-id`, then use `esrally compare`.
+
+### 1. Run the baseline
+
+Start the baseline ES (e.g., 9.3.3), then:
+
+```bash
+esrally race --track-path=has_privileges_bystander \
+  --pipeline=benchmark-only \
+  --target-hosts=http://localhost:9200 \
+  --client-options="basic_auth_user:'elastic',basic_auth_password:'password'" \
+  --track-params='{"cached_bystander_clients": 8, "has_privileges_clients": 2, "iterations": 10, "warmup_iterations": 1}' \
+  --on-error=abort \
+  --race-id=baseline-933 \
+  --user-tag="version:9.3.3"
+```
+
+### 2. Run the contender
+
+Stop the baseline, start the contender ES, then run the same command with a different `--race-id` and `--user-tag`:
+
+```bash
+esrally race --track-path=has_privileges_bystander \
+  --pipeline=benchmark-only \
+  --target-hosts=http://localhost:9200 \
+  --client-options="basic_auth_user:'elastic',basic_auth_password:'password'" \
+  --track-params='{"cached_bystander_clients": 8, "has_privileges_clients": 2, "iterations": 10, "warmup_iterations": 1}' \
+  --on-error=abort \
+  --race-id=contender-branch \
+  --user-tag="version:my-branch"
+```
+
+### 3. Compare
+
+```bash
+esrally compare --baseline=baseline-933 --contender=contender-branch
+```
+
+### Key metrics to watch
+
+| Metric | Indicates |
+|---|---|
+| `has_privileges` p50/p100 | Cost of the expensive authorization path |
+| `has_privileges_cached` p50 | Steady-state bystander latency (should be sub-ms) |
+| `has_privileges_cached` p100 | Worst-case bystander latency -- drops dramatically when head-of-line blocking is eliminated |
+| `has_privileges_cached` throughput | Bystander throughput under contention |
+| error rate | Non-zero on either task indicates a functional regression (e.g., auth context leak) |
+
+A successful fix for head-of-line blocking shows bystander p100 dropping from ~2s (matching `has_privileges` latency) to sub-200ms, while bystander p50 stays sub-millisecond.
 
 ## Cost Center
 

--- a/has_privileges_bystander/track.json
+++ b/has_privileges_bystander/track.json
@@ -1,12 +1,7 @@
 {
   "version": 2,
-  "description": "Demonstrates Netty event-loop head-of-line blocking caused by expensive _has_privileges requests. Requires http.netty.worker_count:1 on the target cluster.",
+  "description": "Benchmarks expensive _has_privileges requests alongside lightweight bystander requests.",
   "schedule": [
-    {
-      "operation": {
-        "operation-type": "check_netty_worker_count"
-      }
-    },
     {
       "operation": {
         "operation-type": "create_roles_and_users",
@@ -14,7 +9,8 @@
         "num_users": {{num_users | default(1)}},
         "num_roles_per_user": {{num_roles_per_user | default(100)}},
         "wildcard_mode": "{{wildcard_mode | default('both')}}",
-        "index_privileges_per_role": {{index_privileges_per_role | default(10)}}
+        "index_privileges_per_role": {{index_privileges_per_role | default(10)}},
+        "cached_bystander_clients": {{cached_bystander_clients | default(0)}}
       }
     },
     {
@@ -26,6 +22,16 @@
       "iterations": {{warmup_iterations | default(3)}},
       "clients": 1
     },
+{% if cached_bystander_clients | default(0) > 0 %}
+    {
+      "name": "warmup_has_privileges_cached",
+      "operation": {
+        "operation-type": "has_privileges_cached"
+      },
+      "iterations": 5,
+      "clients": 1
+    },
+{% endif %}
     {
       "parallel": {
         "completed-by": "has_privileges",
@@ -39,6 +45,16 @@
             "iterations": {{iterations | default(100)}},
             "clients": {{has_privileges_clients | default(1)}}
           },
+{% if cached_bystander_clients | default(0) > 0 %}
+          {
+            "name": "has_privileges_cached",
+            "operation": {
+              "operation-type": "has_privileges_cached"
+            },
+            "iterations": 10000000,
+            "clients": {{cached_bystander_clients}}
+          }
+{% else %}
           {
             "name": "cluster_info",
             "operation": {
@@ -47,6 +63,7 @@
             "iterations": 10000000,
             "clients": {{bystander_clients | default(1)}}
           }
+{% endif %}
         ]
       }
     }

--- a/has_privileges_bystander/track.py
+++ b/has_privileges_bystander/track.py
@@ -56,22 +56,6 @@ def build_heavy_has_privileges_body():
     return {"cluster": cluster_privs, "index": index_privs}
 
 
-async def check_netty_worker_count(es, params):
-    """Verify that the target cluster is running with http.netty.worker_count: 1.
-    This is required to deterministically reproduce event-loop head-of-line blocking."""
-    resp = await es.nodes.info(metric="settings")
-    for node_id, node in resp["nodes"].items():
-        count = node.get("settings", {}).get("http", {}).get("netty", {}).get("worker_count", None)
-        if count is None or int(count) != 1:
-            from esrally import exceptions
-
-            raise exceptions.InvalidSyntax(
-                f"Node [{node.get('name', node_id)}] has http.netty.worker_count={count}. "
-                f"This track requires http.netty.worker_count: 1 in elasticsearch.yml "
-                f"to deterministically reproduce Netty event-loop head-of-line blocking."
-            )
-
-
 async def create_roles_and_users(es, params):
     num_roles = params.get("num_roles", 100)
     num_users = params.get("num_users", 1)
@@ -107,6 +91,18 @@ async def create_roles_and_users(es, params):
             roles=random.sample(roles, k=num_roles_per_user),
         )
 
+    if params.get("cached_bystander_clients", 0) > 0:
+        await es.security.put_role(
+            name="bystander_role",
+            indices=[{"names": ["test-index"], "privileges": ["read"]}],
+            cluster=["monitor"],
+        )
+        await es.security.put_user(
+            username="bystander_user",
+            password="password",
+            roles=["bystander_role"],
+        )
+
 
 async def has_privileges(es, params):
     num_users = params.get("num_users", 1)
@@ -117,12 +113,18 @@ async def has_privileges(es, params):
     ).security.has_privileges(body=body)
 
 
+async def has_privileges_cached(es, params):
+    await es.options(
+        basic_auth=("bystander_user", "password"),
+    ).security.has_privileges(body={"cluster": ["monitor"], "index": [{"names": ["test-index"], "privileges": ["read"]}]})
+
+
 async def cluster_info(es, params):
     await es.info()
 
 
 def register(registry):
-    registry.register_runner("check_netty_worker_count", check_netty_worker_count, async_runner=True)
     registry.register_runner("create_roles_and_users", create_roles_and_users, async_runner=True)
     registry.register_runner("has_privileges", has_privileges, async_runner=True)
+    registry.register_runner("has_privileges_cached", has_privileges_cached, async_runner=True)
     registry.register_runner("cluster_info", cluster_info, async_runner=True)


### PR DESCRIPTION
## Summary

- Adds a `has_privileges_cached` bystander mode that uses lightweight, cache-hitting `_has_privileges` requests (as a simple `bystander_user`) instead of `GET /` for more realistic head-of-line blocking measurement
- Removes the `http.netty.worker_count: 1` prerequisite and pre-flight check, so the track works against any cluster without static config changes
- Adds comparison benchmarking instructions to the README for baseline vs. contender workflows using `esrally compare`

## New parameters

| Parameter | Default | Description |
|---|---|---|
| `cached_bystander_clients` | 0 | When > 0, uses cached `_has_privileges` bystander requests instead of `GET /` |