### PR TITLE
[msmarco-v2-vector] Remove numpy dependency from KnnParamSource

### DIFF
--- a/msmarco-v2-vector/track.json
+++ b/msmarco-v2-vector/track.json
@@ -4,8 +4,7 @@
   "version": 2,
   "description": "Benchmark for vector search with msmarco-v2 passage data",
   "dependencies": [
-    "pytrec_eval==0.5",
-    "numpy"
+    "pytrec_eval==0.5"
   ],
   "indices": [
     {

--- a/msmarco-v2-vector/track.py
+++ b/msmarco-v2-vector/track.py
@@ -114,11 +114,12 @@ class KnnParamSource:
         self.infinite = True
 
     def _random_normalized_vector(self, dims):
-        import numpy as np
+        import math
+        import random
 
-        v = np.random.normal(size=dims)
-        v /= np.linalg.norm(v)
-        return v.tolist()
+        v = [random.gauss(0, 1) for _ in range(dims)]
+        norm = math.sqrt(sum(x * x for x in v))
+        return [x / norm for x in v]
 
     def partition(self, partition_index, total_partitions):
         return self


### PR DESCRIPTION
The `_random_normalized_vector` method in `KnnParamSource` introduced a dependency on `numpy` (via `np.random.normal` + `np.linalg.norm`) that causes `ModuleNotFoundError: No module named 'numpy'` at runtime in the `search-autoscale` challenge. Although `numpy` is declared in `track.json` dependencies, Rally's worker processes fail to find it due to `~/.rally/libs` not being added to `sys.path` during worker bootstrap.

This PR replaces the numpy calls with stdlib equivalents. The replacement produces the same uniform distribution on the unit hypersphere (mathematically equivalent) and removes the external dependency entirely. `numpy` is also removed from `track.json` dependencies.

Note: `_tools/parse_documents.py` and `_tools/parse_queries.py` still use numpy. Those are offline data preparation scripts, not part of benchmark execution, so they are unaffected.