### PR TITLE
Fix .backportrc.json

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,8 +1,13 @@
 {
+  "repoOwner": "elastic",
+  "repoName": "rally-tracks",
   "targetBranchChoices" : [ "9.4", "9.3", "9.2", "9.1", "9.0", "8.19" ],
   "targetPRLabels" : [ "backport" ],
   "branchLabelMapping" : {
-    "^v9.4$" : "master",
+    "^v9.5$" : "master",
     "^v(\\d{1,2}).(\\d{1,2})$" : "$1.$2"
-  }
+  },
+  "autoMerge": true,
+  "autoMergeMethod": "squash",
+  "prDescription": "{defaultPrDescription}\n\n<!--BACKPORT {commits} BACKPORT-->"
 }


### PR DESCRIPTION
https://github.com/elastic/rally-tracks/commit/e3b7558c18918f9593c9c9f2d427e2d4cd6e4b7e had overwritten required options, and did not update the _next_ label in `branchLabelMapping`.