### PR TITLE
[9.4] Fix msmarco-v2-vector recall-doc-set selection and reduce merge-wait log noise (#1133)

### DIFF
--- a/msmarco-v2-vector/challenges/default.json
+++ b/msmarco-v2-vector/challenges/default.json
@@ -41,6 +41,7 @@
           "expected-value": 0
         },
         "retry-until-success": true,
+        "retry-wait-period": 10,
         "include-in-reporting": false
       }
     },
@@ -68,6 +69,7 @@
           "expected-value": 0
         },
         "retry-until-success": true,
+        "retry-wait-period": 10,
         "include-in-reporting": true
       }
     },

--- a/msmarco-v2-vector/operations/default.json
+++ b/msmarco-v2-vector/operations/default.json
@@ -79,7 +79,7 @@
   {%- endif -%}
   "oversample-rescore": {{p_search_ops[i][2]}},
   "include-in-reporting": false,
-  {%- if initial_indexing_ingest_doc_count is defined and initial_indexing_ingest_doc_count == 10000000 -%}
+  {%- if initial_indexing_ingest_doc_count is defined and initial_indexing_ingest_doc_count | int == 10000000 -%}
     "recall-doc-set": "10m"
   {%- else -%}
     "recall-doc-set": "full"

--- a/msmarco-v2-vector/track.py
+++ b/msmarco-v2-vector/track.py
@@ -174,6 +174,7 @@ class KnnRecallRunner:
             queries_recall = QUERIES_RECALL_10M_FILENAME
         else:
             queries_recall = QUERIES_RECALL_FILENAME
+        logger.info(f"recall_doc_set={recall_doc_set!r} (type={type(recall_doc_set).__name__}), using recall file: {queries_recall}")
 
         with bz2.open(os.path.join(cwd, queries_recall), "r") as queries_file:
             for line in queries_file:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.4`:
 - [Fix msmarco-v2-vector recall-doc-set selection and reduce merge-wait log noise (#1133)](https://github.com/elastic/rally-tracks/pull/1133)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Chris Hegarty","email":"62058229+ChrisHegarty@users.noreply.github.com"},"sourceCommit":{"committedDate":"2026-04-24T14:53:08Z","message":"Fix msmarco-v2-vector recall-doc-set selection and reduce merge-wait log noise (#1133)","sha":"7b828539dce36d65cb1395da03bfaca3a9381c64","branchLabelMapping":{"^v9.5$":"master","^vServerless$":"master","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.3","v9.4","v9.5"],"title":"Fix msmarco-v2-vector recall-doc-set selection and reduce merge-wait log noise","number":1133,"url":"https://github.com/elastic/rally-tracks/pull/1133","mergeCommit":{"message":"Fix msmarco-v2-vector recall-doc-set selection and reduce merge-wait log noise (#1133)","sha":"7b828539dce36d65cb1395da03bfaca3a9381c64"}},"sourceBranch":"master","suggestedTargetBranches":["9.3","9.4"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"master","label":"v9.5","branchLabelMappingKey":"^v9.5$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/rally-tracks/pull/1133","number":1133,"mergeCommit":{"message":"Fix msmarco-v2-vector recall-doc-set selection and reduce merge-wait log noise (#1133)","sha":"7b828539dce36d65cb1395da03bfaca3a9381c64"}}]}] BACKPORT-->