### PR TITLE
msmacro adds retry-on-error after #1142

### DIFF
--- a/msmarco-v2-vector/challenges/default.json
+++ b/msmarco-v2-vector/challenges/default.json
@@ -41,6 +41,7 @@
           "expected-value": 0
         },
         "retries": 1440,
+        "retry-on-error": true,
         "retry-wait-period": 30,
         "include-in-reporting": false
       }
@@ -69,6 +70,7 @@
           "expected-value": 0
         },
         "retries": 1440,
+        "retry-on-error": true,
         "retry-wait-period": 30,
         "include-in-reporting": true
       }


### PR DESCRIPTION
After #1142 msmacro benchmark fails because equivalent code in [rally](https://github.com/elastic/rally/blob/master/esrally/driver/runner.py#L3336-L3344) needs
`"retry-on-error": true` to execute the specified retries. As a result of this absence, no executions are retried. 
Since this PR was intentional, in order to limit the life of msmacro, we fix that by adding this parameter in the track instead of reverting it.
