### PR TITLE
[msmarco-v2-vector] Use random query vectors by default in KnnParamSource

### DIFF
--- a/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
@@ -70,6 +70,8 @@
         "operation": {
           "operation-type": "search",
           "param-source": "knn-param-source",
+          "random-query": true,
+          "dims": 1024,
           "k": 10,
           "num-candidates": 100,
           {%- if p_vector_index_type == "bbq_hnsw" %}
@@ -87,6 +89,8 @@
         "operation": {
           "operation-type": "search",
           "param-source": "knn-param-source",
+          "random-query": true,
+          "dims": 1024,
           "k": 10,
           "num-candidates": 100,
           {%- if p_vector_index_type == "bbq_hnsw" %}

--- a/msmarco-v2-vector/challenges/common/search-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/search-autoscale-schedule.json
@@ -48,6 +48,8 @@
   "operation": {
     "operation-type": "search",
     "param-source": "knn-param-source",
+    "random-query": true,
+    "dims": 1024,
     "k": 10,
     "num-candidates": 100,
     {%- if p_vector_index_type == "bbq_hnsw" %}
@@ -67,6 +69,8 @@
   "operation": {
     "operation-type": "search",
     "param-source": "knn-param-source",
+    "random-query": true,
+    "dims": 1024,
     "k": 100,
     "num-candidates": 500,
     {%- if p_vector_index_type == "bbq_hnsw" %}
@@ -87,6 +91,8 @@
   "operation": {
     "operation-type": "search",
     "param-source": "knn-param-source",
+    "random-query": true,
+    "dims": 1024,
     "k": 10,
     "num-candidates": 100,
     {%- if p_vector_index_type == "bbq_hnsw" %}
@@ -107,6 +113,8 @@
   "operation": {
     "operation-type": "search",
     "param-source": "knn-param-source",
+    "random-query": true,
+    "dims": 1024,
     "k": 100,
     "num-candidates": 500,
     {%- if p_vector_index_type == "bbq_hnsw" %}

--- a/msmarco-v2-vector/operations/default.json
+++ b/msmarco-v2-vector/operations/default.json
@@ -55,6 +55,8 @@
   {%- endif -%},
   "operation-type": "search",
   "param-source": "knn-param-source",
+  "random-query": true,
+  "dims": 1024,
   "k": {{p_search_ops[i][0]}},
   "num-candidates": {{p_search_ops[i][1]}},
   {%- if p_search_ops[i]|length > 3 -%}
@@ -150,10 +152,10 @@
 }
 {%- endfor -%},
 {
-"name": "esql-profile-hybrid-search-bm25-knn",
-"operation-type": "esql-profile",
-"param-source": "esql-hybrid-bm25-knn-param-source",
-"size": 100,
-"k": 100,
-"num-candidates": 200
+  "name": "esql-profile-hybrid-search-bm25-knn",
+  "operation-type": "esql-profile",
+  "param-source": "esql-hybrid-bm25-knn-param-source",
+  "size": 100,
+  "k": 100,
+  "num-candidates": 200
 }

--- a/msmarco-v2-vector/track.py
+++ b/msmarco-v2-vector/track.py
@@ -2,12 +2,12 @@ import bz2
 import csv
 import json
 import logging
-import numpy as np
 import os
 import statistics
 from collections import defaultdict
 from typing import Any, Dict, List
 
+import numpy as np
 from esrally.driver import runner
 
 logger = logging.getLogger(__name__)

--- a/msmarco-v2-vector/track.py
+++ b/msmarco-v2-vector/track.py
@@ -2,6 +2,7 @@ import bz2
 import csv
 import json
 import logging
+import numpy as np
 import os
 import statistics
 from collections import defaultdict
@@ -87,14 +88,29 @@ class KnnParamSource:
         self._cache = params.get("cache", False)
         self._params = params
         self._queries = []
+        self._random_query = params.get("random-query", False)
+        self._dims = params.get("dims")
 
-        cwd = os.path.dirname(__file__)
-        with bz2.open(os.path.join(cwd, QUERIES_FILENAME), "r") as queries_file:
-            for vector_query in queries_file:
-                self._queries.append(json.loads(vector_query))
+        if self._random_query:
+            if self._dims is None:
+                raise ValueError("'dims' parameter is required when 'random-vector-query' is enabled")
+            if not isinstance(self._dims, int) or self._dims <= 0:
+                raise ValueError(f"'dims' must be a positive integer, got [{self._dims}]")
+            self._maxIters = 1
+        else:
+            cwd = os.path.dirname(__file__)
+            with bz2.open(os.path.join(cwd, QUERIES_FILENAME), "r") as queries_file:
+                for vector_query in queries_file:
+                    self._queries.append(json.loads(vector_query))
+            self._maxIters = len(self._queries)
+
         self._iters = 0
-        self._maxIters = len(self._queries)
         self.infinite = True
+
+    def _random_normalized_vector(self, dims):
+        v = np.random.normal(size=dims)
+        v /= np.linalg.norm(v)
+        return v.tolist()
 
     def partition(self, partition_index, total_partitions):
         return self
@@ -103,15 +119,23 @@ class KnnParamSource:
         top_k = self._params.get("k", 10)
         visit_percentage = self._params.get("visit-percentage")
         num_candidates = self._params.get("num-candidates", 50)
-        query_vec = self._queries[self._iters]
+
+        if self._random_query:
+            query_vec = self._random_normalized_vector(self._dims)
+        else:
+            query_vec = self._queries[self._iters]
+
         if visit_percentage is None:
             knn_query = {"field": "emb", "query_vector": query_vec, "k": top_k, "num_candidates": num_candidates}
         else:
             knn_query = {"field": "emb", "query_vector": query_vec, "k": top_k, "visit_percentage": visit_percentage}
+
         if self._params.get("oversample-rescore", -1) >= 0:
             knn_query["rescore_vector"] = {"oversample": self._params.get("oversample-rescore")}
+
         if "filter" in self._params:
             knn_query["filter"] = self._params["filter"]
+
         result = {
             "index": self._index_name,
             "cache": self._params.get("cache", False),

--- a/msmarco-v2-vector/track.py
+++ b/msmarco-v2-vector/track.py
@@ -7,7 +7,6 @@ import statistics
 from collections import defaultdict
 from typing import Any, Dict, List
 
-import numpy as np
 from esrally.driver import runner
 
 logger = logging.getLogger(__name__)
@@ -108,6 +107,8 @@ class KnnParamSource:
         self.infinite = True
 
     def _random_normalized_vector(self, dims):
+        import numpy as np
+
         v = np.random.normal(size=dims)
         v /= np.linalg.norm(v)
         return v.tolist()


### PR DESCRIPTION
Switch KnnParamSource to generate random normalized query vectors by default, replacing the use of static recorded queries.
Random queries improve coverage of the vector space and better stress the index, avoiding bias from repeatedly querying the same regions.
Static queries can still be used by disabling `random-query`.