### PR TITLE
[9.4] Add subquery benchmark (#1110)

### DIFF
--- a/nyc_taxis/challenges/esql-views.json
+++ b/nyc_taxis/challenges/esql-views.json
@@ -355,6 +355,48 @@
           "clients": 1,
           "warmup-iterations": 10,
           "iterations": 50
+        },
+        {
+          "operation": "two_subqueries_avg_with_sort",
+          "tags": ["subquery", "stats", "sort"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 10
+        },
+        {
+          "operation": "four_subqueries_avg_with_sort",
+          "tags": ["subquery", "stats", "sort"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 10
+        },
+        {
+          "operation": "eight_subqueries_avg_with_sort",
+          "tags": ["subquery", "stats", "sort"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 10
+        },
+        {
+          "operation": "two_subqueries_date_histogram_with_sort",
+          "tags": ["subquery", "stats", "sort"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 10
+        },
+        {
+          "operation": "four_subqueries_date_histogram_with_sort",
+          "tags": ["subquery", "stats", "sort"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 10
+        },
+        {
+          "operation": "eight_subqueries_date_histogram_with_sort",
+          "tags": ["subquery", "stats", "sort"],
+          "clients": 1,
+          "warmup-iterations": 2,
+          "iterations": 10
         }
       ]
     }

--- a/nyc_taxis/operations/esql-views.json
+++ b/nyc_taxis/operations/esql-views.json
@@ -220,4 +220,34 @@
       "name": "esql_view_d3_filtered_sort",
       "operation-type": "esql",
       "query": "FROM nyc_view_d3_filtered | sort pickup_datetime desc | KEEP pickup_datetime, dropoff_datetime, trip_distance | LIMIT 1000"
+    },
+    {
+      "name": "two_subqueries_avg_with_sort",
+      "operation-type": "esql",
+      "query" : "FROM (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count), (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count)"
+    },
+    {
+      "name": "four_subqueries_avg_with_sort",
+      "operation-type": "esql",
+      "query" : "FROM (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count), (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count), (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count), (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count)"
+    },
+    {
+      "name": "eight_subqueries_avg_with_sort",
+      "operation-type": "esql",
+      "query" : "FROM (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count), (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count), (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count), (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count), (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count), (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count), (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count), (FROM nyc_taxis | stats avg(total_amount) by passenger_count | sort passenger_count)"
+    },
+    {
+      "name": "two_subqueries_date_histogram_with_sort",
+      "operation-type": "esql",
+      "query": "FROM (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time), (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time)"
+    },
+    {
+      "name": "four_subqueries_date_histogram_with_sort",
+      "operation-type": "esql",
+      "query": "FROM (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time), (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time), (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time), (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time)"
+    },
+    {
+      "name": "eight_subqueries_date_histogram_with_sort",
+      "operation-type": "esql",
+      "query": "FROM (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time), (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time), (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time), (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time), (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time), (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time), (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time), (FROM nyc_taxis | where dropoff_datetime < \"2016-01-01T00:00:00\" AND dropoff_datetime >= \"2015-01-01T00:00:00\" | eval dropoffs_over_time=date_trunc(1 month, dropoff_datetime) | stats c = count(dropoff_datetime) by dropoffs_over_time | sort dropoffs_over_time)"
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.4`:
 - [Add subquery benchmark (#1110)](https://github.com/elastic/rally-tracks/pull/1110)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Fang Xing","email":"155562079+fang-xing-esql@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-15T13:37:19Z","message":"Add subquery benchmark (#1110)\n\n* add subquery benchmark into esql-views challenge","sha":"91120b123f6f30d02cea9a7d8e55af3982f21ff4","branchLabelMapping":{"^v9.5$":"master","^vServerless$":"master","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["new workload","v9.4","v9.5"],"title":"Add subquery benchmark","number":1110,"url":"https://github.com/elastic/rally-tracks/pull/1110","mergeCommit":{"message":"Add subquery benchmark (#1110)\n\n* add subquery benchmark into esql-views challenge","sha":"91120b123f6f30d02cea9a7d8e55af3982f21ff4"}},"sourceBranch":"master","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"master","label":"v9.5","branchLabelMappingKey":"^v9.5$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/rally-tracks/pull/1110","number":1110,"mergeCommit":{"message":"Add subquery benchmark (#1110)\n\n* add subquery benchmark into esql-views challenge","sha":"91120b123f6f30d02cea9a7d8e55af3982f21ff4"}}]}] BACKPORT-->