### PR TITLE
Fix msmarco-v2-vector recall-doc-set selection and reduce merge-wait log noise

### DIFF
--- a/msmarco-v2-vector/challenges/default.json
+++ b/msmarco-v2-vector/challenges/default.json
@@ -41,6 +41,7 @@
           "expected-value": 0
         },
         "retry-until-success": true,
+        "retry-wait-period": 10,
         "include-in-reporting": false
       }
     },
@@ -68,6 +69,7 @@
           "expected-value": 0
         },
         "retry-until-success": true,
+        "retry-wait-period": 10,
         "include-in-reporting": true
       }
     },

--- a/msmarco-v2-vector/operations/default.json
+++ b/msmarco-v2-vector/operations/default.json
@@ -79,7 +79,7 @@
   {%- endif -%}
   "oversample-rescore": {{p_search_ops[i][2]}},
   "include-in-reporting": false,
-  {%- if initial_indexing_ingest_doc_count is defined and initial_indexing_ingest_doc_count == 10000000 -%}
+  {%- if initial_indexing_ingest_doc_count is defined and initial_indexing_ingest_doc_count | int == 10000000 -%}
     "recall-doc-set": "10m"
   {%- else -%}
     "recall-doc-set": "full"

--- a/msmarco-v2-vector/track.py
+++ b/msmarco-v2-vector/track.py
@@ -174,6 +174,7 @@ class KnnRecallRunner:
             queries_recall = QUERIES_RECALL_10M_FILENAME
         else:
             queries_recall = QUERIES_RECALL_FILENAME
+        logger.info(f"recall_doc_set={recall_doc_set!r} (type={type(recall_doc_set).__name__}), using recall file: {queries_recall}")
 
         with bz2.open(os.path.join(cwd, queries_recall), "r") as queries_file:
             for line in queries_file:


### PR DESCRIPTION
 I ran into two issues when running the msmarco-v2-vector track with a 10M dataset:

* Fix recall-doc-set detection for 10M runs. The Jinja2 condition that selects the 10m recall ground truth file was comparing `initial_indexing_ingest_doc_count` with `==`, but depending on how Rally passes the parameter it can arrive as a string rather than an `int`. I added a  `| int` filter so the comparison works reliably. I also added a debug log line in `track.py` so it's clear which recall file is being used during a run.
* Reduce merge-wait polling noise . The two `retry-until-success` operations that wait for merges to complete were polling every 0.5 seconds, flooding `rally.log` with hundreds of INFO messages during force merge. I increased the retry interval to 10 seconds, which is plenty for a merge that takes commonly minutes.

