### PR TITLE
Add HNSW and merge scheduler params to msmarco-v2-vector

### DIFF
--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -67,7 +67,10 @@ $ python _tools/parse_queries.py -r
 This track accepts the following parameters with Rally 0.8.0+ using `--track-params`:
  - `base_url` (default: `https://rally-tracks.elastic.co/cohere-msmarco-v2-embed-english-v3`): Specifies the bucket path from where to download the data set.
  - `vector_index_type` (default: bbq_hnsw)
+ - `hnsw_m` (default: unset): The number of neighbors each node will be connected to in the HNSW graph.
+ - `hnsw_ef_construction` (default: unset): The number of candidates to track while assembling the HNSW graph.
  - `aggressive_merge_policy` (default: false): Whether to apply a more aggressive merge strategy.
+ - `index_merge_scheduler_auto_throttle` (default: true): Whether to enable auto-throttling for the merge scheduler. Matches the Elasticsearch default; set to `false` to disable.
  - `index_refresh_interval` (default: unset): The index refresh interval.
  - `corpora` (default: ["msmarco-v2_float-initial-indexing-1", ..., "msmarco-v2_float-initial-indexing-8"])
  - `initial_indexing_bulk_indexing_clients` (default: 5)

--- a/msmarco-v2-vector/index-vectors-only-mapping.json
+++ b/msmarco-v2-vector/index-vectors-only-mapping.json
@@ -16,7 +16,8 @@
       {% if p_include_non_serverless_index_settings %}
       {{comma()}}
       "number_of_shards": {{number_of_shards | default(1)}},
-      "number_of_replicas": {{number_of_replicas | default(0)}}
+      "number_of_replicas": {{number_of_replicas | default(0)}},
+      "merge.scheduler.auto_throttle": {{ index_merge_scheduler_auto_throttle | default(true) | tojson }}
       {% endif %}
       {% if enable_experimental_features | default(false) %}
       {{comma()}}
@@ -49,6 +50,12 @@
         "similarity": "dot_product",
         "index_options": {
           "type": {{ vector_index_type | default("bbq_hnsw") | tojson }}
+          {%- if hnsw_m is defined %},
+          "m": {{ hnsw_m }}
+          {%- endif %}
+          {%- if hnsw_ef_construction is defined %},
+          "ef_construction": {{ hnsw_ef_construction }}
+          {%- endif %}
         }
       }
     }

--- a/msmarco-v2-vector/index-vectors-with-text-mapping.json
+++ b/msmarco-v2-vector/index-vectors-with-text-mapping.json
@@ -12,7 +12,8 @@
     {% if p_include_non_serverless_index_settings %}
     {{comma()}}
     "index.number_of_shards": {{number_of_shards | default(1)}},
-    "index.number_of_replicas": {{number_of_replicas | default(0)}}
+    "index.number_of_replicas": {{number_of_replicas | default(0)}},
+    "index.merge.scheduler.auto_throttle": {{ index_merge_scheduler_auto_throttle | default(true) | tojson }}
     {% endif %}
     {% if enable_experimental_features | default(false) %}
     {{comma()}}
@@ -40,6 +41,12 @@
         "similarity": "dot_product",
         "index_options": {
           "type": {{ vector_index_type | default("int8_hnsw") |tojson }}
+          {%- if hnsw_m is defined %},
+          "m": {{ hnsw_m }}
+          {%- endif %}
+          {%- if hnsw_ef_construction is defined %},
+          "ef_construction": {{ hnsw_ef_construction }}
+          {%- endif %}
         }
       }
     }


### PR DESCRIPTION
- hnsw_m and hnsw_ef_construction: optional HNSW graph tuning
- index_merge_scheduler_auto_throttle: toggle auto-throttle, defaults to true to match the Elasticsearch default