### PR TITLE
Revert "[msmarco-v2-vector] Remove numpy dependency from KnnParamSource (#1144)"

### DIFF
--- a/msmarco-v2-vector/track.json
+++ b/msmarco-v2-vector/track.json
@@ -4,7 +4,8 @@
   "version": 2,
   "description": "Benchmark for vector search with msmarco-v2 passage data",
   "dependencies": [
-    "pytrec_eval==0.5"
+    "pytrec_eval==0.5",
+    "numpy"
   ],
   "indices": [
     {

--- a/msmarco-v2-vector/track.py
+++ b/msmarco-v2-vector/track.py
@@ -114,12 +114,11 @@ class KnnParamSource:
         self.infinite = True
 
     def _random_normalized_vector(self, dims):
-        import math
-        import random
+        import numpy as np
 
-        v = [random.gauss(0, 1) for _ in range(dims)]
-        norm = math.sqrt(sum(x * x for x in v))
-        return [x / norm for x in v]
+        v = np.random.normal(size=dims)
+        v /= np.linalg.norm(v)
+        return v.tolist()
 
     def partition(self, partition_index, total_partitions):
         return self


### PR DESCRIPTION
Several [benchmarks](https://buildkite.com/elastic/elasticsearch-performance-vector-db/builds/86) failed last night with the error `ModuleNotFoundError: No module named 'numpy'`.

NumPy is a transitive dependency of `pytrec_eval` which is used to calculate recall, it may not be simple to extract the NumPy dependency.

This reverts commit 5fc9d002fe94d686677fb6f36fcea11669a5cf62.