### PR TITLE
Add index_mode option to all dense_vector tracks

### DIFF
--- a/cohere_vector/README.md
+++ b/cohere_vector/README.md
@@ -59,3 +59,4 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - vector_index_type (default: "hnsw"): The index kind for storing the vectors.
  - vector_index_element_type (default: "float"): Sets the dense_vector element type.
  - enable_experimental_features (default: false): Enables experimental dense vector features that may break backward compatibility.
+ - index_mode (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").

--- a/cohere_vector/index-vectors-only-mapping.json
+++ b/cohere_vector/index-vectors-only-mapping.json
@@ -1,9 +1,12 @@
 {
+{%- set comma = joiner(",") -%}
   "settings": {
     {% if index_mode is defined %}
-    "index.mode": {{ index_mode | tojson }},
+    {{comma()}}
+    "index.mode": {{ index_mode | tojson }}
     {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {{comma()}}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem"],
       {% endif %}

--- a/cohere_vector/index-vectors-only-mapping.json
+++ b/cohere_vector/index-vectors-only-mapping.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    {% if index_mode is defined %}
+    "index.mode": {{ index_mode | tojson }},
+    {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem"],

--- a/cohere_vector/index-vectors-with-text-mapping.json
+++ b/cohere_vector/index-vectors-with-text-mapping.json
@@ -1,9 +1,12 @@
 {
+{%- set comma = joiner(",") -%}
   "settings": {
     {% if index_mode is defined %}
-    "index.mode": {{ index_mode | tojson }},
+    {{comma()}}
+    "index.mode": {{ index_mode | tojson }}
     {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {{comma()}}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem"],
       {% endif %}

--- a/cohere_vector/index-vectors-with-text-mapping.json
+++ b/cohere_vector/index-vectors-with-text-mapping.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    {% if index_mode is defined %}
+    "index.mode": {{ index_mode | tojson }},
+    {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem"],

--- a/dense_vector/README.md
+++ b/dense_vector/README.md
@@ -38,4 +38,3 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `vector_index_element_type` (default: "float"): Sets the dense_vector element type.
 * `enable_experimental_features` (default: false): Enables experimental dense vector features that may break backward compatibility.
 * `index_mode` (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").
-* `index_mode` (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").

--- a/dense_vector/README.md
+++ b/dense_vector/README.md
@@ -37,3 +37,5 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `vector_index_type` (default: "int8_hnsw"): The index kind for storing the vectors.
 * `vector_index_element_type` (default: "float"): Sets the dense_vector element type.
 * `enable_experimental_features` (default: false): Enables experimental dense vector features that may break backward compatibility.
+* `index_mode` (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").
+* `index_mode` (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").

--- a/dense_vector/index.json
+++ b/dense_vector/index.json
@@ -1,10 +1,13 @@
 {
+{%- set comma = joiner(",") -%}
   "settings": {
     "index": {
       {% if index_mode is defined %}
-      "mode": {{ index_mode | tojson }},
+      {{comma()}}
+      "mode": {{ index_mode | tojson }}
       {% endif %}
       {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+      {{comma()}}
       "number_of_shards": {{ number_of_shards | default(2) }},
       "number_of_replicas": {{ number_of_replicas | default(0) }}{% if enable_experimental_features | default(false) %},
       "dense_vector.experimental_features": true{% endif %}

--- a/dense_vector/index.json
+++ b/dense_vector/index.json
@@ -1,6 +1,9 @@
 {
   "settings": {
     "index": {
+      {% if index_mode is defined %}
+      "mode": {{ index_mode | tojson }},
+      {% endif %}
       {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       "number_of_shards": {{ number_of_shards | default(2) }},
       "number_of_replicas": {{ number_of_replicas | default(0) }}{% if enable_experimental_features | default(false) %},

--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -96,6 +96,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - `vector_index_type` (default: "int8_hnsw"): The index kind for storing the vectors.
  - `vector_index_element_type` (default: "float"): Sets the dense_vector element type.
  - `enable_experimental_features` (default: false): Enables experimental dense vector features that may break backward compatibility.
+ - `index_mode` (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").
  - `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
 
 For running with Base64 encoded strings, use a parameter file like:

--- a/msmarco-v2-vector/index-vectors-only-mapping.json
+++ b/msmarco-v2-vector/index-vectors-only-mapping.json
@@ -4,6 +4,10 @@
 {%- set comma = joiner(",") -%}
   "settings": {
     "index": {
+      {% if index_mode is defined %}
+      {{comma()}}
+      "mode": {{ index_mode | tojson }}
+      {% endif %}
       {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {%- if index_refresh_interval is defined %}
       {{comma()}}

--- a/msmarco-v2-vector/index-vectors-with-text-mapping.json
+++ b/msmarco-v2-vector/index-vectors-with-text-mapping.json
@@ -1,8 +1,12 @@
 {% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 
 {
-  {%- set comma = joiner(",") -%}
+{%- set comma = joiner(",") -%}
   "settings": {
+    {% if index_mode is defined %}
+    {{comma()}}
+    "index.mode": {{ index_mode | tojson }}
+    {% endif %}
     {# non-serverless-index-settings-marker-start #}
     {%- if build_flavor != "serverless" or serverless_operator == true -%}
     {% if preload_pagecache %}

--- a/openai_vector/README.md
+++ b/openai_vector/README.md
@@ -55,6 +55,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 - vector_index_type (default: "hnsw"): The index kind for storing the vectors.
 - vector_index_element_type (default: "float"): Sets the dense_vector element type.
 - enable_experimental_features (default: false): Enables experimental dense vector features that may break backward compatibility.
+- index_mode (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").
 - search_ops (default: [[10, 20, 0], [10, 20, 1], [10, 20, 2], [10, 50, 1], [10, 50, 2], [10, 100, 1], [100, 120, 1], [100, 120, 2], [100, 200, 1], [100, 200, 2], [100, 500, 1], [100, 500, 2]]): The vector search operations, formattied [k, num_candidates, oversample], where `oversample` indicates the ratio of extra `k` to gather and then rescore.
 
 ### License

--- a/openai_vector/index-vectors-only-mapping.json
+++ b/openai_vector/index-vectors-only-mapping.json
@@ -1,9 +1,12 @@
 {
+{%- set comma = joiner(",") -%}
   "settings": {
     {% if index_mode is defined %}
-    "index.mode": {{ index_mode | tojson }},
+    {{comma()}}
+    "index.mode": {{ index_mode | tojson }}
     {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {{comma()}}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],
       {% endif %}

--- a/openai_vector/index-vectors-only-mapping.json
+++ b/openai_vector/index-vectors-only-mapping.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    {% if index_mode is defined %}
+    "index.mode": {{ index_mode | tojson }},
+    {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],

--- a/openai_vector/index-vectors-only-with-docid-mapping.json
+++ b/openai_vector/index-vectors-only-with-docid-mapping.json
@@ -1,9 +1,12 @@
 {
+{%- set comma = joiner(",") -%}
   "settings": {
     {% if index_mode is defined %}
-    "index.mode": {{ index_mode | tojson }},
+    {{comma()}}
+    "index.mode": {{ index_mode | tojson }}
     {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {{comma()}}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],
       {% endif %}

--- a/openai_vector/index-vectors-only-with-docid-mapping.json
+++ b/openai_vector/index-vectors-only-with-docid-mapping.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    {% if index_mode is defined %}
+    "index.mode": {{ index_mode | tojson }},
+    {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],

--- a/openai_vector/index-vectors-with-text-mapping.json
+++ b/openai_vector/index-vectors-with-text-mapping.json
@@ -1,9 +1,12 @@
 {
+{%- set comma = joiner(",") -%}
   "settings": {
     {% if index_mode is defined %}
-    "index.mode": {{ index_mode | tojson }},
+    {{comma()}}
+    "index.mode": {{ index_mode | tojson }}
     {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {{comma()}}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],
       {% endif %}

--- a/openai_vector/index-vectors-with-text-mapping.json
+++ b/openai_vector/index-vectors-with-text-mapping.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    {% if index_mode is defined %}
+    "index.mode": {{ index_mode | tojson }},
+    {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],

--- a/random_vector/README.md
+++ b/random_vector/README.md
@@ -89,3 +89,5 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - rescore_oversample (default: -1): `-1` uses the index default, `0` disables rescore, and values greater than `0` set an explicit oversample.
  - vector_index_element_type (default: "float"): Sets the dense_vector element type.
  - enable_experimental_features (default: false): Enables experimental dense vector features that may break backward compatibility.
+ - index_mode (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").
+ - index_mode (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").

--- a/random_vector/README.md
+++ b/random_vector/README.md
@@ -90,4 +90,3 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
  - vector_index_element_type (default: "float"): Sets the dense_vector element type.
  - enable_experimental_features (default: false): Enables experimental dense vector features that may break backward compatibility.
  - index_mode (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").
- - index_mode (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").

--- a/random_vector/index-template-routing.json
+++ b/random_vector/index-template-routing.json
@@ -6,6 +6,9 @@
   },
   "template": {
     "settings": {
+      {% if index_mode is defined %}
+      "index.mode": {{ index_mode | tojson }},
+      {% endif %}
       {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       "number_of_shards": {{number_of_shards | default(1)}},
       "number_of_replicas": {{number_of_replicas | default(0)}}{% if enable_experimental_features | default(false) %},

--- a/random_vector/index-template.json
+++ b/random_vector/index-template.json
@@ -4,6 +4,9 @@
   "data_stream": {},
   "template": {
     "settings": {
+      {% if index_mode is defined %}
+      "index.mode": {{ index_mode | tojson }},
+      {% endif %}
       {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       "number_of_shards": {{number_of_shards | default(1)}},
       "number_of_replicas": {{number_of_replicas | default(0)}}{% if enable_experimental_features | default(false) %},

--- a/so_vector/README.md
+++ b/so_vector/README.md
@@ -80,7 +80,6 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `vector_index_element_type` (default: "float"): Sets the dense_vector element type.
 * `enable_experimental_features` (default: false): Enables experimental dense vector features that may break backward compatibility.
 * `index_mode` (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").
-* `index_mode` (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").
 
 ### License
 We use the same license for the data as the original data: [CC-SA-4.0](http://creativecommons.org/licenses/by-sa/4.0/).

--- a/so_vector/README.md
+++ b/so_vector/README.md
@@ -79,6 +79,8 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 * `search_clients` (default: 8) - Number of clients that issue search requests in the multi-client search challenges.
 * `vector_index_element_type` (default: "float"): Sets the dense_vector element type.
 * `enable_experimental_features` (default: false): Enables experimental dense vector features that may break backward compatibility.
+* `index_mode` (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").
+* `index_mode` (default: not set, uses "standard"): If defined, sets the index mode (e.g., "vectordb_document").
 
 ### License
 We use the same license for the data as the original data: [CC-SA-4.0](http://creativecommons.org/licenses/by-sa/4.0/).

--- a/so_vector/index.json
+++ b/so_vector/index.json
@@ -1,11 +1,14 @@
 {% set p_include_non_serverless_index_settings = (include_non_serverless_index_settings | default(build_flavor != "serverless")) %}
 
 {
+{%- set comma = joiner(",") -%}
   "settings": {
     {% if index_mode is defined %}
-    "index.mode": {{ index_mode | tojson }},
+    {{comma()}}
+    "index.mode": {{ index_mode | tojson }}
     {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {{comma()}}
       {% if p_include_non_serverless_index_settings %}
     "index.number_of_shards": {{number_of_shards | default(2)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}}{% if enable_experimental_features | default(false) %},

--- a/so_vector/index.json
+++ b/so_vector/index.json
@@ -8,8 +8,8 @@
     "index.mode": {{ index_mode | tojson }}
     {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
-    {{comma()}}
       {% if p_include_non_serverless_index_settings %}
+    {{comma()}}
     "index.number_of_shards": {{number_of_shards | default(2)}},
     "index.number_of_replicas": {{number_of_replicas | default(0)}}{% if enable_experimental_features | default(false) %},
     "index.dense_vector.experimental_features": true{% endif %}

--- a/so_vector/index.json
+++ b/so_vector/index.json
@@ -2,6 +2,9 @@
 
 {
   "settings": {
+    {% if index_mode is defined %}
+    "index.mode": {{ index_mode | tojson }},
+    {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {% if p_include_non_serverless_index_settings %}
     "index.number_of_shards": {{number_of_shards | default(2)}},

--- a/wiki_en_cohere_vector_int8/README.md
+++ b/wiki_en_cohere_vector_int8/README.md
@@ -71,6 +71,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 | `preload_pagecache` | (unset) | Whether to preload vector files to page cache |
 | `index_settings` | `{}` | Additional index settings |
 | `enable_experimental_features` | `false` | Enables experimental dense vector features that may break backward compatibility |
+| `index_mode` | not set (uses "standard") | If defined, sets the index mode (e.g., "vectordb_document") |
 
 ### Example Usage
 

--- a/wiki_en_cohere_vector_int8/README.md
+++ b/wiki_en_cohere_vector_int8/README.md
@@ -71,7 +71,7 @@ This track accepts the following parameters with Rally 0.8.0+ using `--track-par
 | `preload_pagecache` | (unset) | Whether to preload vector files to page cache |
 | `index_settings` | `{}` | Additional index settings |
 | `enable_experimental_features` | `false` | Enables experimental dense vector features that may break backward compatibility |
-| `index_mode` | not set (uses "standard") | If defined, sets the index mode (e.g., "vectordb_document") |
+| `index_mode` | (unset) | If defined, sets the index mode (e.g., `"vectordb_document"`) |
 
 ### Example Usage
 

--- a/wiki_en_cohere_vector_int8/index-vectors-only-mapping.json
+++ b/wiki_en_cohere_vector_int8/index-vectors-only-mapping.json
@@ -1,9 +1,12 @@
 {
+{%- set comma = joiner(",") -%}
   "settings": {
     {% if index_mode is defined %}
-    "index.mode": {{ index_mode | tojson }},
+    {{comma()}}
+    "index.mode": {{ index_mode | tojson }}
     {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {{comma()}}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],
       {% endif %}

--- a/wiki_en_cohere_vector_int8/index-vectors-only-mapping.json
+++ b/wiki_en_cohere_vector_int8/index-vectors-only-mapping.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    {% if index_mode is defined %}
+    "index.mode": {{ index_mode | tojson }},
+    {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],

--- a/wiki_en_cohere_vector_int8/index-vectors-only-with-docid-mapping.json
+++ b/wiki_en_cohere_vector_int8/index-vectors-only-with-docid-mapping.json
@@ -1,9 +1,12 @@
 {
+{%- set comma = joiner(",") -%}
   "settings": {
     {% if index_mode is defined %}
-    "index.mode": {{ index_mode | tojson }},
+    {{comma()}}
+    "index.mode": {{ index_mode | tojson }}
     {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {{comma()}}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],
       {% endif %}

--- a/wiki_en_cohere_vector_int8/index-vectors-only-with-docid-mapping.json
+++ b/wiki_en_cohere_vector_int8/index-vectors-only-with-docid-mapping.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    {% if index_mode is defined %}
+    "index.mode": {{ index_mode | tojson }},
+    {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],

--- a/wiki_en_cohere_vector_int8/index-vectors-with-text-mapping.json
+++ b/wiki_en_cohere_vector_int8/index-vectors-with-text-mapping.json
@@ -1,9 +1,12 @@
 {
+{%- set comma = joiner(",") -%}
   "settings": {
     {% if index_mode is defined %}
-    "index.mode": {{ index_mode | tojson }},
+    {{comma()}}
+    "index.mode": {{ index_mode | tojson }}
     {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
+    {{comma()}}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],
       {% endif %}

--- a/wiki_en_cohere_vector_int8/index-vectors-with-text-mapping.json
+++ b/wiki_en_cohere_vector_int8/index-vectors-with-text-mapping.json
@@ -1,5 +1,8 @@
 {
   "settings": {
+    {% if index_mode is defined %}
+    "index.mode": {{ index_mode | tojson }},
+    {% endif %}
     {# non-serverless-index-settings-marker-start #}{%- if build_flavor != "serverless" or serverless_operator == true -%}
       {% if preload_pagecache %}
     "index.store.preload": [ "vec", "vex", "vem", "veq", "veqm", "veb", "vebm"],


### PR DESCRIPTION
Add configurable index_mode setting to all tracks with dense_vector fields. When index_mode is defined (e.g., "vectordb_document"), it sets the index.mode setting. If not defined, defaults to standard index mode.

Updated mapping files:
- so_vector, dense_vector, random_vector
- cohere_vector, openai_vector, msmarco-v2-vector
- wiki_en_cohere_vector_int8