### PR TITLE
[9.4] add an optional force merge option to msmarco-v2-vector (#1120)

### DIFF
--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -85,6 +85,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - `parallel_indexing_bulk_target_throughput` (default: 1)
  - `parallel_indexing_search_clients` (default: 3)
  - `parallel_indexing_search_target_throughput` (default: 100)
+ - `force_merge_max_num_segments` (default: unset)
  - `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.
  - `post_ingest_sleep_duration` (default: 30): Sleep duration in seconds.
  - `search_ops` (default: [(10, 20, 0), (10, 20, 20), (10, 50, 0), (10, 50, 20), (10, 100, 0), (10, 100, 20), (10, 200, 0), (10, 200, 20), (10, 500, 0), (10, 500, 20), (10, 1000, 0), (10, 1000, 20), (100, 120, 0), (100, 120, 120), (100, 200, 0), (100, 200, 120), (100, 500, 0), (100, 500, 120), (100, 1000, 0), (100, 1000, 120)]): The search and recall operations to run (k, ef_search, num_rescore).
@@ -187,3 +188,21 @@ Use mapping_type = `vectors-with-text` for this track since we perform lexical s
 
 When `as_ingest_target_throughputs` is a positive number, the ingest throughput formula in documents per second is `ingest_bulk_size * as_ingest_target_throughputs`.
 When `as_search_target_throughputs` is a positive number, the search throughput formula in documents per second is `search_size * as_search_target_throughputs`.
+
+### Force merge (optional)
+
+The `force_merge_max_num_segments` parameter enables an optional force merge step in the
+default `index-and-search` challenge. When set, a force merge is triggered after initial
+indexing and natural merge completion, but before any search or recall operations run.
+The step reduces each shard to at most the specified number of segments, then waits for
+all merges to finish before proceeding.
+
+This is disabled by default. To enable it, set the parameter to the desired maximum
+number of segments per shard:
+
+```json
+{
+  "force_merge_max_num_segments": 16
+}
+```
+

--- a/msmarco-v2-vector/challenges/default.json
+++ b/msmarco-v2-vector/challenges/default.json
@@ -53,6 +53,25 @@
       }
     },
     {%- endif -%}{# serverless-post-ingest-sleep-marker-end #}
+    {%- if force_merge_max_num_segments is defined %}
+    {
+      "name": "force-merge-after-index",
+      "operation": "force-merge"
+    },
+    {
+      "name": "wait-until-force-merge-completes",
+      "operation": {
+        "operation-type": "index-stats",
+        "index": "_all",
+        "condition": {
+          "path": "_all.total.merges.current",
+          "expected-value": 0
+        },
+        "retry-until-success": true,
+        "include-in-reporting": true
+      }
+    },
+    {%- endif %}
     {%- endif -%}{# include-initial-indexing-marker-end #}
     {%- for i in range(p_search_ops|length) %}
     {

--- a/msmarco-v2-vector/operations/default.json
+++ b/msmarco-v2-vector/operations/default.json
@@ -34,6 +34,15 @@
   "bulk-size": {{parallel_indexing_bulk_size | default(50)}},
   "ingest-percentage": {{parallel_indexing_ingest_percentage | default(100)}}
 }
+{%- if force_merge_max_num_segments is defined %},
+{
+  "name": "force-merge",
+  "operation-type": "force-merge",
+  "max-num-segments": {{ force_merge_max_num_segments }},
+  "request-timeout": 36000,
+  "include-in-reporting": true
+}
+{%- endif %}
 {%- set p_search_ops = (search_ops | default([(10, 20, 0), (10, 20, 1), (10, 50, 0), (10, 50, 2), (10, 100, 0), (10, 100, 2), (10, 200, 0), (10, 200, 2), (10, 500, 0), (10, 500, 2), (10, 1000, 0), (10, 1000, 2), (100, 120, 0), (100, 120, 1), (100, 200, 0), (100, 200, 1), (100, 500, 0), (100, 500, 120), (100, 1000, 0), (100, 1000, 120)]))%}
 {%- for i in range(p_search_ops|length) %},
 {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.4`:
 - [add an optional force merge option to msmarco-v2-vector (#1120)](https://github.com/elastic/rally-tracks/pull/1120)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Chris Hegarty","email":"62058229+ChrisHegarty@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-16T12:54:09Z","message":"add an optional force merge option to msmarco-v2-vector (#1120)\n\nAfter bulk indexing the full corpus, I observed a long tail of small and tiny segments\nremaining across shards even after natural merges completed. The final flushes during\nbulk indexing and the parallel indexing phase create many small segments that the merge\npolicy does not always consolidate, because there are not enough segments in the same\nsize tier to trigger a merge.\n\nFor HNSW vector search, segment size directly affects recall quality. Each segment\nbuilds an independent HNSW graph, and segments with very few vectors produce\nlower-quality graphs with limited neighbor connectivity. At search time, each segment's\ngraph is queried independently and the results are merged. Small segments contribute\npoor-quality candidates, reducing overall recall.\n\nThis adds an optional force_merge_max_num_segments parameter to the index-and-search\nchallenge. When set, a force merge runs after initial indexing and natural merge\ncompletion, but before search and recall operations. It consolidates small segments into\nlarger ones with better-quality HNSW graphs, leading to more accurate and consistent\nrecall measurements. The intent is not to force merge down to a single segment, but\nrather to allow cleaning up the tiny leftover segments post indexing, choosing an\nappropriate value based on your own number of shards, nodes, and target segment size.\nThe parameter is disabled by default and no existing behavior is changed.","sha":"aba7f1df45a06533092666807be88f79261433d5","branchLabelMapping":{"^v9.5$":"master","^vServerless$":"master","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["backport pending","v9.4","v9.5"],"title":"add an optional force merge option to msmarco-v2-vector","number":1120,"url":"https://github.com/elastic/rally-tracks/pull/1120","mergeCommit":{"message":"add an optional force merge option to msmarco-v2-vector (#1120)\n\nAfter bulk indexing the full corpus, I observed a long tail of small and tiny segments\nremaining across shards even after natural merges completed. The final flushes during\nbulk indexing and the parallel indexing phase create many small segments that the merge\npolicy does not always consolidate, because there are not enough segments in the same\nsize tier to trigger a merge.\n\nFor HNSW vector search, segment size directly affects recall quality. Each segment\nbuilds an independent HNSW graph, and segments with very few vectors produce\nlower-quality graphs with limited neighbor connectivity. At search time, each segment's\ngraph is queried independently and the results are merged. Small segments contribute\npoor-quality candidates, reducing overall recall.\n\nThis adds an optional force_merge_max_num_segments parameter to the index-and-search\nchallenge. When set, a force merge runs after initial indexing and natural merge\ncompletion, but before search and recall operations. It consolidates small segments into\nlarger ones with better-quality HNSW graphs, leading to more accurate and consistent\nrecall measurements. The intent is not to force merge down to a single segment, but\nrather to allow cleaning up the tiny leftover segments post indexing, choosing an\nappropriate value based on your own number of shards, nodes, and target segment size.\nThe parameter is disabled by default and no existing behavior is changed.","sha":"aba7f1df45a06533092666807be88f79261433d5"}},"sourceBranch":"master","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"master","label":"v9.5","branchLabelMappingKey":"^v9.5$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/rally-tracks/pull/1120","number":1120,"mergeCommit":{"message":"add an optional force merge option to msmarco-v2-vector (#1120)\n\nAfter bulk indexing the full corpus, I observed a long tail of small and tiny segments\nremaining across shards even after natural merges completed. The final flushes during\nbulk indexing and the parallel indexing phase create many small segments that the merge\npolicy does not always consolidate, because there are not enough segments in the same\nsize tier to trigger a merge.\n\nFor HNSW vector search, segment size directly affects recall quality. Each segment\nbuilds an independent HNSW graph, and segments with very few vectors produce\nlower-quality graphs with limited neighbor connectivity. At search time, each segment's\ngraph is queried independently and the results are merged. Small segments contribute\npoor-quality candidates, reducing overall recall.\n\nThis adds an optional force_merge_max_num_segments parameter to the index-and-search\nchallenge. When set, a force merge runs after initial indexing and natural merge\ncompletion, but before search and recall operations. It consolidates small segments into\nlarger ones with better-quality HNSW graphs, leading to more accurate and consistent\nrecall measurements. The intent is not to force merge down to a single segment, but\nrather to allow cleaning up the tiny leftover segments post indexing, choosing an\nappropriate value based on your own number of shards, nodes, and target segment size.\nThe parameter is disabled by default and no existing behavior is changed.","sha":"aba7f1df45a06533092666807be88f79261433d5"}}]}] BACKPORT-->