### PR TITLE
[9.4] HTTP Logs: rename ingest_pipeline to ingest_pipeline_name (#1161)

### DIFF
--- a/http_logs/README.md
+++ b/http_logs/README.md
@@ -43,8 +43,8 @@ This track allows to overwrite the following parameters with Rally 0.8.0+ using 
 * `source_enabled` (default: true): A boolean defining whether the `_source` field is stored in the index.
 * `index_settings`: A list of index settings. Index settings defined elsewhere (e.g. `number_of_replicas`) need to be overridden explicitly.
 * `cluster_health` (default: "green"): The minimum required cluster health.
-* `ingest_pipeline`: Only applicable for `--challenge=append-index-only-with-ingest-pipeline`, selects which ingest
-node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'geoip'`. For example: `--challenge=append-index-only-with-ingest-pipeline --track-params="ingest_pipeline:'baseline'" `
+* `ingest_pipeline_name`: Only applicable for `--challenge=append-index-only-with-ingest-pipeline`, selects which ingest
+node pipeline to run. Valid options are `'baseline'` (default), `'grok'`  and `'geoip'`. For example: `--challenge=append-index-only-with-ingest-pipeline --track-params="ingest_pipeline_name:'baseline'" `
 * `runtime_fields`: If defined the challenge loads the `unparsed` set of documents, indexing the `@timestamp` and the raw `message` field and the runtime fields required for the `runtime-fields` challenge.
 * `error_level` (default: "non-fatal"): Available for bulk operations only to specify ignore-response-error-level.
 * `post_ingest_sleep` (default: false): Whether to pause after ingest and prior to subsequent operations.

--- a/http_logs/challenges/default.json
+++ b/http_logs/challenges/default.json
@@ -182,11 +182,11 @@
         },
         {
           "tags": ["setup"],
-          "operation": "create-http-log-{{ingest_pipeline | default('baseline')}}-pipeline"
+          "operation": "create-http-log-{{ingest_pipeline_name | default('baseline')}}-pipeline"
         },
         {
           "tags": ["index"],
-          "operation": "index-append-with-ingest-{{ingest_pipeline | default('baseline')}}-pipeline",
+          "operation": "index-append-with-ingest-{{ingest_pipeline_name | default('baseline')}}-pipeline",
           "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}},
           "ignore-response-error-level": "{{error_level | default('non-fatal')}}"

--- a/http_logs/index.json
+++ b/http_logs/index.json
@@ -30,7 +30,7 @@
     {%- endif %}
     "properties": {
       "@timestamp": {
-        {%- if ingest_pipeline is defined and ingest_pipeline == "grok" %}
+        {%- if ingest_pipeline_name is defined and ingest_pipeline_name == "grok" %}
         "format": "strict_date_optional_time",
         {%- else %}
         "format": "epoch_second",

--- a/http_logs/track.json
+++ b/http_logs/track.json
@@ -51,7 +51,7 @@
     }
   ],
   "corpora": [
-      {%- if ingest_pipeline is defined and ingest_pipeline == "grok" or runtime_fields is defined %}
+      {%- if ingest_pipeline_name is defined and ingest_pipeline_name == "grok" or runtime_fields is defined %}
         {
           "name": "http_logs_unparsed",
           "base-url": "https://rally-tracks.elastic.co/http_logs",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.4`:
 - [HTTP Logs: rename ingest_pipeline to ingest_pipeline_name (#1161)](https://github.com/elastic/rally-tracks/pull/1161)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Grzegorz Banasiak","email":"grzegorz.banasiak@elastic.co"},"sourceCommit":{"committedDate":"2026-05-29T08:48:52Z","message":"HTTP Logs: rename ingest_pipeline to ingest_pipeline_name (#1161)","sha":"1194d47517d21cf7f4ed2fd2eaf4d18acbb9a564","branchLabelMapping":{"^v9.5$":"master","^vServerless$":"master","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.4"],"title":"HTTP Logs: rename ingest_pipeline to ingest_pipeline_name","number":1161,"url":"https://github.com/elastic/rally-tracks/pull/1161","mergeCommit":{"message":"HTTP Logs: rename ingest_pipeline to ingest_pipeline_name (#1161)","sha":"1194d47517d21cf7f4ed2fd2eaf4d18acbb9a564"}},"sourceBranch":"master","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->