### PR TITLE
Update bz2 with zst for elastic/logs

### DIFF
--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -699,7 +699,7 @@
         "documents": [
           {
             "target-data-stream": "logs-apache.error-default",
-            "source-file": "document-0.json.bz2",
+            "source-file": "document-0.json.zst",
             "document-count": 310000
           }
         ]

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -493,7 +493,7 @@
           {% if not i == 0 %},{% endif %}
           {
           "target-data-stream": "logs-kafka.log-default",
-          "source-file": "document-{{i}}.json.bz2",
+          "source-file": "document-{{i}}.json.zst",
           {# These "document-count" values equate to approximately 1GB of de-compressed data. #}
           "document-count": 312333
           }
@@ -508,7 +508,7 @@
           {% if not i == 0 %},{% endif %}
           {
             "target-data-stream": "logs-nginx.access-default",
-            "source-file": "document-{{i}}.json.bz2",
+            "source-file": "document-{{i}}.json.zst",
             "document-count": 277500
           }
         {% endfor %}
@@ -522,7 +522,7 @@
           {% if not i == 0 %},{% endif %}
           {
             "target-data-stream": "logs-nginx.access-default",
-            "source-file": "document-{{i}}.json.bz2",
+            "source-file": "document-{{i}}.json.zst",
             "document-count": 648000
           }
         {% endfor %}
@@ -536,7 +536,7 @@
           {% if not i == 0 %},{% endif %}
           {
             "target-data-stream": "logs-nginx.error-default",
-            "source-file": "document-{{i}}.json.bz2",
+            "source-file": "document-{{i}}.json.zst",
             "document-count": 263000
           }
         {% endfor %}
@@ -550,7 +550,7 @@
           {% if not i == 0 %},{% endif %}
           {
             "target-data-stream": "logs-nginx.error-default",
-            "source-file": "document-{{i}}.json.bz2",
+            "source-file": "document-{{i}}.json.zst",
             "document-count": 591705
           }
         {% endfor %}
@@ -564,7 +564,7 @@
             {% if not i == 0 %},{% endif %}
             {
               "target-data-stream": "logs-k8-application.log-default",
-              "source-file": "document-{{i}}.json.bz2",
+              "source-file": "document-{{i}}.json.zst",
               "document-count": 660000
             }
           {% endfor %}
@@ -578,7 +578,7 @@
             {% if not i == 0 %},{% endif %}
             {
               "target-data-stream": "logs-k8-application.log-default",
-              "source-file": "document-{{i}}.json.bz2",
+              "source-file": "document-{{i}}.json.zst",
               "document-count": 570000
             }
           {% endfor %}
@@ -590,7 +590,7 @@
         "documents": [
           {
             "target-data-stream": "logs-mysql.error-default",
-            "source-file": "document-0.json.bz2",
+            "source-file": "document-0.json.zst",
             "document-count": 86390
           }
         ]
@@ -603,7 +603,7 @@
             {% if not i == 0 %},{% endif %}
             {
               "target-data-stream": "logs-mysql.slowlog-default",
-              "source-file": "document-{{i}}.json.bz2",
+              "source-file": "document-{{i}}.json.zst",
               "document-count": 287000
             }
           {% endfor %}
@@ -617,7 +617,7 @@
             {% if not i == 0 %},{% endif %}
             {
               "target-data-stream": "logs-system.auth-default",
-              "source-file": "document-{{i}}.json.bz2",
+              "source-file": "document-{{i}}.json.zst",
               "document-count": 666666
             }
           {% endfor %}
@@ -631,7 +631,7 @@
             {% if not i == 0 %},{% endif %}
             {
               "target-data-stream": "logs-system.syslog-default",
-              "source-file": "document-{{i}}.json.bz2",
+              "source-file": "document-{{i}}.json.zst",
               "document-count": 645000
             }
           {% endfor %}
@@ -645,7 +645,7 @@
             {% if not i == 0 %},{% endif %}
             {
               "target-data-stream": "logs-system.auth-default",
-              "source-file": "document-{{i}}.json.bz2",
+              "source-file": "document-{{i}}.json.zst",
               "document-count": 880000
             }
           {% endfor %}
@@ -659,7 +659,7 @@
             {% if not i == 0 %},{% endif %}
             {
               "target-data-stream": "logs-system.syslog-default",
-              "source-file": "document-{{i}}.json.bz2",
+              "source-file": "document-{{i}}.json.zst",
               "document-count": 734450
             }
           {% endfor %}
@@ -673,7 +673,7 @@
             {% if not i == 0 %},{% endif %}
             {
               "target-data-stream": "logs-postgresql.log-default",
-              "source-file": "document-{{i}}.json.bz2",
+              "source-file": "document-{{i}}.json.zst",
               "document-count": 285400
             }
           {% endfor %}
@@ -687,7 +687,7 @@
             {% if not i == 0 %},{% endif %}
             {
               "target-data-stream": "logs-apache.access-default",
-              "source-file": "document-{{i}}.json.bz2",
+              "source-file": "document-{{i}}.json.zst",
               "document-count": 322200
             }
           {% endfor %}
@@ -699,7 +699,7 @@
         "documents": [
           {
             "target-data-stream": "logs-apache.error-default",
-            "source-file": "document-0.json.bz2",
+            "source-file": "document-0.json.zst",
             "document-count": 310000
           }
         ]
@@ -712,7 +712,7 @@
             {% if not i == 0 %},{% endif %}
             {
               "target-data-stream": "logs-redis.log-default",
-              "source-file": "document-{{i}}.json.bz2",
+              "source-file": "document-{{i}}.json.zst",
               "document-count": 343090
             }
           {% endfor %}
@@ -726,7 +726,7 @@
             {% if not i == 0 %},{% endif %}
             {
               "target-data-stream": "logs-redis.slowlog-default",
-              "source-file": "document-{{i}}.json.bz2",
+              "source-file": "document-{{i}}.json.zst",
               "document-count": 550000
             }
           {% endfor %}

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -699,7 +699,7 @@
         "documents": [
           {
             "target-data-stream": "logs-apache.error-default",
-            "source-file": "document-0.json.zst",
+            "source-file": "document-0.json.bz2",
             "document-count": 310000
           }
         ]


### PR DESCRIPTION
Change corpora files to use zst to speedup the initial setup stage.