### PR TITLE
add an optional force merge option to msmarco-v2-vector

### DIFF
--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -206,16 +206,3 @@ number of segments per shard:
 }
 ```
 
-This is particularly useful for HNSW vector search benchmarks where small segments can
-degrade recall. Each segment builds an independent HNSW graph, and segments with very
-few vectors produce lower-quality graphs. After bulk indexing, the tail end of flushed
-segments may not be merged by the normal merge policy, leaving many small segments.
-Force merging consolidates these into larger segments with better-quality HNSW graphs,
-leading to more consistent recall measurements.
-
-Choose a value based on the total docs per shard and the target segment size. For
-example, with 6 shards over 138M documents (~23M docs/shard), setting
-`force_merge_max_num_segments` to `16` yields segments of roughly 1.4M documents each.
-Setting it to `1` produces a single segment per shard with the best possible recall, at
-the cost of a longer merge.
-

--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -85,6 +85,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - `parallel_indexing_bulk_target_throughput` (default: 1)
  - `parallel_indexing_search_clients` (default: 3)
  - `parallel_indexing_search_target_throughput` (default: 100)
+ - `force_merge_max_num_segments` (default: unset)
  - `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
  - `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
  - `search_ops` (default: [(10, 20, 0), (10, 20, 20), (10, 50, 0), (10, 50, 20), (10, 100, 0), (10, 100, 20), (10, 200, 0), (10, 200, 20), (10, 500, 0), (10, 500, 20), (10, 1000, 0), (10, 1000, 20), (100, 120, 0), (100, 120, 120), (100, 200, 0), (100, 200, 120), (100, 500, 0), (100, 500, 120), (100, 1000, 0), (100, 1000, 120)]): The search and recall operations to run (k, ef_search, num_rescore).
@@ -187,3 +188,34 @@ Use mapping_type = `vectors-with-text` for this track since we perform lexical s
 
 When `as_ingest_target_throughputs` is a positive number, the ingest throughput formula in documents per second is `ingest_bulk_size * as_ingest_target_throughputs`.
 When `as_search_target_throughputs` is a positive number, the search throughput formula in documents per second is `search_size * as_search_target_throughputs`.
+
+### Force merge (optional)
+
+The `force_merge_max_num_segments` parameter enables an optional force merge step in the
+default `index-and-search` challenge. When set, a force merge is triggered after initial
+indexing and natural merge completion, but before any search or recall operations run.
+The step reduces each shard to at most the specified number of segments, then waits for
+all merges to finish before proceeding.
+
+This is disabled by default. To enable it, set the parameter to the desired maximum
+number of segments per shard:
+
+```json
+{
+  "force_merge_max_num_segments": 16
+}
+```
+
+This is particularly useful for HNSW vector search benchmarks where small segments can
+degrade recall. Each segment builds an independent HNSW graph, and segments with very
+few vectors produce lower-quality graphs. After bulk indexing, the tail end of flushed
+segments may not be merged by the normal merge policy, leaving many small segments.
+Force merging consolidates these into larger segments with better-quality HNSW graphs,
+leading to more consistent recall measurements.
+
+Choose a value based on the total docs per shard and the target segment size. For
+example, with 6 shards over 138M documents (~23M docs/shard), setting
+`force_merge_max_num_segments` to `16` yields segments of roughly 1.4M documents each.
+Setting it to `1` produces a single segment per shard with the best possible recall, at
+the cost of a longer merge.
+

--- a/msmarco-v2-vector/challenges/default.json
+++ b/msmarco-v2-vector/challenges/default.json
@@ -53,6 +53,25 @@
       }
     },
     {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
+    {%- if force_merge_max_num_segments is defined %},
+    {
+      "name": "force-merge-after-index",
+      "operation": "force-merge"
+    },
+    {
+      "name": "wait-until-force-merge-completes",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "_all",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": true
+      }
+    }
+    {%- endif %}
     {%- endif -%}{# include-initial-indexing-marker-end #}
     {%- for i in range(p_search_ops|length) %}
     {

--- a/msmarco-v2-vector/challenges/default.json
+++ b/msmarco-v2-vector/challenges/default.json
@@ -53,7 +53,7 @@
       }
     },
     {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
-    {%- if force_merge_max_num_segments is defined %},
+    {%- if force_merge_max_num_segments is defined %}
     {
       "name": "force-merge-after-index",
       "operation": "force-merge"

--- a/msmarco-v2-vector/challenges/default.json
+++ b/msmarco-v2-vector/challenges/default.json
@@ -70,7 +70,7 @@
         "retry-until-success": true,
         "include-in-reporting": true
       }
-    }
+    },
     {%- endif %}
     {%- endif -%}{# include-initial-indexing-marker-end #}
     {%- for i in range(p_search_ops|length) %}

--- a/msmarco-v2-vector/operations/default.json
+++ b/msmarco-v2-vector/operations/default.json
@@ -34,7 +34,6 @@
   "bulk-size": {{parallel_indexing_bulk_size | default(50)}},
   "ingest-percentage": {{parallel_indexing_ingest_percentage | default(100)}}
 }
-{%- if force_merge_max_num_segments is defined %},
 {
   "name": "force-merge",
   "operation-type": "force-merge",
@@ -42,7 +41,6 @@
   "request-timeout": 36000,
   "include-in-reporting": true
 }
-{%- endif %}
 {%- set p_search_ops = (search_ops | default([(10, 20, 0), (10, 20, 1), (10, 50, 0), (10, 50, 2), (10, 100, 0), (10, 100, 2), (10, 200, 0), (10, 200, 2), (10, 500, 0), (10, 500, 2), (10, 1000, 0), (10, 1000, 2), (100, 120, 0), (100, 120, 1), (100, 200, 0), (100, 200, 1), (100, 500, 0), (100, 500, 120), (100, 1000, 0), (100, 1000, 120)]))%}
 {%- for i in range(p_search_ops|length) %},
 {

--- a/msmarco-v2-vector/operations/default.json
+++ b/msmarco-v2-vector/operations/default.json
@@ -33,7 +33,8 @@
   "corpora": {{parallel_corpora | default("msmarco-v2_float-parallel-indexing") | tojson }},
   "bulk-size": {{parallel_indexing_bulk_size | default(50)}},
   "ingest-percentage": {{parallel_indexing_ingest_percentage | default(100)}}
-},
+}
+{%- if force_merge_max_num_segments is defined %},
 {
   "name": "force-merge",
   "operation-type": "force-merge",
@@ -41,6 +42,7 @@
   "request-timeout": 36000,
   "include-in-reporting": true
 }
+{%- endif %}
 {%- set p_search_ops = (search_ops | default([(10, 20, 0), (10, 20, 1), (10, 50, 0), (10, 50, 2), (10, 100, 0), (10, 100, 2), (10, 200, 0), (10, 200, 2), (10, 500, 0), (10, 500, 2), (10, 1000, 0), (10, 1000, 2), (100, 120, 0), (100, 120, 1), (100, 200, 0), (100, 200, 1), (100, 500, 0), (100, 500, 120), (100, 1000, 0), (100, 1000, 120)]))%}
 {%- for i in range(p_search_ops|length) %},
 {

--- a/msmarco-v2-vector/operations/default.json
+++ b/msmarco-v2-vector/operations/default.json
@@ -34,6 +34,15 @@
   "bulk-size": {{parallel_indexing_bulk_size | default(50)}},
   "ingest-percentage": {{parallel_indexing_ingest_percentage | default(100)}}
 }
+{%- if force_merge_max_num_segments is defined %},
+{
+  "name": "force-merge",
+  "operation-type": "force-merge",
+  "max-num-segments": {{ force_merge_max_num_segments }},
+  "request-timeout": 36000,
+  "include-in-reporting": true
+}
+{%- endif %}
 {%- set p_search_ops = (search_ops | default([(10, 20, 0), (10, 20, 1), (10, 50, 0), (10, 50, 2), (10, 100, 0), (10, 100, 2), (10, 200, 0), (10, 200, 2), (10, 500, 0), (10, 500, 2), (10, 1000, 0), (10, 1000, 2), (100, 120, 0), (100, 120, 1), (100, 200, 0), (100, 200, 1), (100, 500, 0), (100, 500, 120), (100, 1000, 0), (100, 1000, 120)]))%}
 {%- for i in range(p_search_ops|length) %},
 {

--- a/msmarco-v2-vector/operations/default.json
+++ b/msmarco-v2-vector/operations/default.json
@@ -33,7 +33,7 @@
   "corpora": {{parallel_corpora | default("msmarco-v2_float-parallel-indexing") | tojson }},
   "bulk-size": {{parallel_indexing_bulk_size | default(50)}},
   "ingest-percentage": {{parallel_indexing_ingest_percentage | default(100)}}
-}
+},
 {
   "name": "force-merge",
   "operation-type": "force-merge",


### PR DESCRIPTION
  After bulk indexing the full corpus, I observed a long tail of small and tiny segments
  remaining across shards even after natural merges completed. The final flushes during
  bulk indexing and the parallel indexing phase create many small segments that the merge
  policy does not always consolidate, because there are not enough segments in the same
  size tier to trigger a merge.

  For HNSW vector search, segment size directly affects recall quality. Each segment
  builds an independent HNSW graph, and segments with very few vectors produce
  lower-quality graphs with limited neighbor connectivity. At search time, each segment's
  graph is queried independently and the results are merged. Small segments contribute
  poor-quality candidates, reducing overall recall.

  This adds an optional `force_merge_max_num_segments` parameter to the `index-and-search`
  challenge. When set, a force merge runs after initial indexing and natural merge
  completion, but before search and recall operations. It consolidates small segments into
  larger ones with better-quality HNSW graphs, leading to more accurate and consistent
  recall measurements. The intent is not to force merge down to a single segment, but
  rather to allow cleaning up the tiny leftover segments post indexing, choosing an
  appropriate value based on your own number of shards, nodes, and target segment size.
  The parameter is disabled by default and no existing behavior is changed.

