### PR TITLE
Align backport target branches with existing labels

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,7 @@
 {
   "repoOwner": "elastic",
   "repoName": "rally-tracks",
-  "targetBranchChoices" : [ "master", "9.4", "9.3", "9.2", "9.1", "9.0", "8.19" ],
+  "targetBranchChoices" : [ "master", "9.4", "9.3", "9.2", "9.1", "8.19", "8.15" ],
   "targetPRLabels" : [ "backport" ],
   "branchLabelMapping" : {
     "^v9.5$" : "master",


### PR DESCRIPTION
There is no `v9.0` label, but there is `v8.15` label.