### PR TITLE
Update Reminder message + add serverless label

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -5,6 +5,7 @@
   "targetPRLabels" : [ "backport" ],
   "branchLabelMapping" : {
     "^v9.5$" : "master",
+    "^vServerless": "master",
     "^v(\\d{1,2}).(\\d{1,2})$" : "$1.$2"
   },
   "autoMerge": true,

--- a/.backportrc.json
+++ b/.backportrc.json
@@ -5,7 +5,7 @@
   "targetPRLabels" : [ "backport" ],
   "branchLabelMapping" : {
     "^v9.5$" : "master",
-    "^vServerless": "master",
+    "^vServerless$": "master",
     "^v(\\d{1,2}).(\\d{1,2})$" : "$1.$2"
   },
   "autoMerge": true,

--- a/github_ci_tools/scripts/backport.py
+++ b/github_ci_tools/scripts/backport.py
@@ -86,13 +86,14 @@ REMINDER_BODY = (
     "A backport is pending for this PR.\n"
     "Apply all the labels that correspond to Elasticsearch minor versions expected to work with this PR, but select only from the available ones.\n"
     "If intended for future releases, apply label for next minor\n\n"
+    "If the PR is only applicable for serverless, add the vServerless label"
     "When a `vX.Y` label is added, a new pull request will be automatically created, unless merge conflicts are detected or if the label supplied points to the next Elasticsearch minor version. If successful, a link to the newly opened backport PR will be provided in a comment.\n\n"
     "In case of merge conflicts during backporting, create the backport PR manually following the steps from [README](https://github.com/elastic/rally-tracks?tab=readme-ov-file#merge-conflicts):\n"
     "**Final steps to complete the backporting process:**\n"
     "   1. Ensure the correct version labels exist in this PR.\n"
     "   2. Ensure each backport pull request is labeled with `backport`.\n"
     "   3. Review and merge each backport pull request into the appropriate version branch.\n"
-    "   4. Remove `backport pending` label from this PR once all backport PRs are merged.\n\n"
+    "   4. Remove `backport pending` label from this PR once all backport PRs are merged. Note: a version label must be added, otherwise the bot will add back the ´backport pending´ label. \n\n"
     "Thank you!"
 )
 

--- a/github_ci_tools/scripts/backport.py
+++ b/github_ci_tools/scripts/backport.py
@@ -86,7 +86,7 @@ REMINDER_BODY = (
     "A backport is pending for this PR.\n"
     "Apply all the labels that correspond to Elasticsearch minor versions expected to work with this PR, but select only from the available ones.\n"
     "If intended for future releases, apply label for next minor\n\n"
-    "If the PR is only applicable for serverless, add the vServerless label"
+    "If the PR is only applicable for serverless, add the `vServerless` label"
     "When a `vX.Y` label is added, a new pull request will be automatically created, unless merge conflicts are detected or if the label supplied points to the next Elasticsearch minor version. If successful, a link to the newly opened backport PR will be provided in a comment.\n\n"
     "In case of merge conflicts during backporting, create the backport PR manually following the steps from [README](https://github.com/elastic/rally-tracks?tab=readme-ov-file#merge-conflicts):\n"
     "**Final steps to complete the backporting process:**\n"

--- a/github_ci_tools/scripts/backport.py
+++ b/github_ci_tools/scripts/backport.py
@@ -86,7 +86,7 @@ REMINDER_BODY = (
     "A backport is pending for this PR.\n"
     "Apply all the labels that correspond to Elasticsearch minor versions expected to work with this PR, but select only from the available ones.\n"
     "If intended for future releases, apply label for next minor\n\n"
-    "If the PR is only applicable for serverless, add the `vServerless` label"
+    "If the PR is only applicable for serverless, add the `vServerless` label.\n\n"
     "When a `vX.Y` label is added, a new pull request will be automatically created, unless merge conflicts are detected or if the label supplied points to the next Elasticsearch minor version. If successful, a link to the newly opened backport PR will be provided in a comment.\n\n"
     "In case of merge conflicts during backporting, create the backport PR manually following the steps from [README](https://github.com/elastic/rally-tracks?tab=readme-ov-file#merge-conflicts):\n"
     "**Final steps to complete the backporting process:**\n"

--- a/github_ci_tools/scripts/backport.py
+++ b/github_ci_tools/scripts/backport.py
@@ -21,7 +21,7 @@
 
 - Apply 'backport pending' label to merged PRs that require backport.
 - Post reminder comments on such PRs that have a 'backport pending' label
-but a version label (e.g. vX.Y) has not been added yet. 
+but a version label (e.g. vX.Y) has not been added yet.
 - Omits PRs labeled 'backport'.
 
 Usage: backport.py [options] <command> [flags]
@@ -63,8 +63,6 @@ import json
 import logging
 import os
 import re
-import sys
-import urllib.error
 import urllib.request
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -195,8 +193,23 @@ def ensure_backport_pending_label() -> None:
     add_repository_label(repository=CONFIG.repo, name=PENDING_LABEL, color=PENDING_LABEL_COLOR)
 
 
+def load_defined_patterns() -> list[str]:
+    config_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".backportrc.json"))
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            config = json.load(f)
+    except FileNotFoundError:
+        LOG.warning("No .backportrc.json found at %s; using default version label pattern", config_path)
+        return [VERSION_LABEL_RE]
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Invalid JSON in {config_path}: {e}") from e
+    patterns = config.get("branchLabelMapping", {}).keys()
+    patterns_re = [re.compile(p) for p in patterns]
+    return patterns_re
+
+
 def pr_needs_pending_label(info: PRInfo) -> bool:
-    has_version_label = any(VERSION_LABEL_RE.match(label) for label in info.labels)
+    has_version_label = any(any(pattern.match(label) for pattern in load_defined_patterns()) for label in info.labels)
     return PENDING_LABEL not in info.labels and BACKPORT_LABEL not in info.labels and not has_version_label
 
 

--- a/github_ci_tools/tests/test_backport_label.py
+++ b/github_ci_tools/tests/test_backport_label.py
@@ -10,7 +10,7 @@ from github_ci_tools.tests.resources.case_registry import (
     expected_actions_for_repo,
     select_pull_requests,
 )
-from github_ci_tools.tests.resources.cases import GHInteractionCase, RepoCase, cases
+from github_ci_tools.tests.resources.cases import GHInteractionCase, PullRequestCase, RepoCase, cases
 from github_ci_tools.tests.utils import LABELS, STATIC_ROUTES
 
 
@@ -87,3 +87,29 @@ def test_label_logic(backport_mod, gh_mock, case: GHInteractionCase):
             backport_mod.add_pull_request_label(pr.number, backport_mod.PENDING_LABEL)
             case.expected_order += expected_actions_for_prs(GHInteractAction.PR_ADD_PENDING_LABEL, [case_by_number(pr.number)])
     gh_mock.assert_calls_in_order(*case.expected_order)
+
+
+@cases(
+    no_version_labels_needs_pending=PullRequestCase(number=501, labels=[], needs_pending=True),
+    single_version_label_no_pending=PullRequestCase(number=502, labels=LABELS["versioned"], needs_pending=False),
+    multiple_version_labels_no_pending=PullRequestCase(number=503, labels=LABELS["multiple_versioned"], needs_pending=False),
+    single_version_with_other_labels_no_pending=PullRequestCase(
+        number=504, labels=[*LABELS["versioned"], LABELS["backport_typo"][0]], needs_pending=False
+    ),
+    multiple_versions_with_other_labels_no_pending=PullRequestCase(
+        number=505, labels=[*LABELS["multiple_versioned_with_other"]], needs_pending=False
+    ),
+    has_backport_label_no_pending=PullRequestCase(number=506, labels=LABELS["backport"], needs_pending=False),
+    has_pending_label_no_pending=PullRequestCase(number=507, labels=LABELS["pending"], needs_pending=False),
+    has_both_version_and_pending_no_pending=PullRequestCase(number=508, labels=LABELS["versioned_pending"], needs_pending=False),
+)
+def test_version_label_scenarios(backport_mod, case: PullRequestCase):
+    """Test pr_needs_pending_label with various version label configurations.
+
+    Covers:
+    - PRs with no version labels (should need pending)
+    - PRs with single version label (should NOT need pending)
+    - PRs with multiple version labels (should NOT need pending)
+    """
+    pr_info = backport_mod.PRInfo.from_dict(asdict(case))
+    assert backport_mod.pr_needs_pending_label(pr_info) is case.needs_pending

--- a/github_ci_tools/tests/test_backport_label.py
+++ b/github_ci_tools/tests/test_backport_label.py
@@ -107,6 +107,7 @@ def test_label_logic(backport_mod, gh_mock, case: GHInteractionCase):
     has_backport_label_no_pending=PullRequestCase(number=506, labels=LABELS["backport"], needs_pending=False),
     has_pending_label_no_pending=PullRequestCase(number=507, labels=LABELS["pending"], needs_pending=False),
     has_both_version_and_pending_no_pending=PullRequestCase(number=508, labels=LABELS["versioned_pending"], needs_pending=False),
+    just_serverless_label_no_pending=PullRequestCase(number=509, labels=LABELS["serverless"], needs_pending=False),
 )
 def test_version_label_scenarios(backport_mod, case: PullRequestCase):
     """Test pr_needs_pending_label with various version label configurations.

--- a/github_ci_tools/tests/test_backport_label.py
+++ b/github_ci_tools/tests/test_backport_label.py
@@ -10,7 +10,12 @@ from github_ci_tools.tests.resources.case_registry import (
     expected_actions_for_repo,
     select_pull_requests,
 )
-from github_ci_tools.tests.resources.cases import GHInteractionCase, PullRequestCase, RepoCase, cases
+from github_ci_tools.tests.resources.cases import (
+    GHInteractionCase,
+    PullRequestCase,
+    RepoCase,
+    cases,
+)
 from github_ci_tools.tests.utils import LABELS, STATIC_ROUTES
 
 

--- a/github_ci_tools/tests/utils.py
+++ b/github_ci_tools/tests/utils.py
@@ -126,6 +126,7 @@ LABELS = {
     "versioned_pending_typo": [Label(name) for name in ["v9.2", "backport pend"]],
     "multiple_versioned": [Label(name) for name in ["v9.2", "v8.15", "vServerless"]],
     "multiple_versioned_with_other": [Label(name) for name in ["v9.2", "v8.15", "documentation"]],
+    "serverless": [Label("vServerless")],
 }
 
 COMMENT_MARKER_BASE = "<!-- backport-pending-reminder -->"

--- a/github_ci_tools/tests/utils.py
+++ b/github_ci_tools/tests/utils.py
@@ -124,6 +124,8 @@ LABELS = {
     "versioned_typo": [Label(name) for name in ["v9.2124215s", "123.v2.1sada", "version9.2", "..v9.2..", "v!@#9.20%^@"]],
     "versioned_pending": [Label(name) for name in ["v9.2", PENDING_LABEL]],  # for remove tests
     "versioned_pending_typo": [Label(name) for name in ["v9.2", "backport pend"]],
+    "multiple_versioned": [Label(name) for name in ["v9.2", "v8.15", "vServerless"]],
+    "multiple_versioned_with_other": [Label(name) for name in ["v9.2", "v8.15", "documentation"]],
 }
 
 COMMENT_MARKER_BASE = "<!-- backport-pending-reminder -->"


### PR DESCRIPTION
This updates the message for backport reminders to be a bit clearer, as well as refer to a new label - vServerless - that can be used for PRs that only make sense for serverless. 