### PR TITLE
add more esql queries

### DIFF
--- a/big5/challenges/esql.json
+++ b/big5/challenges/esql.json
@@ -1,0 +1,184 @@
+{
+  "name": "big5-esql",
+  "description": "ESQL equivalents of the Big5 QueryDSL benchmarks",
+  "schedule": [
+    {
+      "operation": "create-ilm-policy"
+    },
+    {
+      "operation": "create-index-template"
+    },
+    {
+      "operation": "create-data-stream"
+    },
+    {
+      "operation": "bulk-index",
+      "clients": {{ bulk_indexing_clients | default(1) }}
+    },
+    {
+      "operation": "esql_default",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_desc_sort_timestamp",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_asc_sort_timestamp",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_desc_sort_with_after_timestamp",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_asc_sort_with_after_timestamp",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_desc_sort_timestamp_with_match",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_asc_sort_timestamp_with_match",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_term",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_multi_terms_keyword",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_keyword_terms",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_keyword_terms_low_cardinality",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_multi_terms",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_multi_terms_three_keyword",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_date_histogram_daily",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_range",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_range_numeric",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_keyword_in_range",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_date_histogram_hourly_agg",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_date_histogram_minute_agg",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_query_string_on_message",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_query_string_on_message_filtered",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_query_string_on_message_filtered_sorted_num",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_sort_keyword_with_match",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_sort_numeric_desc",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_sort_numeric_asc",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_sort_numeric_desc_with_match",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_sort_numeric_asc_with_match",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_range_field_conjunction_big_range_big_term_query",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_range_field_disjunction_big_range_small_term_query",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_range_field_conjunction_small_range_small_term_query",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_range_field_conjunction_small_range_big_term_query",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_range_auto_date_histo",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    },
+    {
+      "operation": "esql_range_auto_date_histo_with_metrics",
+      "warmup-iterations": {{ warmup_iterations | default(100) }},
+      "iterations": {{ iterations | default(1000) }}
+    }
+  ]
+}

--- a/big5/operations/esql.json
+++ b/big5/operations/esql.json
@@ -1,0 +1,171 @@
+    {
+      "name": "esql_default",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev"
+    },
+    {
+      "name": "esql_term",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE log.file.path == \"/var/log/messages/fuschiashoulder\""
+    },
+    {
+      "name": "esql_range",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-01T00:00:00.000Z\" AND @timestamp < \"2023-01-03T00:00:00.000Z\""
+    },
+    {
+      "name": "esql_range_numeric",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE metrics.size >= 20 AND metrics.size <= 200"
+    },
+    {
+      "name": "esql_keyword_in_range",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-01T00:00:00.000Z\" AND @timestamp < \"2023-01-03T00:00:00.000Z\" AND process.name == \"kernel\""
+    },
+
+    {
+      "name": "esql_desc_sort_timestamp",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | SORT @timestamp DESC"
+    },
+    {
+      "name": "esql_asc_sort_timestamp",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | SORT @timestamp ASC"
+    },
+    {
+      "name": "esql_desc_sort_with_after_timestamp",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp < \"2023-01-06T23:59:58.000Z\" | SORT @timestamp DESC"
+    },
+    {
+      "name": "esql_asc_sort_with_after_timestamp",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp > \"2023-01-01T23:59:58.000Z\" | SORT @timestamp ASC"
+    },
+    {
+      "name": "esql_desc_sort_timestamp_with_match",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE process.name == \"kernel\" | SORT @timestamp DESC"
+    },
+    {
+      "name": "esql_asc_sort_timestamp_with_match",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE process.name == \"kernel\" | SORT @timestamp ASC"
+    },
+    {
+      "name": "esql_sort_keyword_with_match",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE process.name == \"kernel\" | SORT meta.file ASC"
+    },
+    {
+      "name": "esql_sort_numeric_desc",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | SORT metrics.size DESC"
+    },
+    {
+      "name": "esql_sort_numeric_asc",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | SORT metrics.size ASC"
+    },
+    {
+      "name": "esql_sort_numeric_desc_with_match",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE log.file.path == \"/var/log/messages/solarshark\" | SORT metrics.size DESC"
+    },
+    {
+      "name": "esql_sort_numeric_asc_with_match",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE log.file.path == \"/var/log/messages/solarshark\" | SORT metrics.size ASC"
+    },
+
+    {
+      "name": "esql_date_histogram_hourly_agg",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 hour, @timestamp) | SORT bucket"
+    },
+    {
+      "name": "esql_date_histogram_minute_agg",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-01T00:00:00.000Z\" AND @timestamp < \"2023-01-03T00:00:00.000Z\" | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 minute, @timestamp) | SORT bucket"
+    },
+
+    {
+      "name": "esql_range_auto_date_histo",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | EVAL size_bucket = CASE(metrics.size < -10, \"lt_neg10\", metrics.size >= -10 AND metrics.size < 10, \"neg10_to_10\", metrics.size >= 10 AND metrics.size < 100, \"10_to_100\", metrics.size >= 100 AND metrics.size < 1000, \"100_to_1000\", metrics.size >= 1000 AND metrics.size < 2000, \"1000_to_2000\", \"gte_2000\") | STATS count=COUNT(*) BY size_bucket, date_bucket=BUCKET(@timestamp, 20, \"2023-01-01T00:00:00.000Z\", \"2023-01-08T00:00:00.000Z\") | SORT size_bucket, date_bucket"
+    },
+    {
+      "name": "esql_range_auto_date_histo_with_metrics",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | EVAL size_bucket = CASE(metrics.size < 100, \"lt_100\", metrics.size >= 100 AND metrics.size < 1000, \"100_to_1000\", metrics.size >= 1000 AND metrics.size < 2000, \"1000_to_2000\", \"gte_2000\") | STATS tmin=MIN(metrics.tmin), tavg=AVG(metrics.size), tmax=MAX(metrics.size) BY size_bucket, date_bucket=BUCKET(@timestamp, 10, \"2023-01-01T00:00:00.000Z\", \"2023-01-08T00:00:00.000Z\") | SORT size_bucket, date_bucket"
+    },
+
+    {
+      "name": "esql_keyword_terms",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | STATS count=COUNT(*) BY aws.cloudwatch.log_stream | SORT count DESC | LIMIT 500"
+    },
+    {
+      "name": "esql_keyword_terms_low_cardinality",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | STATS count=COUNT(*) BY aws.cloudwatch.log_stream | SORT count DESC | LIMIT 50"
+    },
+    {
+      "name": "esql_multi_terms_keyword",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-05T00:00:00.000Z\" AND @timestamp < \"2023-01-05T05:00:00.000Z\" | STATS count=COUNT(*) BY process.name, cloud.region | SORT count DESC | LIMIT 10"
+    },
+    {
+      "name": "esql_multi_terms",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-02T00:00:00.000Z\" AND @timestamp < \"2023-01-02T10:00:00.000Z\" | STATS count=COUNT(*) BY process.name, cloud.region | SORT process.name DESC, cloud.region ASC"
+    },
+    {
+      "name": "esql_multi_terms_three_keyword",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-02T00:00:00.000Z\" AND @timestamp < \"2023-01-02T10:00:00.000Z\" | STATS count=COUNT(*) BY process.name, cloud.region, aws.cloudwatch.log_stream | SORT process.name DESC, cloud.region ASC, aws.cloudwatch.log_stream ASC"
+    },
+    {
+      "name": "esql_date_histogram_daily",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2022-12-30T00:00:00.000Z\" AND @timestamp < \"2023-01-07T12:00:00.000Z\" | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 day, @timestamp) | SORT bucket"
+    },
+
+    {
+      "name": "esql_range_field_conjunction_big_range_big_term_query",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE process.name == \"systemd\" AND metrics.size >= 1 AND metrics.size <= 100"
+    },
+    {
+      "name": "esql_range_field_disjunction_big_range_small_term_query",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE aws.cloudwatch.log_stream == \"indigodagger\" OR (metrics.size >= 1 AND metrics.size <= 100)"
+    },
+    {
+      "name": "esql_range_field_conjunction_small_range_small_term_query",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE aws.cloudwatch.log_stream == \"indigodagger\" OR (metrics.size >= 10 AND metrics.size <= 20)"
+    },
+    {
+      "name": "esql_range_field_conjunction_small_range_big_term_query",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE metrics.size >= 20 AND metrics.size <= 30"
+    },
+
+    {
+      "name": "esql_query_string_on_message",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE QSTR(\"message: monkey jackal bear\")"
+    },
+    {
+      "name": "esql_query_string_on_message_filtered",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-03T00:00:00.000Z\" AND @timestamp < \"2023-01-03T10:00:00.000Z\" AND QSTR(\"message: monkey jackal bear\")"
+    },
+    {
+      "name": "esql_query_string_on_message_filtered_sorted_num",
+      "operation-type": "esql",
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-03T00:00:00.000Z\" AND @timestamp < \"2023-01-03T10:00:00.000Z\" AND QSTR(\"message: monkey jackal bear\") | SORT @timestamp ASC"
+    }

--- a/big5/operations/esql.json
+++ b/big5/operations/esql.json
@@ -1,105 +1,105 @@
     {
       "name": "esql_default",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev"
+      "query": "FROM logs-benchmark-dev | LIMIT 100"
     },
     {
       "name": "esql_term",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE log.file.path == \"/var/log/messages/fuschiashoulder\""
+      "query": "FROM logs-benchmark-dev | WHERE log.file.path == \"/var/log/messages/fuschiashoulder\" | LIMIT 100"
     },
     {
       "name": "esql_range",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-01T00:00:00.000Z\" AND @timestamp < \"2023-01-03T00:00:00.000Z\""
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-01T00:00:00.000Z\" AND @timestamp < \"2023-01-03T00:00:00.000Z\" | LIMIT 100"
     },
     {
       "name": "esql_range_numeric",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE metrics.size >= 20 AND metrics.size <= 200"
+      "query": "FROM logs-benchmark-dev | WHERE metrics.size >= 20 AND metrics.size <= 200 | LIMIT 100"
     },
     {
       "name": "esql_keyword_in_range",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-01T00:00:00.000Z\" AND @timestamp < \"2023-01-03T00:00:00.000Z\" AND process.name == \"kernel\""
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-01T00:00:00.000Z\" AND @timestamp < \"2023-01-03T00:00:00.000Z\" AND process.name == \"kernel\" | LIMIT 100"
     },
 
     {
       "name": "esql_desc_sort_timestamp",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | SORT @timestamp DESC"
+      "query": "FROM logs-benchmark-dev | SORT @timestamp DESC | LIMIT 100"
     },
     {
       "name": "esql_asc_sort_timestamp",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | SORT @timestamp ASC"
+      "query": "FROM logs-benchmark-dev | SORT @timestamp ASC | LIMIT 100"
     },
     {
       "name": "esql_desc_sort_with_after_timestamp",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE @timestamp < \"2023-01-06T23:59:58.000Z\" | SORT @timestamp DESC"
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp < \"2023-01-06T23:59:58.000Z\" | SORT @timestamp DESC | LIMIT 100"
     },
     {
       "name": "esql_asc_sort_with_after_timestamp",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE @timestamp > \"2023-01-01T23:59:58.000Z\" | SORT @timestamp ASC"
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp > \"2023-01-01T23:59:58.000Z\" | SORT @timestamp ASC | LIMIT 100"
     },
     {
       "name": "esql_desc_sort_timestamp_with_match",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE process.name == \"kernel\" | SORT @timestamp DESC"
+      "query": "FROM logs-benchmark-dev | WHERE process.name == \"kernel\" | SORT @timestamp DESC | LIMIT 100"
     },
     {
       "name": "esql_asc_sort_timestamp_with_match",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE process.name == \"kernel\" | SORT @timestamp ASC"
+      "query": "FROM logs-benchmark-dev | WHERE process.name == \"kernel\" | SORT @timestamp ASC | LIMIT 100"
     },
     {
       "name": "esql_sort_keyword_with_match",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE process.name == \"kernel\" | SORT meta.file ASC"
+      "query": "FROM logs-benchmark-dev | WHERE process.name == \"kernel\" | SORT meta.file ASC | LIMIT 100"
     },
     {
       "name": "esql_sort_numeric_desc",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | SORT metrics.size DESC"
+      "query": "FROM logs-benchmark-dev | SORT metrics.size DESC | LIMIT 100"
     },
     {
       "name": "esql_sort_numeric_asc",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | SORT metrics.size ASC"
+      "query": "FROM logs-benchmark-dev | SORT metrics.size ASC | LIMIT 100"
     },
     {
       "name": "esql_sort_numeric_desc_with_match",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE log.file.path == \"/var/log/messages/solarshark\" | SORT metrics.size DESC"
+      "query": "FROM logs-benchmark-dev | WHERE log.file.path == \"/var/log/messages/solarshark\" | SORT metrics.size DESC | LIMIT 100"
     },
     {
       "name": "esql_sort_numeric_asc_with_match",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE log.file.path == \"/var/log/messages/solarshark\" | SORT metrics.size ASC"
+      "query": "FROM logs-benchmark-dev | WHERE log.file.path == \"/var/log/messages/solarshark\" | SORT metrics.size ASC | LIMIT 100"
     },
 
     {
       "name": "esql_date_histogram_hourly_agg",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 hour, @timestamp) | SORT bucket"
+      "query": "FROM logs-benchmark-dev | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 hour, @timestamp) | SORT bucket | LIMIT 100"
     },
     {
       "name": "esql_date_histogram_minute_agg",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-01T00:00:00.000Z\" AND @timestamp < \"2023-01-03T00:00:00.000Z\" | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 minute, @timestamp) | SORT bucket"
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-01T00:00:00.000Z\" AND @timestamp < \"2023-01-03T00:00:00.000Z\" | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 minute, @timestamp) | SORT bucket | LIMIT 100"
     },
 
     {
       "name": "esql_range_auto_date_histo",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | EVAL size_bucket = CASE(metrics.size < -10, \"lt_neg10\", metrics.size >= -10 AND metrics.size < 10, \"neg10_to_10\", metrics.size >= 10 AND metrics.size < 100, \"10_to_100\", metrics.size >= 100 AND metrics.size < 1000, \"100_to_1000\", metrics.size >= 1000 AND metrics.size < 2000, \"1000_to_2000\", \"gte_2000\") | STATS count=COUNT(*) BY size_bucket, date_bucket=BUCKET(@timestamp, 20, \"2023-01-01T00:00:00.000Z\", \"2023-01-08T00:00:00.000Z\") | SORT size_bucket, date_bucket"
+      "query": "FROM logs-benchmark-dev | EVAL size_bucket = CASE(metrics.size < -10, \"lt_neg10\", metrics.size >= -10 AND metrics.size < 10, \"neg10_to_10\", metrics.size >= 10 AND metrics.size < 100, \"10_to_100\", metrics.size >= 100 AND metrics.size < 1000, \"100_to_1000\", metrics.size >= 1000 AND metrics.size < 2000, \"1000_to_2000\", \"gte_2000\") | STATS count=COUNT(*) BY size_bucket, date_bucket=BUCKET(@timestamp, 20, \"2023-01-01T00:00:00.000Z\", \"2023-01-08T00:00:00.000Z\") | SORT size_bucket, date_bucket | LIMIT 100"
     },
     {
       "name": "esql_range_auto_date_histo_with_metrics",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | EVAL size_bucket = CASE(metrics.size < 100, \"lt_100\", metrics.size >= 100 AND metrics.size < 1000, \"100_to_1000\", metrics.size >= 1000 AND metrics.size < 2000, \"1000_to_2000\", \"gte_2000\") | STATS tmin=MIN(metrics.tmin), tavg=AVG(metrics.size), tmax=MAX(metrics.size) BY size_bucket, date_bucket=BUCKET(@timestamp, 10, \"2023-01-01T00:00:00.000Z\", \"2023-01-08T00:00:00.000Z\") | SORT size_bucket, date_bucket"
+      "query": "FROM logs-benchmark-dev | EVAL size_bucket = CASE(metrics.size < 100, \"lt_100\", metrics.size >= 100 AND metrics.size < 1000, \"100_to_1000\", metrics.size >= 1000 AND metrics.size < 2000, \"1000_to_2000\", \"gte_2000\") | STATS tmin=MIN(metrics.tmin), tavg=AVG(metrics.size), tmax=MAX(metrics.size) BY size_bucket, date_bucket=BUCKET(@timestamp, 10, \"2023-01-01T00:00:00.000Z\", \"2023-01-08T00:00:00.000Z\") | SORT size_bucket, date_bucket | LIMIT 100"
     },
 
     {
@@ -120,52 +120,52 @@
     {
       "name": "esql_multi_terms",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-02T00:00:00.000Z\" AND @timestamp < \"2023-01-02T10:00:00.000Z\" | STATS count=COUNT(*) BY process.name, cloud.region | SORT process.name DESC, cloud.region ASC"
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-02T00:00:00.000Z\" AND @timestamp < \"2023-01-02T10:00:00.000Z\" | STATS count=COUNT(*) BY process.name, cloud.region | SORT process.name DESC, cloud.region ASC | LIMIT 100"
     },
     {
       "name": "esql_multi_terms_three_keyword",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-02T00:00:00.000Z\" AND @timestamp < \"2023-01-02T10:00:00.000Z\" | STATS count=COUNT(*) BY process.name, cloud.region, aws.cloudwatch.log_stream | SORT process.name DESC, cloud.region ASC, aws.cloudwatch.log_stream ASC"
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-02T00:00:00.000Z\" AND @timestamp < \"2023-01-02T10:00:00.000Z\" | STATS count=COUNT(*) BY process.name, cloud.region, aws.cloudwatch.log_stream | SORT process.name DESC, cloud.region ASC, aws.cloudwatch.log_stream ASC | LIMIT 100"
     },
     {
       "name": "esql_date_histogram_daily",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2022-12-30T00:00:00.000Z\" AND @timestamp < \"2023-01-07T12:00:00.000Z\" | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 day, @timestamp) | SORT bucket"
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2022-12-30T00:00:00.000Z\" AND @timestamp < \"2023-01-07T12:00:00.000Z\" | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 day, @timestamp) | SORT bucket | LIMIT 100"
     },
 
     {
       "name": "esql_range_field_conjunction_big_range_big_term_query",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE process.name == \"systemd\" AND metrics.size >= 1 AND metrics.size <= 100"
+      "query": "FROM logs-benchmark-dev | WHERE process.name == \"systemd\" AND metrics.size >= 1 AND metrics.size <= 100 | LIMIT 100"
     },
     {
       "name": "esql_range_field_disjunction_big_range_small_term_query",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE aws.cloudwatch.log_stream == \"indigodagger\" OR (metrics.size >= 1 AND metrics.size <= 100)"
+      "query": "FROM logs-benchmark-dev | WHERE aws.cloudwatch.log_stream == \"indigodagger\" OR (metrics.size >= 1 AND metrics.size <= 100) | LIMIT 100"
     },
     {
       "name": "esql_range_field_conjunction_small_range_small_term_query",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE aws.cloudwatch.log_stream == \"indigodagger\" OR (metrics.size >= 10 AND metrics.size <= 20)"
+      "query": "FROM logs-benchmark-dev | WHERE aws.cloudwatch.log_stream == \"indigodagger\" OR (metrics.size >= 10 AND metrics.size <= 20) | LIMIT 100"
     },
     {
       "name": "esql_range_field_conjunction_small_range_big_term_query",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE metrics.size >= 20 AND metrics.size <= 30"
+      "query": "FROM logs-benchmark-dev | WHERE metrics.size >= 20 AND metrics.size <= 30 | LIMIT 100"
     },
 
     {
       "name": "esql_query_string_on_message",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE QSTR(\"message: monkey jackal bear\")"
+      "query": "FROM logs-benchmark-dev | WHERE QSTR(\"message: monkey jackal bear\") | LIMIT 100"
     },
     {
       "name": "esql_query_string_on_message_filtered",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-03T00:00:00.000Z\" AND @timestamp < \"2023-01-03T10:00:00.000Z\" AND QSTR(\"message: monkey jackal bear\")"
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-03T00:00:00.000Z\" AND @timestamp < \"2023-01-03T10:00:00.000Z\" AND QSTR(\"message: monkey jackal bear\") | LIMIT 100"
     },
     {
       "name": "esql_query_string_on_message_filtered_sorted_num",
       "operation-type": "esql",
-      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-03T00:00:00.000Z\" AND @timestamp < \"2023-01-03T10:00:00.000Z\" AND QSTR(\"message: monkey jackal bear\") | SORT @timestamp ASC"
+      "query": "FROM logs-benchmark-dev | WHERE @timestamp >= \"2023-01-03T00:00:00.000Z\" AND @timestamp < \"2023-01-03T10:00:00.000Z\" AND QSTR(\"message: monkey jackal bear\") | SORT @timestamp ASC | LIMIT 100"
     }

--- a/http_logs/challenges/esql-queries.json
+++ b/http_logs/challenges/esql-queries.json
@@ -1,0 +1,170 @@
+    {
+      "name": "esql-queries",
+      "description": "ESQL equivalents of the HTTP logs QueryDSL benchmarks",
+      "schedule": [
+        {
+          "tags": ["setup"],
+          "operation": "delete-index"
+        },
+        {
+          "tags": ["setup"],
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "tags": ["health"],
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "logs-*",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            },
+            "retry-until-success": true
+          }
+        },
+        {
+          "tags": ["index"],
+          "operation": "index-append",
+          "warmup-time-period": 240,
+          "clients": {{bulk_indexing_clients | default(8)}},
+          "ignore-response-error-level": "{{error_level | default('non-fatal')}}"
+        },
+        {
+          "name": "refresh-after-index",
+          "tags": ["index"],
+          "operation": "refresh"
+        },
+        {
+          "tags": ["index"],
+          "operation": {
+            "operation-type": "force-merge",
+            "request-timeout": 7200
+          }
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "tags": ["index"],
+          "operation": "refresh"
+        },
+        {
+          "name": "wait-until-merges-finish",
+          "tags": ["index"],
+          "operation": {
+            "operation-type": "index-stats",
+            "index": "_all",
+            "condition": {
+              "path": "_all.total.merges.current",
+              "expected-value": 0
+            },
+            "retry-until-success": true,
+            "include-in-reporting": false
+          }
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_default",
+          "warmup-iterations": 500,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_term",
+          "warmup-iterations": 500,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_range",
+          "warmup-iterations": 100,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_200s_in_range",
+          "warmup-iterations": 500,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_400s_in_range",
+          "warmup-iterations": 500,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_hourly_agg",
+          "warmup-iterations": 100,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_desc_sort_timestamp",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_asc_sort_timestamp",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_desc_sort_with_after_timestamp",
+          "warmup-iterations": 10,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_asc_sort_with_after_timestamp",
+          "warmup-iterations": 10,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_desc_sort_timestamp_with_match",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_sort_size_desc",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_sort_size_asc",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_sort_status_desc",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_sort_status_asc",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_sort_keyword_with_match",
+          "warmup-iterations": 200,
+          "iterations": 100
+        },
+        {
+          "tags": ["esql"],
+          "operation": "esql_sort_numeric_with_match",
+          "warmup-iterations": 200,
+          "iterations": 100
+        }
+      ]
+    }

--- a/http_logs/operations/esql.json
+++ b/http_logs/operations/esql.json
@@ -1,0 +1,88 @@
+    {
+      "name": "esql_default",
+      "operation-type": "esql",
+      "query": "FROM logs-*"
+    },
+    {
+      "name": "esql_term",
+      "operation-type": "esql",
+      "query": "FROM logs-* | WHERE request.raw == \"GET / HTTP/1.0\""
+    },
+    {
+      "name": "esql_range",
+      "operation-type": "esql",
+      "query": "FROM logs-* | WHERE @timestamp >= \"1998-05-15T00:00:00.000Z\""
+    },
+    {
+      "name": "esql_200s_in_range",
+      "operation-type": "esql",
+      "query": "FROM logs-* | WHERE @timestamp >= \"1998-05-01T00:00:00.000Z\" AND @timestamp < \"1998-05-02T00:00:00.000Z\" AND status == 200"
+    },
+    {
+      "name": "esql_400s_in_range",
+      "operation-type": "esql",
+      "query": "FROM logs-* | WHERE @timestamp >= \"1998-05-01T00:00:00.000Z\" AND @timestamp < \"1998-05-02T00:00:00.000Z\" AND status == 400"
+    },
+
+    {
+      "name": "esql_hourly_agg",
+      "operation-type": "esql",
+      "query": "FROM logs-* | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 hour, @timestamp) | SORT bucket"
+    },
+
+    {
+      "name": "esql_desc_sort_timestamp",
+      "operation-type": "esql",
+      "query": "FROM logs-* | SORT @timestamp DESC"
+    },
+    {
+      "name": "esql_asc_sort_timestamp",
+      "operation-type": "esql",
+      "query": "FROM logs-* | SORT @timestamp ASC"
+    },
+    {
+      "name": "esql_desc_sort_with_after_timestamp",
+      "operation-type": "esql",
+      "query": "FROM logs-* | WHERE @timestamp < \"1998-06-10T00:00:00.000Z\" | SORT @timestamp DESC"
+    },
+    {
+      "name": "esql_asc_sort_with_after_timestamp",
+      "operation-type": "esql",
+      "query": "FROM logs-* | WHERE @timestamp > \"1998-06-10T00:00:00.000Z\" | SORT @timestamp ASC"
+    },
+    {
+      "name": "esql_desc_sort_timestamp_with_match",
+      "operation-type": "esql",
+      "query": "FROM logs-* | WHERE status == 200 | SORT @timestamp DESC"
+    },
+
+    {
+      "name": "esql_sort_size_desc",
+      "operation-type": "esql",
+      "query": "FROM logs-* | SORT size DESC"
+    },
+    {
+      "name": "esql_sort_size_asc",
+      "operation-type": "esql",
+      "query": "FROM logs-* | SORT size ASC"
+    },
+    {
+      "name": "esql_sort_status_desc",
+      "operation-type": "esql",
+      "query": "FROM logs-* | SORT status DESC"
+    },
+    {
+      "name": "esql_sort_status_asc",
+      "operation-type": "esql",
+      "query": "FROM logs-* | SORT status ASC"
+    },
+    {
+      "name": "esql_sort_keyword_with_match",
+      "operation-type": "esql",
+      "query": "FROM logs-* | WHERE status == 200 | SORT geoip.country_name ASC"
+    },
+    {
+      "name": "esql_sort_numeric_with_match",
+      "operation-type": "esql",
+      "query": "FROM logs-* | WHERE status == 200 | SORT size DESC"
+    }

--- a/http_logs/operations/esql.json
+++ b/http_logs/operations/esql.json
@@ -57,6 +57,11 @@
     },
 
     {
+      "name": "esql_asc_sort_timestamp_with_match",
+      "operation-type": "esql",
+      "query": "FROM logs-* | WHERE status == 200 | SORT @timestamp ASC"
+    },
+    {
       "name": "esql_sort_size_desc",
       "operation-type": "esql",
       "query": "FROM logs-* | SORT size DESC"

--- a/http_logs/operations/esql.json
+++ b/http_logs/operations/esql.json
@@ -1,93 +1,93 @@
     {
       "name": "esql_default",
       "operation-type": "esql",
-      "query": "FROM logs-*"
+      "query": "FROM logs-* | LIMIT 100"
     },
     {
       "name": "esql_term",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE request.raw == \"GET / HTTP/1.0\""
+      "query": "FROM logs-* | WHERE request.raw == \"GET / HTTP/1.0\" | LIMIT 100"
     },
     {
       "name": "esql_range",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE @timestamp >= \"1998-05-15T00:00:00.000Z\""
+      "query": "FROM logs-* | WHERE @timestamp >= \"1998-05-15T00:00:00.000Z\" | LIMIT 100"
     },
     {
       "name": "esql_200s_in_range",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE @timestamp >= \"1998-05-01T00:00:00.000Z\" AND @timestamp < \"1998-05-02T00:00:00.000Z\" AND status == 200"
+      "query": "FROM logs-* | WHERE @timestamp >= \"1998-05-01T00:00:00.000Z\" AND @timestamp < \"1998-05-02T00:00:00.000Z\" AND status == 200 | LIMIT 100"
     },
     {
       "name": "esql_400s_in_range",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE @timestamp >= \"1998-05-01T00:00:00.000Z\" AND @timestamp < \"1998-05-02T00:00:00.000Z\" AND status == 400"
+      "query": "FROM logs-* | WHERE @timestamp >= \"1998-05-01T00:00:00.000Z\" AND @timestamp < \"1998-05-02T00:00:00.000Z\" AND status == 400 | LIMIT 100"
     },
 
     {
       "name": "esql_hourly_agg",
       "operation-type": "esql",
-      "query": "FROM logs-* | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 hour, @timestamp) | SORT bucket"
+      "query": "FROM logs-* | STATS count=COUNT(*) BY bucket=DATE_TRUNC(1 hour, @timestamp) | SORT bucket | LIMIT 100"
     },
 
     {
       "name": "esql_desc_sort_timestamp",
       "operation-type": "esql",
-      "query": "FROM logs-* | SORT @timestamp DESC"
+      "query": "FROM logs-* | SORT @timestamp DESC | LIMIT 100"
     },
     {
       "name": "esql_asc_sort_timestamp",
       "operation-type": "esql",
-      "query": "FROM logs-* | SORT @timestamp ASC"
+      "query": "FROM logs-* | SORT @timestamp ASC | LIMIT 100"
     },
     {
       "name": "esql_desc_sort_with_after_timestamp",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE @timestamp < \"1998-06-10T00:00:00.000Z\" | SORT @timestamp DESC"
+      "query": "FROM logs-* | WHERE @timestamp < \"1998-06-10T00:00:00.000Z\" | SORT @timestamp DESC | LIMIT 100"
     },
     {
       "name": "esql_asc_sort_with_after_timestamp",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE @timestamp > \"1998-06-10T00:00:00.000Z\" | SORT @timestamp ASC"
+      "query": "FROM logs-* | WHERE @timestamp > \"1998-06-10T00:00:00.000Z\" | SORT @timestamp ASC | LIMIT 100"
     },
     {
       "name": "esql_desc_sort_timestamp_with_match",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE status == 200 | SORT @timestamp DESC"
+      "query": "FROM logs-* | WHERE status == 200 | SORT @timestamp DESC | LIMIT 100"
     },
 
     {
       "name": "esql_asc_sort_timestamp_with_match",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE status == 200 | SORT @timestamp ASC"
+      "query": "FROM logs-* | WHERE status == 200 | SORT @timestamp ASC | LIMIT 100"
     },
     {
       "name": "esql_sort_size_desc",
       "operation-type": "esql",
-      "query": "FROM logs-* | SORT size DESC"
+      "query": "FROM logs-* | SORT size DESC | LIMIT 100"
     },
     {
       "name": "esql_sort_size_asc",
       "operation-type": "esql",
-      "query": "FROM logs-* | SORT size ASC"
+      "query": "FROM logs-* | SORT size ASC | LIMIT 100"
     },
     {
       "name": "esql_sort_status_desc",
       "operation-type": "esql",
-      "query": "FROM logs-* | SORT status DESC"
+      "query": "FROM logs-* | SORT status DESC | LIMIT 100"
     },
     {
       "name": "esql_sort_status_asc",
       "operation-type": "esql",
-      "query": "FROM logs-* | SORT status ASC"
+      "query": "FROM logs-* | SORT status ASC | LIMIT 100"
     },
     {
       "name": "esql_sort_keyword_with_match",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE status == 200 | SORT geoip.country_name ASC"
+      "query": "FROM logs-* | WHERE status == 200 | SORT geoip.country_name ASC | LIMIT 100"
     },
     {
       "name": "esql_sort_numeric_with_match",
       "operation-type": "esql",
-      "query": "FROM logs-* | WHERE status == 200 | SORT size DESC"
+      "query": "FROM logs-* | WHERE status == 200 | SORT size DESC | LIMIT 100"
     }


### PR DESCRIPTION
Adds ESQL versions of queryDSL queries for the HTTP logs and Big5 tracks.  These are meant to be ESQL-ish versions of the existing challenges, and are named to reflect that.

Resolves https://github.com/elastic/logs-program/issues/67
Resolves https://github.com/elastic/logs-program/issues/66

Assisted by cursor
