### PR TITLE
msmarco-v2-vector: use base64 corpus for parallel updates

### DIFF
--- a/msmarco-v2-vector/operations/default.json
+++ b/msmarco-v2-vector/operations/default.json
@@ -30,7 +30,7 @@
 {
   "name": "parallel-documents-indexing",
   "operation-type": "bulk",
-  "corpora": {{parallel_corpora | default("msmarco-v2_float-parallel-indexing") | tojson }},
+  "corpora": {{parallel_corpora | default("msmarco-v2_base64-parallel-indexing") | tojson }},
   "bulk-size": {{parallel_indexing_bulk_size | default(50)}},
   "ingest-percentage": {{parallel_indexing_ingest_percentage | default(100)}}
 }


### PR DESCRIPTION
Ingestion uses base64 encoding, so use the base64 variant of the parallel-indexing corpus for compatibility.