### PR TITLE
Add optional project_routing to ES|QL queries in JOINS track

### DIFF
--- a/joins/README.md
+++ b/joins/README.md
@@ -48,6 +48,7 @@ This track allows to overwrite the following parameters using `--track-params`:
 * `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
 * `auto_expand_replicas` (default: "0-all"): Set the auto_expand_replicas behaviour for lookup indices. Only applied on non-serverless clusters (or serverless operator), as the setting is not allowed on Serverless.
 * `query_clients` (default 1): number of queries to be run in parallel
+* `project_routing` (optional): a full ES|QL project routing expression (Lucene syntax). When set, `SET project_routing="<expr>";` is prepended to every ES|QL query. When unset (default), queries run unchanged. Examples: `_alias:my-project`, `_alias:p1,p2`, `_alias:_origin`, `_alias:*`.
 
 
 ### License

--- a/joins/operations/default.json
+++ b/joins/operations/default.json
@@ -1,3 +1,5 @@
+{# If `project_routing` track-param is set, prepend `SET project_routing="<expr>";` to every ES|QL query. Value is a full Lucene-style expression, e.g. "_alias:my-project" or "_alias:p1,p2". #}
+{% set routing_prefix = ('SET project_routing=\\"' ~ project_routing ~ '\\"; ') if project_routing is defined and project_routing else '' %}
     {
       "name": "index-base",
       "operation-type": "bulk",
@@ -79,91 +81,91 @@
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit1",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1000",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_limit10000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 10000",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 10000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_keep_limit10000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | keep @timestamp, lookup_keyword_0 | limit 10000",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | keep @timestamp, lookup_keyword_0 | limit 10000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_sort_limit10000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | sort lookup_keyword_0 asc | limit 10000",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | sort lookup_keyword_0 asc | limit 10000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val 1*\" | limit 1000",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val 1*\" | limit 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_few_matching_like_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val 249*\" | limit 1000",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val 249*\" | limit 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_expression_eq_{{idx_suffix[i]}}_keys_where_few_matching_like_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | RENAME key_{{key_suffix[i]}} as left_key_{{key_suffix[i]}} | LOOKUP JOIN lookup_idx_{{key_suffix[i]}}_f10 on left_key_{{key_suffix[i]}}==key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val 249*\" | limit 1000",
+      "query": "{{routing_prefix}}FROM join_base_idx | RENAME key_{{key_suffix[i]}} as left_key_{{key_suffix[i]}} | LOOKUP JOIN lookup_idx_{{key_suffix[i]}}_f10 on left_key_{{key_suffix[i]}}==key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val 249*\" | limit 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_expression_lte_gte_{{idx_suffix[i]}}_keys_where_all_matching_like_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | RENAME key_{{key_suffix[i]}} as left_key_{{key_suffix[i]}} | EVAL left_key2_{{key_suffix[i]}} = left_key_{{key_suffix[i]}}| LOOKUP JOIN lookup_idx_{{key_suffix[i]}}_f10 on left_key_{{key_suffix[i]}}>=key_{{key_suffix[i]}} AND left_key2_{{key_suffix[i]}}<=key_{{key_suffix[i]}}| where lookup_keyword_0 like \"val *\" | limit 1000",
+      "query": "{{routing_prefix}}FROM join_base_idx | RENAME key_{{key_suffix[i]}} as left_key_{{key_suffix[i]}} | EVAL left_key2_{{key_suffix[i]}} = left_key_{{key_suffix[i]}}| LOOKUP JOIN lookup_idx_{{key_suffix[i]}}_f10 on left_key_{{key_suffix[i]}}>=key_{{key_suffix[i]}} AND left_key2_{{key_suffix[i]}}<=key_{{key_suffix[i]}}| where lookup_keyword_0 like \"val *\" | limit 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_few_matching_concat_like_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where concat(\"x\", lookup_keyword_0) like \"xval 249*\" | limit 1000",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where concat(\"x\", lookup_keyword_0) like \"xval 249*\" | limit 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_all_matching_like_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val *\" | limit 1000",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 like \"val *\" | limit 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_all_matching_concat_like_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where concat(\"x\", lookup_keyword_0) like \"xval *\" | limit 1000",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where concat(\"x\", lookup_keyword_0) like \"xval *\" | limit 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_no_match",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where concat(lookup_keyword_0, \"foo\") == \"bar\"",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where concat(lookup_keyword_0, \"foo\") == \"bar\"",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_not_matching_equals",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 == \"non existing\"",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 == \"non existing\"",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_keys_where_one_matching_equals",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 == \"val 10 rep 0\"",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | where lookup_keyword_0 == \"val 10 rep 0\"",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
 
@@ -171,13 +173,13 @@
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_two_keys",
       "operation-type": "esql",
-      "query": "from join_base_idx | eval lookup_keyword_0.keyword = concat(\"val \", key_{{key_suffix[i]}}::keyword, \" rep 0\") | keep key_{{key_suffix[i]}}, lookup_keyword_0.keyword, @timestamp | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}}, lookup_keyword_0.keyword",
+      "query": "{{routing_prefix}}from join_base_idx | eval lookup_keyword_0.keyword = concat(\"val \", key_{{key_suffix[i]}}::keyword, \" rep 0\") | keep key_{{key_suffix[i]}}, lookup_keyword_0.keyword, @timestamp | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}}, lookup_keyword_0.keyword",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_{{idx_suffix[i]}}_two_keys_where_one_matching_equals",
       "operation-type": "esql",
-      "query": "from join_base_idx | eval lookup_keyword_0.keyword = concat(\"val \", key_{{key_suffix[i]}}::keyword, \" rep 0\") | keep key_{{key_suffix[i]}}, lookup_keyword_0.keyword, @timestamp | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}}, lookup_keyword_0.keyword | where lookup_keyword_0 == \"val 10 rep 0\"",
+      "query": "{{routing_prefix}}from join_base_idx | eval lookup_keyword_0.keyword = concat(\"val \", key_{{key_suffix[i]}}::keyword, \" rep 0\") | keep key_{{key_suffix[i]}}, lookup_keyword_0.keyword, @timestamp | lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}}, lookup_keyword_0.keyword | where lookup_keyword_0 == \"val 10 rep 0\"",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
 
@@ -188,7 +190,7 @@
     {
       "name": "esql_lookup_join_100k_to_{{idx_suffix[i]}}",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | rename key_100000 as key_{{key_suffix[i]}}| lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1000",
+      "query": "{{routing_prefix}}FROM join_base_idx | rename key_100000 as key_{{key_suffix[i]}}| lookup join lookup_idx_{{key_suffix[i]}}_f10 on key_{{key_suffix[i]}} | limit 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
 {% endfor %}
@@ -196,118 +198,118 @@
     {
       "name": "esql_lookup_join_100k_keys_x10_limit1000",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_100000_f10_x10 on key_100000 | limit 1000",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_100000_f10_x10 on key_100000 | limit 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_1k_100k_200k_500k",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | lookup join lookup_idx_1000_f10 on key_1000 | rename lookup_keyword_0 as lk_1k | lookup join lookup_idx_100000_f10 on key_100000 | rename lookup_keyword_0 as lk_100k | lookup join lookup_idx_200000_f10 on key_200000 | rename lookup_keyword_0 as lk_200k | lookup join lookup_idx_500000_f10 on key_500000 | rename lookup_keyword_0 as lk_500k | keep id, key_1000, key_100000, key_200000, key_500000, lk_1k, lk_100k, lk_200k, lk_500k | limit 1000",
+      "query": "{{routing_prefix}}FROM join_base_idx | lookup join lookup_idx_1000_f10 on key_1000 | rename lookup_keyword_0 as lk_1k | lookup join lookup_idx_100000_f10 on key_100000 | rename lookup_keyword_0 as lk_100k | lookup join lookup_idx_200000_f10 on key_200000 | rename lookup_keyword_0 as lk_200k | lookup join lookup_idx_500000_f10 on key_500000 | rename lookup_keyword_0 as lk_500k | keep id, key_1000, key_100000, key_200000, key_500000, lk_1k, lk_100k, lk_200k, lk_500k | limit 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
 
     {
       "name": "esql_lookup_join_limit10_expanding10000_filter1",
       "operation-type": "esql",
-      "query": "from join_base_idx | limit 10 | eval key_1 = \"0\" | keep key_1, @timestamp | lookup join lookup_idx_1_f2_x10000 on key_1 | where lookup_int_0 == 8599",
+      "query": "{{routing_prefix}}from join_base_idx | limit 10 | eval key_1 = \"0\" | keep key_1, @timestamp | lookup join lookup_idx_1_f2_x10000 on key_1 | where lookup_int_0 == 8599",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_limit50_expanding10000_filter1",
       "operation-type": "esql",
-      "query": "from join_base_idx | limit 50 | eval key_1 = \"0\" | keep key_1, @timestamp | lookup join lookup_idx_1_f2_x10000 on key_1 | where lookup_int_0 == 8599",
+      "query": "{{routing_prefix}}from join_base_idx | limit 50 | eval key_1 = \"0\" | keep key_1, @timestamp | lookup join lookup_idx_1_f2_x10000 on key_1 | where lookup_int_0 == 8599",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
 
     {
       "name": "esql_lookup_join_expanding10000_filter10",
       "operation-type": "esql",
-      "query": "FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword | LIMIT 30000 | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1 | WHERE lookup_int_0 < 10 | stats c= count(*) | LIMIT 1",
+      "query": "{{routing_prefix}}FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword | LIMIT 30000 | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1 | WHERE lookup_int_0 < 10 | stats c= count(*) | LIMIT 1",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_expanding10000_filter100",
       "operation-type": "esql",
-      "query": "FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword | LIMIT 30000 | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1 | WHERE lookup_int_0 < 100 | stats c= count(*) | LIMIT 1",
+      "query": "{{routing_prefix}}FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword | LIMIT 30000 | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1 | WHERE lookup_int_0 < 100 | stats c= count(*) | LIMIT 1",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_expanding10000_filter1000",
       "operation-type": "esql",
-      "query": "FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword | LIMIT 30000 | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1 | WHERE lookup_int_0 < 1000 | stats c= count(*) | LIMIT 1",
+      "query": "{{routing_prefix}}FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword | LIMIT 30000 | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1 | WHERE lookup_int_0 < 1000 | stats c= count(*) | LIMIT 1",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_expanding10000_filter5000",
       "operation-type": "esql",
-      "query": "FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword | LIMIT 30000 | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1 | WHERE lookup_int_0 < 5000 | stats c= count(*) | LIMIT 1",
+      "query": "{{routing_prefix}}FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword | LIMIT 30000 | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1 | WHERE lookup_int_0 < 5000 | stats c= count(*) | LIMIT 1",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
 
     {
       "name": "esql_lookup_join_expanding10000_two_keys",
       "operation-type": "esql",
-      "query": "FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword, lookup_int_0 = key_100000::long | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1, lookup_int_0",
+      "query": "{{routing_prefix}}FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword, lookup_int_0 = key_100000::long | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1, lookup_int_0",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_expanding10000_two_keys_filter1000",
       "operation-type": "esql",
-      "query": "FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword, lookup_int_0 = key_100000::long | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1, lookup_int_0 | WHERE lookup_int_0 < 1000",
+      "query": "{{routing_prefix}}FROM lookup_idx_100000_f10 | EVAL key_1 = (key_100000::integer-key_100000::integer)::keyword, lookup_int_0 = key_100000::long | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1, lookup_int_0 | WHERE lookup_int_0 < 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_expression_expanding_eq_10000_two_keys_filter1000",
       "operation-type": "esql",
-      "query": "FROM lookup_idx_100000_f10 | EVAL key_1_left = (key_100000::integer-key_100000::integer)::keyword, lookup_int_0_left = key_100000::long | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1_left == key_1 AND lookup_int_0_left == lookup_int_0 | WHERE lookup_int_0 < 1000",
+      "query": "{{routing_prefix}}FROM lookup_idx_100000_f10 | EVAL key_1_left = (key_100000::integer-key_100000::integer)::keyword, lookup_int_0_left = key_100000::long | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1_left == key_1 AND lookup_int_0_left == lookup_int_0 | WHERE lookup_int_0 < 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_expression_expanding_gte_lte_10000_two_keys_filter1000",
       "operation-type": "esql",
-      "query": "FROM lookup_idx_100000_f10 | EVAL key_1_left = (key_100000::integer-key_100000::integer)::keyword, lookup_int_0_left = key_100000::long | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1_left >= key_1 AND lookup_int_0_left <= lookup_int_0 | WHERE lookup_int_0 < 1000",
+      "query": "{{routing_prefix}}FROM lookup_idx_100000_f10 | EVAL key_1_left = (key_100000::integer-key_100000::integer)::keyword, lookup_int_0_left = key_100000::long | LOOKUP JOIN lookup_idx_1_f2_x10000 on key_1_left >= key_1 AND lookup_int_0_left <= lookup_int_0 | WHERE lookup_int_0 < 1000",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_1k_100k_200k_one_key_count",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000 | STATS count(*)",
+      "query": "{{routing_prefix}}FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000 | STATS count(*)",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_1k_100k_200k_two_keys_count",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000, key_1000 | STATS count(*)",
+      "query": "{{routing_prefix}}FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000, key_1000 | STATS count(*)",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
         "name": "esql_lookup_join_1k_100k_200k_three_keys_count",
         "operation-type": "esql",
-        "query": "FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000, key_100000, key_1000 | STATS count(*)",
+        "query": "{{routing_prefix}}FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000, key_100000, key_1000 | STATS count(*)",
         "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
         "name": "esql_lookup_join_expression_1k_100k_200k_three_keys_count",
         "operation-type": "esql",
-        "query": "FROM join_base_idx | RENAME key_200000 as key_200000_left | RENAME  key_100000 as key_100000_left | RENAME key_1000 as key_1000_left | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000 == key_200000_left AND key_100000 == key_100000_left AND key_1000 == key_1000_left | STATS count(*)",
+        "query": "{{routing_prefix}}FROM join_base_idx | RENAME key_200000 as key_200000_left | RENAME  key_100000 as key_100000_left | RENAME key_1000 as key_1000_left | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000 == key_200000_left AND key_100000 == key_100000_left AND key_1000 == key_1000_left | STATS count(*)",
         "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_1k_100k_200k_one_key_filter_count",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000 | WHERE lookup_int_0 < 5000 | STATS count(*)",
+      "query": "{{routing_prefix}}FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000 | WHERE lookup_int_0 < 5000 | STATS count(*)",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_1k_100k_200k_two_keys_filter_count",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000, key_1000 | WHERE lookup_int_0 < 5000 | STATS count(*)",
+      "query": "{{routing_prefix}}FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000, key_1000 | WHERE lookup_int_0 < 5000 | STATS count(*)",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     },
     {
       "name": "esql_lookup_join_1k_100k_200k_three_keys_filter_count",
       "operation-type": "esql",
-      "query": "FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000, key_100000, key_1000 | WHERE lookup_int_0 < 5000 | STATS count(*)",
+      "query": "{{routing_prefix}}FROM join_base_idx | LOOKUP JOIN lookup_idx_1000_100000_200000_f10 ON key_200000, key_100000, key_1000 | WHERE lookup_int_0 < 5000 | STATS count(*)",
       "body": { "accept_pragma_risks": true, "pragma": { "max_concurrent_shards_per_node": {{max_concurrent_shards_per_node | default(10)}} } }
     }
     


### PR DESCRIPTION
Adding an optional `project_routing` parameter to `joins` rally track, for CPS testing.
If it provided, and additional `SET project_routing = "<value>"; ` is added to all the queries