### PR TITLE
Add parallel-update-search challenge (wikipedia, msmarco-v2-vector)

### DIFF
--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -178,7 +178,7 @@ Initial ingest, wait for merges to settle, then run a single parallel phase that
 Both bulk tasks use the `bulk-copy-docid-param-source` from `track.py`, which copies each document's `docid` field into the bulk action line as `_id`. The corpus is not rewritten — the `docid` value is left in place as a field and also used as the document `_id`, so re-ingestion overwrites existing documents instead of appending new ones with fresh auto-generated `_id`s.
 
 - Mapping:
-    - `vector_index_type` (default: bbq_disk)
+    - `vector_index_type` (default: bbq_hnsw)
 - Initial indexing (always ingests the full configured corpora):
     - `corpora` (default: `["msmarco-v2_base64-initial-indexing-1"]`): The corpora to ingest and later target with updates. The update task re-indexes documents from this same set so they remain true updates rather than new docs.
     - `initial_ingest_clients` (default: 4)

--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -171,6 +171,26 @@ When `as_search_target_throughputs` is a positive number, the search throughput 
     - `as_search_clients` (default: [1,2,4,8,16])
     - `as_search_target_throughputs` (default: [-1,-1,-1,-1,-1])
 
+### Parameters for parallel-update-search challenge
+
+Initial ingest, wait for merges to settle, then run a single parallel phase that updates a percentage of the corpus (by re-indexing documents with the same `_id` from the same corpus) at a target docs/s while running queries. The search task runs until the update task completes (via `completed-by`).
+
+- Mapping:
+    - `vector_index_type` (default: bbq_disk)
+- Initial indexing (always ingests the full configured corpora):
+    - `corpora` (default: `["msmarco-v2_base64-initial-indexing-1"]`): The corpora to ingest and later target with updates. The update task re-indexes documents from this same set so they remain true updates rather than new docs.
+    - `initial_ingest_clients` (default: 4)
+    - `initial_ingest_bulk_size` (default: 100)
+- Update operation (X% of the corpus at Y docs/s):
+    - `update_percentage` (default: 10): Percentage of the corpus to update.
+    - `update_clients` (default: 1)
+    - `update_bulk_size` (default: 100)
+    - `update_target_throughput_docs_per_sec` (default: 1000): Update throughput in documents per second. The schedule converts this to the bulks/s value Rally expects via `update_target_throughput_docs_per_sec / update_bulk_size`, so the effective docs/s rate is the value you set, spread across `update_clients`.
+- Search operation:
+    - `search_clients` (default: 4)
+    - `search_target_throughput` (default: -1): Target throughput for the search task in operations per second (one operation = one query). If negative, search runs unthrottled.
+    - `search_warmup_time_period` (default: 60)
+
 ### Parameters for hybrid-search-queries-dsl-and-esql challenge
 
 Use mapping_type = `vectors-with-text` for this track since we perform lexical search on the title and text fields

--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -175,6 +175,8 @@ When `as_search_target_throughputs` is a positive number, the search throughput 
 
 Initial ingest, wait for merges to settle, then run a single parallel phase that updates a percentage of the corpus (by re-indexing documents with the same `_id` from the same corpus) at a target docs/s while running queries. The search task runs until the update task completes (via `completed-by`).
 
+Both bulk tasks use the `bulk-copy-docid-param-source` from `track.py`, which copies each document's `docid` field into the bulk action line as `_id`. The corpus is not rewritten — the `docid` value is left in place as a field and also used as the document `_id`, so re-ingestion overwrites existing documents instead of appending new ones with fresh auto-generated `_id`s.
+
 - Mapping:
     - `vector_index_type` (default: bbq_disk)
 - Initial indexing (always ingests the full configured corpora):

--- a/msmarco-v2-vector/challenges/common/parallel-update-search-schedule.json
+++ b/msmarco-v2-vector/challenges/common/parallel-update-search-schedule.json
@@ -20,6 +20,7 @@
   "clients": {{ initial_ingest_clients | default(4) | int }},
   "operation": {
     "operation-type": "bulk",
+    "param-source": "bulk-copy-docid-param-source",
     "bulk-size": {{ initial_ingest_bulk_size | default(100) | int }},
     "corpora":  [
       {% for doc_id in p_corpora %}
@@ -67,6 +68,7 @@
         "clients": {{p_update_clients}},
         "operation": {
           "operation-type": "bulk",
+          "param-source": "bulk-copy-docid-param-source",
           "bulk-size": {{p_update_bulk_size}},
           "corpora":  [
             {% for doc_id in p_corpora %}

--- a/msmarco-v2-vector/challenges/common/parallel-update-search-schedule.json
+++ b/msmarco-v2-vector/challenges/common/parallel-update-search-schedule.json
@@ -1,0 +1,116 @@
+{
+  "name": "delete-index",
+  "operation": {
+    "operation-type": "delete-index"
+  }
+},
+{
+  "name": "create-index",
+  "operation": {
+    "operation-type": "create-index"
+  }
+},
+{
+  "name": "check-cluster-health",
+  "operation": "check-cluster-health"
+},
+{% set p_corpora = (corpora | default(["msmarco-v2_base64-initial-indexing-1"])) %}
+{
+  "name": "initial-ingest",
+  "clients": {{ initial_ingest_clients | default(4) | int }},
+  "operation": {
+    "operation-type": "bulk",
+    "bulk-size": {{ initial_ingest_bulk_size | default(100) | int }},
+    "corpora":  [
+      {% for doc_id in p_corpora %}
+        {{doc_id | tojson}}
+        {{ ", " if not loop.last else "" }}
+      {% endfor %}]
+  }
+},
+{
+  "name": "refresh-after-initial-ingest",
+  "operation": {
+    "operation-type": "refresh",
+    "request-timeout": 1000,
+    "include-in-reporting": true
+  }
+},
+{
+  "name": "wait-until-merges-finish-after-initial-ingest",
+  "operation": {
+    "operation-type": "index-stats",
+    "index": "_all",
+    "condition": {
+      "path": "_all.total.merges.current",
+      "expected-value": 0
+    },
+    "retry-until-success": true,
+    "retry-wait-period": 10,
+    "include-in-reporting": false
+  }
+}
+{%- set p_vector_index_type = (vector_index_type | default("bbq_disk")) %}
+{%- set p_update_percentage = (update_percentage | default(10)) %}
+{%- set p_update_clients = (update_clients | default(1)) %}
+{%- set p_update_bulk_size = (update_bulk_size | default(100)) %}
+{%- set p_update_target_throughput_docs_per_sec = (update_target_throughput_docs_per_sec | default(1000)) %}
+{%- set p_search_clients = (search_clients | default(4)) %}
+{%- set p_search_target_throughput = (search_target_throughput | default(-1)) %}
+{%- set p_search_warmup_time_period = (search_warmup_time_period | default(60)) %},
+{
+  "parallel": {
+    "completed-by": "parallel-update-c{{p_update_clients}}-b{{p_update_bulk_size}}-p{{p_update_percentage}}",
+    "tasks": [
+      {
+        "name": "parallel-update-c{{p_update_clients}}-b{{p_update_bulk_size}}-p{{p_update_percentage}}",
+        "clients": {{p_update_clients}},
+        "operation": {
+          "operation-type": "bulk",
+          "bulk-size": {{p_update_bulk_size}},
+          "corpora":  [
+            {% for doc_id in p_corpora %}
+              {{doc_id | tojson}}
+              {{ ", " if not loop.last else "" }}
+            {% endfor %}],
+          "ingest-percentage": {{p_update_percentage}}
+        },
+        "target-throughput": {{ p_update_target_throughput_docs_per_sec / p_update_bulk_size }}
+      },
+  {%- if p_search_target_throughput < 0 %}
+      {
+        "name": "parallel-search-c{{p_search_clients}}-s10",
+        "clients": {{p_search_clients}},
+        "operation": {
+          "operation-type": "search",
+          "param-source": "knn-param-source",
+          "random-query": true,
+          "dims": 1024,
+          "k": 10,
+          "num-candidates": 100,
+          "visit-percentage": 2,
+          "looped": true
+        },
+        "warmup-time-period": {{p_search_warmup_time_period}}
+      }
+  {%- else %}
+      {
+        "name": "parallel-search-c{{p_search_clients}}-s10-t{{p_search_target_throughput}}",
+        "clients": {{p_search_clients}},
+        "operation": {
+          "operation-type": "search",
+          "param-source": "knn-param-source",
+          "random-query": true,
+          "dims": 1024,
+          "k": 10,
+          "num-candidates": 100,
+          "visit-percentage": 2,
+          "looped": true
+        },
+        "warmup-time-period": {{p_search_warmup_time_period}},
+        "target-throughput": {{p_search_target_throughput}}
+      }
+  {%- endif %}
+    ]
+  }
+}

--- a/msmarco-v2-vector/challenges/default.json
+++ b/msmarco-v2-vector/challenges/default.json
@@ -168,6 +168,14 @@
   ]
 },
 {
+  "name": "parallel-update-search",
+  "description": "Initial ingest, wait for merges, then in parallel update a percentage of the corpus at a target docs/s while running queries",
+  "default": false,
+  "schedule": [
+    {{ rally.collect(parts="common/parallel-update-search-schedule.json") }}
+  ]
+},
+{
   "name": "hybrid-search-queries-dsl-and-esql",
   "description": "Benchmark hybrid search queries using query DSL and ESQL",
   "default": false,

--- a/msmarco-v2-vector/track.py
+++ b/msmarco-v2-vector/track.py
@@ -4,11 +4,13 @@ import json
 import logging
 import os
 import random
+import re
 import statistics
 from collections import defaultdict
 from typing import Any, Dict, List
 
 from esrally.driver import runner
+from esrally.track.params import BulkIndexParamSource
 
 logger = logging.getLogger(__name__)
 
@@ -391,9 +393,78 @@ class EsqlHybridParamSource:
         return {"query": hybrid_query, "body": {"params": params}}
 
 
+class BulkCopyDocIdParamSource:
+    # Wraps Rally's standard bulk param source so each bulk action line carries
+    # _id=<docid> taken from the doc itself. The corpus is not rewritten — the
+    # docid field is read from the JSON doc body and merged into the action
+    # line that Rally already emits. This makes re-ingesting the same corpus
+    # an actual update of existing docs rather than appending new ones under
+    # fresh auto-generated _ids.
+
+    _DOCID_RE = re.compile(rb'"docid"\s*:\s*"([^"]+)"')
+
+    def __init__(self, track, params, **kwargs):
+        self._inner = BulkIndexParamSource(track, params, **kwargs)
+        self.infinite = self._inner.infinite
+
+    def partition(self, partition_index, total_partitions):
+        return _DocIdRewritingPartition(self._inner.partition(partition_index, total_partitions), self._DOCID_RE)
+
+
+class _DocIdRewritingPartition:
+    def __init__(self, inner, docid_re):
+        self._inner = inner
+        self._docid_re = docid_re
+        self.infinite = inner.infinite
+
+    @property
+    def percent_completed(self):
+        return self._inner.percent_completed
+
+    def partition(self, partition_index, total_partitions):
+        return self
+
+    def params(self):
+        p = self._inner.params()
+        body = p["body"]
+        body_was_str = isinstance(body, str)
+        body_bytes = body.encode("utf-8") if body_was_str else body
+        new_body = self._rewrite_body(body_bytes)
+        p["body"] = new_body.decode("utf-8") if body_was_str else new_body
+        return p
+
+    def _rewrite_body(self, body_bytes):
+        lines = body_bytes.split(b"\n")
+        out = []
+        i = 0
+        n = len(lines)
+        while i < n:
+            line = lines[i]
+            if not line:
+                i += 1
+                continue
+            if i + 1 >= n:
+                out.append(line)
+                break
+            doc_line = lines[i + 1]
+            i += 2
+            match = self._docid_re.search(doc_line)
+            if match is None:
+                out.append(line)
+            else:
+                action = json.loads(line)
+                verb = next(iter(action))
+                action[verb]["_id"] = match.group(1).decode("utf-8")
+                out.append(json.dumps(action, separators=(",", ":")).encode("utf-8"))
+            out.append(doc_line)
+        out.append(b"")
+        return b"\n".join(out)
+
+
 def register(registry):
     registry.register_param_source("knn-param-source", KnnParamSource)
     registry.register_param_source("knn-recall-param-source", KnnRecallParamSource)
     registry.register_param_source("hybrid-bm25-knn-param-source", HybridParamSource)
     registry.register_param_source("esql-hybrid-bm25-knn-param-source", EsqlHybridParamSource)
+    registry.register_param_source("bulk-copy-docid-param-source", BulkCopyDocIdParamSource)
     registry.register_runner("knn-recall", KnnRecallRunner(), async_runner=True)

--- a/wikipedia/README.md
+++ b/wikipedia/README.md
@@ -122,6 +122,24 @@ When `as_search_target_throughputs` is a positive number, the search throughput 
 When `as_ingest_target_throughputs` is a positive number, the ingest throughput formula in documents per second is `ingest_bulk_size * as_ingest_target_throughputs`.
 When `as_search_target_throughputs` is a positive number, the search throughput formula in documents per second is `search_size * as_search_target_throughputs`.
 
+### Parameters for parallel-update-search challenge
+
+Initial ingest of the full corpus, wait for merges to settle, then run a single parallel phase that updates a percentage of the corpus (by re-indexing the same documents) at a target docs/s while running queries. The search task runs until the update task completes (via `completed-by`).
+
+- Initial indexing (always ingests the full corpus):
+  - `initial_ingest_clients` (default: 4)
+  - `initial_ingest_bulk_size` (default: 100)
+- Update operation (X% of the corpus at Y docs/s):
+  - `update_percentage` (default: 10): Percentage of the corpus to update.
+  - `update_clients` (default: 1)
+  - `update_bulk_size` (default: 100)
+  - `update_target_throughput_docs_per_sec` (default: 1000): Update throughput in documents per second. The schedule converts this to the bulks/s value Rally expects via `update_target_throughput_docs_per_sec / update_bulk_size`, so the effective docs/s rate is the value you set, spread across `update_clients`.
+- Search operation:
+  - `search_clients` (default: 4)
+  - `search_size` (default: 10)
+  - `search_target_throughput` (default: -1): Target throughput for the search task in operations per second (one operation = one query). If negative, search runs unthrottled.
+  - `search_warmup_time_period` (default: 60)
+
 ### Parameters for esql-full-text-functions challenge
 
 - Initial indexing:

--- a/wikipedia/challenges/common/parallel-update-search-schedule.json
+++ b/wikipedia/challenges/common/parallel-update-search-schedule.json
@@ -1,0 +1,101 @@
+{
+  "name": "delete-index",
+  "operation": {
+    "operation-type": "delete-index"
+  }
+},
+{
+  "name": "create-index",
+  "operation": {
+    "operation-type": "create-index"
+  }
+},
+{
+  "name": "check-cluster-health",
+  "operation": "check-cluster-health"
+},
+{
+  "name": "initial-ingest",
+  "clients": {{ initial_ingest_clients | default(4) | int }},
+  "operation": {
+    "operation-type": "bulk",
+    "bulk-size": {{ initial_ingest_bulk_size | default(100) | int }}
+  }
+},
+{
+  "name": "refresh-after-initial-ingest",
+  "operation": {
+    "operation-type": "refresh",
+    "request-timeout": 1000,
+    "include-in-reporting": true
+  }
+},
+{
+  "name": "wait-until-merges-finish-after-initial-ingest",
+  "operation": {
+    "operation-type": "index-stats",
+    "index": "_all",
+    "condition": {
+      "path": "_all.total.merges.current",
+      "expected-value": 0
+    },
+    "retry-until-success": true,
+    "retry-wait-period": 10,
+    "include-in-reporting": false
+  }
+}
+{%- set p_update_percentage = (update_percentage | default(10)) %}
+{%- set p_update_clients = (update_clients | default(1)) %}
+{%- set p_update_bulk_size = (update_bulk_size | default(100)) %}
+{%- set p_update_target_throughput_docs_per_sec = (update_target_throughput_docs_per_sec | default(1000)) %}
+{%- set p_search_clients = (search_clients | default(4)) %}
+{%- set p_search_target_throughput = (search_target_throughput | default(-1)) %}
+{%- set p_search_size = (search_size | default(10)) %}
+{%- set p_search_warmup_time_period = (search_warmup_time_period | default(60)) %},
+{
+  "parallel": {
+    "completed-by": "parallel-update-c{{p_update_clients}}-b{{p_update_bulk_size}}-p{{p_update_percentage}}",
+    "tasks": [
+      {
+        "name": "parallel-update-c{{p_update_clients}}-b{{p_update_bulk_size}}-p{{p_update_percentage}}",
+        "clients": {{p_update_clients}},
+        "operation": {
+          "operation-type": "bulk",
+          "bulk-size": {{p_update_bulk_size}},
+          "ingest-percentage": {{p_update_percentage}}
+        },
+        "target-throughput": {{ p_update_target_throughput_docs_per_sec / p_update_bulk_size }}
+      },
+  {%- if p_search_target_throughput < 0 %}
+      {
+        "name": "parallel-search-c{{p_search_clients}}-s{{p_search_size}}",
+        "clients": {{p_search_clients}},
+        "operation": {
+          "operation-type": "search",
+          "param-source": "query-search",
+          "query-type": "match",
+          "size": {{p_search_size}},
+          "field": "content",
+          "looped": true
+        },
+        "warmup-time-period": {{p_search_warmup_time_period}}
+      }
+  {%- else %}
+      {
+        "name": "parallel-search-c{{p_search_clients}}-s{{p_search_size}}-t{{p_search_target_throughput}}",
+        "clients": {{p_search_clients}},
+        "operation": {
+          "operation-type": "search",
+          "param-source": "query-search",
+          "query-type": "match",
+          "size": {{p_search_size}},
+          "field": "content",
+          "looped": true
+        },
+        "warmup-time-period": {{p_search_warmup_time_period}},
+        "target-throughput": {{p_search_target_throughput}}
+      }
+  {%- endif %}
+    ]
+  }
+}

--- a/wikipedia/challenges/default.json
+++ b/wikipedia/challenges/default.json
@@ -197,4 +197,12 @@
     "schedule": [
       {{ rally.collect(parts="common/ingest-search-autoscale-schedule.json") }}
     ]
+  },
+  {
+    "name": "parallel-update-search",
+    "description": "Initial ingest, wait for merges, then in parallel update a percentage of the corpus at a target docs/s while running queries",
+    "default": false,
+    "schedule": [
+      {{ rally.collect(parts="common/parallel-update-search-schedule.json") }}
+    ]
   }


### PR DESCRIPTION
Adds a new non-default parallel-update-search challenge to the wikipedia and msmarco-v2-vector tracks. The challenge:

  1. Ingests the full configured corpus.
  2. Refreshes and waits for merges to settle.
  3. Runs a single parallel phase that:
    - Re-indexes a configurable percentage of the corpus at a target docs/s — true updates of existing docs, not new appends.
    - Runs queries with a configurable client count and optional target throughput.
    - Search is bounded by the update via completed-by, so it stops as soon as the update finishes.

  For msmarco-v2-vector, the corpus is normally ingested with auto-generated _ids, which would have made the "update" pass append new docs instead of overwriting. To fix that without rewriting the 1.7 TB
  corpus, a small param-source wrapper (bulk-copy-docid-param-source in track.py) takes the bulk body Rally already emits and merges _id=<docid> into each action line, parsed from the docid field that every
  doc already carries. docid stays on the document as a regular field.
  
  Parameters

  Both tracks expose the same knobs (update_percentage, update_clients, update_bulk_size, update_target_throughput_docs_per_sec, search_clients, search_target_throughput, search_warmup_time_period); wikipedia
  also has search_size, msmarco-v2-vector also has corpora and vector_index_type. The user-facing update_target_throughput_docs_per_sec is converted to Rally's bulks/s target-throughput internally
  (docs_per_sec / bulk_size).
  
  See the ### Parameters for parallel-update-search challenge section in each track's README for full details.
