### PR TITLE
Add master branch to targetBranchChoices

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,7 @@
 {
   "repoOwner": "elastic",
   "repoName": "rally-tracks",
-  "targetBranchChoices" : [ "9.4", "9.3", "9.2", "9.1", "9.0", "8.19" ],
+  "targetBranchChoices" : [ "master", "9.4", "9.3", "9.2", "9.1", "9.0", "8.19" ],
   "targetPRLabels" : [ "backport" ],
   "branchLabelMapping" : {
     "^v9.5$" : "master",


### PR DESCRIPTION
Backport action ends with `Error: There are no branches to backport to. Aborting.` ([example](https://github.com/elastic/rally-tracks/actions/runs/24410858027/job/71306962455)) if version label points at `master`. This change is to verify if the symptom will be different if `targetBranchChoices` includes `master.