### PR TITLE
Fix ES|QL joins track to work on Serverless

### DIFF
--- a/joins/README.md
+++ b/joins/README.md
@@ -46,7 +46,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `index_settings`: A list of index settings. Index settings defined elsewhere need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
 * `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
-* `auto_expand_replicas` (default: "0-all"): Set the auto_expand_replicas behaviour for lookup indices.
+* `auto_expand_replicas` (default: "0-all"): Set the auto_expand_replicas behaviour for lookup indices. Only applied on non-serverless clusters (or serverless operator), as the setting is not allowed on Serverless.
 * `query_clients` (default 1): number of queries to be run in parallel
 
 

--- a/joins/index-lookup_idx_100000000_f10.json
+++ b/joins/index-lookup_idx_100000000_f10.json
@@ -2,9 +2,11 @@
 
 {
   "settings": {
-        "index.mode": "lookup",
-        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+        "index.mode": "lookup"
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
+    , "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+      {% endif %}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/joins/index-lookup_idx_1000000_f10.json
+++ b/joins/index-lookup_idx_1000000_f10.json
@@ -2,9 +2,11 @@
 
 {
   "settings": {
-        "index.mode": "lookup",
-        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+        "index.mode": "lookup"
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
+    , "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+      {% endif %}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/joins/index-lookup_idx_100000_f10.json
+++ b/joins/index-lookup_idx_100000_f10.json
@@ -2,9 +2,11 @@
 
 {
   "settings": {
-        "index.mode": "lookup",
-        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+        "index.mode": "lookup"
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
+    , "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+      {% endif %}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/joins/index-lookup_idx_100000_f10_x10.json
+++ b/joins/index-lookup_idx_100000_f10_x10.json
@@ -2,9 +2,11 @@
 
 {
   "settings": {
-        "index.mode": "lookup",
-        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+        "index.mode": "lookup"
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
+    , "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+      {% endif %}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/joins/index-lookup_idx_1000_100000_200000_f10.json
+++ b/joins/index-lookup_idx_1000_100000_200000_f10.json
@@ -2,9 +2,11 @@
 
 {
   "settings": {
-        "index.mode": "lookup",
-        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+        "index.mode": "lookup"
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
+    , "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+      {% endif %}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/joins/index-lookup_idx_1000_f10.json
+++ b/joins/index-lookup_idx_1000_f10.json
@@ -2,9 +2,11 @@
 
 {
   "settings": {
-        "index.mode": "lookup",
-        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+        "index.mode": "lookup"
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
+    , "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+      {% endif %}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/joins/index-lookup_idx_1_f2_x10000.json
+++ b/joins/index-lookup_idx_1_f2_x10000.json
@@ -2,9 +2,11 @@
 
 {
   "settings": {
-        "index.mode": "lookup",
-        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+        "index.mode": "lookup"
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
+    , "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+      {% endif %}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/joins/index-lookup_idx_200000_f10.json
+++ b/joins/index-lookup_idx_200000_f10.json
@@ -2,9 +2,11 @@
 
 {
   "settings": {
-        "index.mode": "lookup",
-        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+        "index.mode": "lookup"
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
+    , "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+      {% endif %}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/joins/index-lookup_idx_5000000_f10.json
+++ b/joins/index-lookup_idx_5000000_f10.json
@@ -2,9 +2,11 @@
 
 {
   "settings": {
-        "index.mode": "lookup",
-        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+        "index.mode": "lookup"
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
+    , "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+      {% endif %}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },

--- a/joins/index-lookup_idx_500000_f10.json
+++ b/joins/index-lookup_idx_500000_f10.json
@@ -2,9 +2,11 @@
 
 {
   "settings": {
-        "index.mode": "lookup",
-        "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+        "index.mode": "lookup"
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {% if p_include_non_serverless_index_settings %}
+    , "auto_expand_replicas": {{ auto_expand_replicas | default("0-all") | tojson }}
+      {% endif %}
     , "index.requests.cache.enable": false
     {%- endif -%}{# non-serverless-index-settings-marker-end #}
   },


### PR DESCRIPTION
`auto_expand_replicas` is not allowed in Serverless, so we'll make it optional