### PR TITLE
[MS MARCO] Fix autoscale schedule templates for multi-phase configurations

### DIFF
--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -131,7 +131,7 @@ For a 10 million document dataset use:
 
 The three autoscale challenges (`ingest-autoscale`, `search-autoscale`, `ingest-search-autoscale`) share the same array parameter conventions:
 
-- `as_phases` defines the number of measurement phases. All `as_*` arrays are indexed via modulo (`i % len(array)`), so a 1-element array repeats that value for every phase and an `as_phases`-element array assigns one value per phase. Per-track parameter validation is not yet supported natively by Rally; until then, mismatched array lengths wrap silently.
+- `as_phases` defines the number of measurement phases (default: 5 when neither `as_phases` nor `as_warmup_time_periods` is set; falls back to `len(as_warmup_time_periods)` when only `as_warmup_time_periods` is provided, preserving backward compatibility with existing configurations). All `as_*` arrays are indexed via modulo (`i % len(array)`), so a 1-element array repeats that value for every phase and an `as_phases`-element array assigns one value per phase. Per-track parameter validation is not yet supported natively by Rally; until then, mismatched array lengths wrap silently.
 - `as_warmup_time_periods` values of `0` are valid and mean "no warmup". They are clamped to `1` internally to satisfy Rally's schema requirement.
 - Target throughput arrays (`as_search_target_throughputs`, `as_ingest_target_throughputs`) use `-1` to mean unlimited throughput. Any positive value caps throughput in operations per second.
 
@@ -144,7 +144,7 @@ The three autoscale challenges (`ingest-autoscale`, `search-autoscale`, `ingest-
     - `initial_ingest_bulk_size` (default: 100)
 - Ingest Operations:
     - `ingest_bulk_size` (default: 100)
-    - `as_phases` (default: 5)
+    - `as_phases` (default: 5, or `len(as_warmup_time_periods)` if provided without `as_phases`)
     - `as_warmup_time_periods` (default: [600])
     - `as_time_periods` (default: [1800])
     - `as_ingest_clients` (default: [1,2,4,8,16])
@@ -162,7 +162,7 @@ When `as_ingest_target_throughputs` is a positive number, the ingest throughput 
     - `initial_ingest_bulk_size` (default: 100)
 - Search Operations:
     - `search_size` (default: 10)
-    - `as_phases` (default: 5)
+    - `as_phases` (default: 5, or `len(as_warmup_time_periods)` if provided without `as_phases`)
     - `as_warmup_time_periods` (default: [600])
     - `as_time_periods` (default: [1800])
     - `as_search_clients` (default: [1,2,4,8,16])
@@ -178,7 +178,7 @@ When `as_search_target_throughputs` is a positive number, the search throughput 
     - `initial_ingest_clients` (default: 4)
     - `initial_ingest_bulk_size` (default: 100)
 - Operations:
-    - `as_phases` (default: 5)
+    - `as_phases` (default: 5, or `len(as_warmup_time_periods)` if provided without `as_phases`)
     - `as_warmup_time_periods` (default: [600])
     - `as_time_periods` (default: [1800])
 - Ingest Operations:

--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -131,7 +131,7 @@ For a 10 million document dataset use:
 
 The three autoscale challenges (`ingest-autoscale`, `search-autoscale`, `ingest-search-autoscale`) share the same array parameter conventions:
 
-- `as_warmup_time_periods` defines the number of phases. All other `as_*` arrays wrap via modulo, so a shorter array repeats automatically. A single-element array applies that value to every phase.
+- `as_phases` defines the number of measurement phases. All `as_*` arrays are indexed via modulo (`i % len(array)`), so a 1-element array repeats that value for every phase and an `as_phases`-element array assigns one value per phase. Per-track parameter validation is not yet supported natively by Rally; until then, mismatched array lengths wrap silently.
 - `as_warmup_time_periods` values of `0` are valid and mean "no warmup". They are clamped to `1` internally to satisfy Rally's schema requirement.
 - Target throughput arrays (`as_search_target_throughputs`, `as_ingest_target_throughputs`) use `-1` to mean unlimited throughput. Any positive value caps throughput in operations per second.
 
@@ -144,10 +144,11 @@ The three autoscale challenges (`ingest-autoscale`, `search-autoscale`, `ingest-
     - `initial_ingest_bulk_size` (default: 100)
 - Ingest Operations:
     - `ingest_bulk_size` (default: 100)
-    - `as_warmup_time_periods` (default: [600,600,600,600,600])
-    - `as_time_periods` (default: [1800,1800,1800,1800,1800])
+    - `as_phases` (default: 5)
+    - `as_warmup_time_periods` (default: [600])
+    - `as_time_periods` (default: [1800])
     - `as_ingest_clients` (default: [1,2,4,8,16])
-    - `as_ingest_target_throughputs` (default: [-1,-1,-1,-1,-1])
+    - `as_ingest_target_throughputs` (default: [-1])
 
 When `as_ingest_target_throughputs` is a positive number, the ingest throughput formula in documents per second is `ingest_bulk_size * as_ingest_target_throughputs`.
 
@@ -161,10 +162,11 @@ When `as_ingest_target_throughputs` is a positive number, the ingest throughput 
     - `initial_ingest_bulk_size` (default: 100)
 - Search Operations:
     - `search_size` (default: 10)
-    - `as_warmup_time_periods` (default: [600,600,600,600,600])
-    - `as_time_periods` (default: [1800,1800,1800,1800,1800])
+    - `as_phases` (default: 5)
+    - `as_warmup_time_periods` (default: [600])
+    - `as_time_periods` (default: [1800])
     - `as_search_clients` (default: [1,2,4,8,16])
-    - `as_search_target_throughputs` (default: [-1,-1,-1,-1,-1])
+    - `as_search_target_throughputs` (default: [-1])
 
 When `as_search_target_throughputs` is a positive number, the search throughput formula in documents per second is `search_size * as_search_target_throughputs`.
 
@@ -176,16 +178,17 @@ When `as_search_target_throughputs` is a positive number, the search throughput 
     - `initial_ingest_clients` (default: 4)
     - `initial_ingest_bulk_size` (default: 100)
 - Operations:
-    - `as_warmup_time_periods` (default: [600,600,600,600,600])
-    - `as_time_periods` (default: [1800,1800,1800,1800,1800])
+    - `as_phases` (default: 5)
+    - `as_warmup_time_periods` (default: [600])
+    - `as_time_periods` (default: [1800])
 - Ingest Operations:
     - `ingest_bulk_size` (default: 100)
-    - `as_ingest_clients` (default: [1,2,4,8,16])
-    - `as_ingest_target_throughputs` (default: [-1,-1,-1,-1,-1])
+    - `as_ingest_clients` (default: [1])
+    - `as_ingest_target_throughputs` (default: [-1])
 - Search Operations:
     - `search_size` (default: 10)
     - `as_search_clients` (default: [1,2,4,8,16])
-    - `as_search_target_throughputs` (default: [-1,-1,-1,-1,-1])
+    - `as_search_target_throughputs` (default: [-1])
 
 ### Parameters for parallel-update-search challenge
 

--- a/msmarco-v2-vector/README.md
+++ b/msmarco-v2-vector/README.md
@@ -127,6 +127,14 @@ For a 10 million document dataset use:
   ],
 ```
 
+### Autoscale parameter conventions
+
+The three autoscale challenges (`ingest-autoscale`, `search-autoscale`, `ingest-search-autoscale`) share the same array parameter conventions:
+
+- `as_warmup_time_periods` defines the number of phases. All other `as_*` arrays wrap via modulo, so a shorter array repeats automatically. A single-element array applies that value to every phase.
+- `as_warmup_time_periods` values of `0` are valid and mean "no warmup". They are clamped to `1` internally to satisfy Rally's schema requirement.
+- Target throughput arrays (`as_search_target_throughputs`, `as_ingest_target_throughputs`) use `-1` to mean unlimited throughput. Any positive value caps throughput in operations per second.
+
 ### Parameters for ingest-autoscale challenge
 
 - Mapping:

--- a/msmarco-v2-vector/challenges/common/ingest-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/ingest-autoscale-schedule.json
@@ -23,7 +23,13 @@
     "ingest-percentage": {{initial_ingest_percentage | default(100) | int}}
   }
 }
-{%- set p_as_phases = (as_phases | default(5))%}
+{%- if as_phases is defined %}
+{%- set p_as_phases = as_phases %}
+{%- elif as_warmup_time_periods is defined %}
+{%- set p_as_phases = as_warmup_time_periods|length %}
+{%- else %}
+{%- set p_as_phases = 5 %}
+{%- endif %}
 {%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600]))%}
 {%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([-1]))%}
 {%- set p_as_time_periods = (as_time_periods | default([1800]))%}

--- a/msmarco-v2-vector/challenges/common/ingest-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/ingest-autoscale-schedule.json
@@ -23,12 +23,13 @@
     "ingest-percentage": {{initial_ingest_percentage | default(100) | int}}
   }
 }
-{%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600,600,600,600,600]))%}
-{%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([-1,-1,-1,-1,-1]))%}
-{%- set p_as_time_periods = (as_time_periods | default([1800,1800,1800,1800,1800]))%}
+{%- set p_as_phases = (as_phases | default(5))%}
+{%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600]))%}
+{%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([-1]))%}
+{%- set p_as_time_periods = (as_time_periods | default([1800]))%}
 {%- set p_as_ingest_clients = (as_ingest_clients | default([1,2,4,8,16]))%}
 {%- set p_ingest_bulk_size = (ingest_bulk_size | default(100))%}
-{%- for i in range(p_as_warmup_time_periods|length) %},
+{%- for i in range(p_as_phases) %},
   {%- if p_as_ingest_target_throughputs[i % (p_as_ingest_target_throughputs|length)] < 0 %}
 {
   "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i % (p_as_ingest_clients|length)]}}-b{{p_ingest_bulk_size}}",

--- a/msmarco-v2-vector/challenges/common/ingest-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/ingest-autoscale-schedule.json
@@ -28,31 +28,31 @@
 {%- set p_as_time_periods = (as_time_periods | default([1800,1800,1800,1800,1800]))%}
 {%- set p_as_ingest_clients = (as_ingest_clients | default([1,2,4,8,16]))%}
 {%- set p_ingest_bulk_size = (ingest_bulk_size | default(100))%}
-{%- for i in range(p_as_ingest_clients|length) %},
-  {%- if p_as_ingest_target_throughputs[i] < 0 %}
+{%- for i in range(p_as_warmup_time_periods|length) %},
+  {%- if p_as_ingest_target_throughputs[i % (p_as_ingest_target_throughputs|length)] < 0 %}
 {
-  "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
-  "clients": {{p_as_ingest_clients[i]}},
+  "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i % (p_as_ingest_clients|length)]}}-b{{p_ingest_bulk_size}}",
+  "clients": {{p_as_ingest_clients[i % (p_as_ingest_clients|length)]}},
   "operation": {
     "operation-type": "bulk",
     "bulk-size": {{p_ingest_bulk_size}},
     "looped": true
   },
-  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-  "time-period": {{p_as_time_periods[i]}}
+  "warmup-time-period": {{[p_as_warmup_time_periods[i % (p_as_warmup_time_periods|length)], 1]|max}},
+  "time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}}
 },
   {%- else %}
 {
-  "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
-  "clients": {{p_as_ingest_clients[i]}},
+  "name": "ingest-{{loop.index}}-c{{p_as_ingest_clients[i % (p_as_ingest_clients|length)]}}-b{{p_ingest_bulk_size}}",
+  "clients": {{p_as_ingest_clients[i % (p_as_ingest_clients|length)]}},
   "operation": {
     "operation-type": "bulk",
     "bulk-size": {{p_ingest_bulk_size}},
     "looped": true
   },
-  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-  "time-period": {{p_as_time_periods[i]}},
-  "target-throughput": {{p_as_ingest_target_throughputs[i]}}
+  "warmup-time-period": {{[p_as_warmup_time_periods[i % (p_as_warmup_time_periods|length)], 1]|max}},
+  "time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}},
+  "target-throughput": {{p_as_ingest_target_throughputs[i % (p_as_ingest_target_throughputs|length)]}}
 },
   {%- endif %}
 {

--- a/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
@@ -24,14 +24,15 @@
   }
 }
 {%- set p_vector_index_type = (vector_index_type | default("bbq_hnsw"))%}
-{%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600,600,600,600,600]))%}
-{%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([-1,-1,-1,-1,-1]))%}
-{%- set p_as_time_periods = (as_time_periods | default([1800,1800,1800,1800,1800]))%}
-{%- set p_as_ingest_clients = (as_ingest_clients | default([1,1,1,1,1]))%}
+{%- set p_as_phases = (as_phases | default(5))%}
+{%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600]))%}
+{%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([-1]))%}
+{%- set p_as_time_periods = (as_time_periods | default([1800]))%}
+{%- set p_as_ingest_clients = (as_ingest_clients | default([1]))%}
 {%- set p_ingest_bulk_size = (ingest_bulk_size | default(100))%}
 {%- set p_as_search_clients = (as_search_clients | default([1,2,4,8,16]))%}
-{%- set p_as_search_target_throughputs = (as_search_target_throughputs | default([-1,-1,-1,-1,-1]))%}
-{%- for i in range(p_as_warmup_time_periods|length) %},
+{%- set p_as_search_target_throughputs = (as_search_target_throughputs | default([-1]))%}
+{%- for i in range(p_as_phases) %},
 {
   "parallel": {
     "warmup-time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}},

--- a/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
@@ -24,7 +24,13 @@
   }
 }
 {%- set p_vector_index_type = (vector_index_type | default("bbq_hnsw"))%}
-{%- set p_as_phases = (as_phases | default(5))%}
+{%- if as_phases is defined %}
+{%- set p_as_phases = as_phases %}
+{%- elif as_warmup_time_periods is defined %}
+{%- set p_as_phases = as_warmup_time_periods|length %}
+{%- else %}
+{%- set p_as_phases = 5 %}
+{%- endif %}
 {%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600]))%}
 {%- set p_as_ingest_target_throughputs = (as_ingest_target_throughputs | default([-1]))%}
 {%- set p_as_time_periods = (as_time_periods | default([1800]))%}

--- a/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/ingest-search-autoscale-schedule.json
@@ -34,39 +34,39 @@
 {%- for i in range(p_as_warmup_time_periods|length) %},
 {
   "parallel": {
-    "warmup-time-period": {{p_as_time_periods[i]}},
-    "time-period": {{p_as_warmup_time_periods[i]}},
+    "warmup-time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}},
+    "time-period": {{[p_as_warmup_time_periods[i % (p_as_warmup_time_periods|length)], 1]|max}},
     "tasks": [
-  {%- if p_as_ingest_target_throughputs[i] < 0 %}
+  {%- if p_as_ingest_target_throughputs[i % (p_as_ingest_target_throughputs|length)] < 0 %}
       {
-        "name": "parallel-ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
-        "clients": {{p_as_ingest_clients[i]}},
+        "name": "parallel-ingest-{{loop.index}}-c{{p_as_ingest_clients[i % (p_as_ingest_clients|length)]}}-b{{p_ingest_bulk_size}}",
+        "clients": {{p_as_ingest_clients[i % (p_as_ingest_clients|length)]}},
         "operation": {
           "operation-type": "bulk",
           "bulk-size": {{p_ingest_bulk_size}},
           "looped": true
         },
-        "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-        "time-period": {{p_as_time_periods[i]}}
+        "warmup-time-period": {{[p_as_warmup_time_periods[i % (p_as_warmup_time_periods|length)], 1]|max}},
+        "time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}}
       },
   {%- else %}
   {
-    "name": "parallel-ingest-{{loop.index}}-c{{p_as_ingest_clients[i]}}-b{{p_ingest_bulk_size}}",
-    "clients": {{p_as_ingest_clients[i]}},
+    "name": "parallel-ingest-{{loop.index}}-c{{p_as_ingest_clients[i % (p_as_ingest_clients|length)]}}-b{{p_ingest_bulk_size}}",
+    "clients": {{p_as_ingest_clients[i % (p_as_ingest_clients|length)]}},
     "operation": {
       "operation-type": "bulk",
       "bulk-size": {{p_ingest_bulk_size}},
       "looped": true
     },
-    "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-    "time-period": {{p_as_time_periods[i]}},
-    "target-throughput": {{p_as_ingest_target_throughputs[i]}}
+    "warmup-time-period": {{[p_as_warmup_time_periods[i % (p_as_warmup_time_periods|length)], 1]|max}},
+    "time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}},
+    "target-throughput": {{p_as_ingest_target_throughputs[i % (p_as_ingest_target_throughputs|length)]}}
   },
   {%- endif %}
-  {%- if p_as_search_target_throughputs[i] < 0 %}
+  {%- if p_as_search_target_throughputs[i % (p_as_search_target_throughputs|length)] < 0 %}
       {
-        "name": "parallel-search-{{loop.index}}-c{{p_as_search_clients[i]}}-s10",
-        "clients": {{p_as_search_clients[i]}},
+        "name": "parallel-search-{{loop.index}}-c{{p_as_search_clients[i % (p_as_search_clients|length)]}}-s10",
+        "clients": {{p_as_search_clients[i % (p_as_search_clients|length)]}},
         "operation": {
           "operation-type": "search",
           "param-source": "knn-param-source",
@@ -79,13 +79,13 @@
           {%- endif %}
           "looped": true
         },
-        "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-        "time-period": {{p_as_time_periods[i]}}
+        "warmup-time-period": {{[p_as_warmup_time_periods[i % (p_as_warmup_time_periods|length)], 1]|max}},
+        "time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}}
       }
   {%- else %}
       {
-        "name": "parallel-search-{{loop.index}}-c{{p_as_search_clients[i]}}-s10-t{{p_as_search_target_throughputs[i]}}",
-        "clients": {{p_as_search_clients[i]}},
+        "name": "parallel-search-{{loop.index}}-c{{p_as_search_clients[i % (p_as_search_clients|length)]}}-s10-t{{p_as_search_target_throughputs[i % (p_as_search_target_throughputs|length)]}}",
+        "clients": {{p_as_search_clients[i % (p_as_search_clients|length)]}},
         "operation": {
           "operation-type": "search",
           "param-source": "knn-param-source",
@@ -98,9 +98,9 @@
           {%- endif %}
           "looped": true
         },
-        "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-        "time-period": {{p_as_time_periods[i]}},
-        "target-throughput": {{p_as_search_target_throughputs[i]}}
+        "warmup-time-period": {{[p_as_warmup_time_periods[i % (p_as_warmup_time_periods|length)], 1]|max}},
+        "time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}},
+        "target-throughput": {{p_as_search_target_throughputs[i % (p_as_search_target_throughputs|length)]}}
       }
   {%- endif %}
     ]

--- a/msmarco-v2-vector/challenges/common/search-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/search-autoscale-schedule.json
@@ -36,7 +36,13 @@
 },
 {%- endif -%}{# include-initial-indexing-marker-end #}
 {%- set p_vector_index_type = (vector_index_type | default("bbq_hnsw"))%}
-{%- set p_as_phases = (as_phases | default(5))%}
+{%- if as_phases is defined %}
+{%- set p_as_phases = as_phases %}
+{%- elif as_warmup_time_periods is defined %}
+{%- set p_as_phases = as_warmup_time_periods|length %}
+{%- else %}
+{%- set p_as_phases = 5 %}
+{%- endif %}
 {%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600]))%}
 {%- set p_as_time_periods = (as_time_periods | default([1800]))%}
 {%- set p_as_search_clients = (as_search_clients | default([1,2,4,8,16]))%}

--- a/msmarco-v2-vector/challenges/common/search-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/search-autoscale-schedule.json
@@ -36,11 +36,12 @@
 },
 {%- endif -%}{# include-initial-indexing-marker-end #}
 {%- set p_vector_index_type = (vector_index_type | default("bbq_hnsw"))%}
-{%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600,600,600,600,600]))%}
-{%- set p_as_time_periods = (as_time_periods | default([1800,1800,1800,1800,1800]))%}
+{%- set p_as_phases = (as_phases | default(5))%}
+{%- set p_as_warmup_time_periods = (as_warmup_time_periods | default([600]))%}
+{%- set p_as_time_periods = (as_time_periods | default([1800]))%}
 {%- set p_as_search_clients = (as_search_clients | default([1,2,4,8,16]))%}
-{%- set p_as_search_target_throughputs = (as_search_target_throughputs | default([-1,-1,-1,-1,-1]))%}
-{%- for i in range(p_as_warmup_time_periods|length) %}
+{%- set p_as_search_target_throughputs = (as_search_target_throughputs | default([-1]))%}
+{%- for i in range(p_as_phases) %}
   {%- if p_as_search_target_throughputs[i % (p_as_search_target_throughputs|length)] < 0 %}
 {
   "name": "search-{{loop.index}}-c{{p_as_search_clients[i % (p_as_search_clients|length)]}}-s10",

--- a/msmarco-v2-vector/challenges/common/search-autoscale-schedule.json
+++ b/msmarco-v2-vector/challenges/common/search-autoscale-schedule.json
@@ -41,10 +41,10 @@
 {%- set p_as_search_clients = (as_search_clients | default([1,2,4,8,16]))%}
 {%- set p_as_search_target_throughputs = (as_search_target_throughputs | default([-1,-1,-1,-1,-1]))%}
 {%- for i in range(p_as_warmup_time_periods|length) %}
-  {%- if p_as_search_target_throughputs[i] < 0 %}
+  {%- if p_as_search_target_throughputs[i % (p_as_search_target_throughputs|length)] < 0 %}
 {
-  "name": "search-{{loop.index}}-c{{p_as_search_clients[i]}}-s10",
-  "clients": {{p_as_search_clients[i]}},
+  "name": "search-{{loop.index}}-c{{p_as_search_clients[i % (p_as_search_clients|length)]}}-s10",
+  "clients": {{p_as_search_clients[i % (p_as_search_clients|length)]}},
   "operation": {
     "operation-type": "search",
     "param-source": "knn-param-source",
@@ -60,12 +60,12 @@
     {%- endif %}
     "looped": true
   },
-  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-  "time-period": {{p_as_time_periods[i]}}
+  "warmup-time-period": {{[p_as_warmup_time_periods[i % (p_as_warmup_time_periods|length)], 1]|max}},
+  "time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}}
 },
 {
-  "name": "search-{{loop.index}}-c{{p_as_search_clients[i]}}-s100",
-  "clients": {{p_as_search_clients[i]}},
+  "name": "search-{{loop.index}}-c{{p_as_search_clients[i % (p_as_search_clients|length)]}}-s100",
+  "clients": {{p_as_search_clients[i % (p_as_search_clients|length)]}},
   "operation": {
     "operation-type": "search",
     "param-source": "knn-param-source",
@@ -81,13 +81,13 @@
     {%- endif %}
     "looped": true
   },
-  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-  "time-period": {{p_as_time_periods[i]}}
+  "warmup-time-period": {{[p_as_warmup_time_periods[i % (p_as_warmup_time_periods|length)], 1]|max}},
+  "time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}}
 }
   {%- else %}
 {
-  "name": "search-{{loop.index}}-c{{p_as_search_clients[i]}}-s10-t{{p_as_search_target_throughputs[i]}}",
-  "clients": {{p_as_search_clients[i]}},
+  "name": "search-{{loop.index}}-c{{p_as_search_clients[i % (p_as_search_clients|length)]}}-s10-t{{p_as_search_target_throughputs[i % (p_as_search_target_throughputs|length)]}}",
+  "clients": {{p_as_search_clients[i % (p_as_search_clients|length)]}},
   "operation": {
     "operation-type": "search",
     "param-source": "knn-param-source",
@@ -103,13 +103,13 @@
     {%- endif %}
     "looped": true
   },
-  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-  "time-period": {{p_as_time_periods[i]}},
-  "target-throughput": {{p_as_search_target_throughputs[i]}}
+  "warmup-time-period": {{[p_as_warmup_time_periods[i % (p_as_warmup_time_periods|length)], 1]|max}},
+  "time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}},
+  "target-throughput": {{p_as_search_target_throughputs[i % (p_as_search_target_throughputs|length)]}}
 },
 {
-  "name": "search-{{loop.index}}-c{{p_as_search_clients[i]}}-s100-t{{p_as_search_target_throughputs[i]}}",
-  "clients": {{p_as_search_clients[i]}},
+  "name": "search-{{loop.index}}-c{{p_as_search_clients[i % (p_as_search_clients|length)]}}-s100-t{{p_as_search_target_throughputs[i % (p_as_search_target_throughputs|length)]}}",
+  "clients": {{p_as_search_clients[i % (p_as_search_clients|length)]}},
   "operation": {
     "operation-type": "search",
     "param-source": "knn-param-source",
@@ -125,9 +125,9 @@
     {%- endif %}
     "looped": true
   },
-  "warmup-time-period": {{p_as_warmup_time_periods[i]}},
-  "time-period": {{p_as_time_periods[i]}},
-  "target-throughput": {{p_as_search_target_throughputs[i]}}
+  "warmup-time-period": {{[p_as_warmup_time_periods[i % (p_as_warmup_time_periods|length)], 1]|max}},
+  "time-period": {{p_as_time_periods[i % (p_as_time_periods|length)]}},
+  "target-throughput": {{p_as_search_target_throughputs[i % (p_as_search_target_throughputs|length)]}}
 }
   {%- endif %}
   {%- if not loop.last %},{%- endif %}

--- a/msmarco-v2-vector/tests/test_autoscale_schedule.py
+++ b/msmarco-v2-vector/tests/test_autoscale_schedule.py
@@ -19,7 +19,6 @@ import json
 import pathlib
 
 import jinja2
-import pytest
 
 COMMON_DIR = pathlib.Path(__file__).parents[1] / "challenges" / "common"
 
@@ -54,16 +53,31 @@ class TestSearchAutoscaleSchedule:
         # 5 default phases × 2 query sizes (k=10, k=100) = 10 steps
         assert len(steps) == 10
 
-    def test_phase_count_driven_by_warmup_array(self):
-        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0]})
+    def test_default_single_element_warmup_repeats(self):
+        # Template default as_warmup_time_periods=[600] applies to all 5 phases
+        steps = render_search()
+        assert all(s["warmup-time-period"] == 600 for s in steps)
+
+    def test_default_single_element_time_period_repeats(self):
+        # Template default as_time_periods=[1800] applies to all 5 phases
+        steps = render_search()
+        assert all(s["time-period"] == 1800 for s in steps)
+
+    def test_default_single_element_throughput_is_unlimited(self):
+        # Template default as_search_target_throughputs=[-1] means no throttle
+        steps = render_search()
+        assert all("target-throughput" not in s for s in steps)
+
+    def test_phase_count_driven_by_as_phases(self):
+        steps = render_search({"as_phases": 4, "as_search_clients": [1]})
         assert len(steps) == 8  # 4 phases × 2 query sizes
 
     def test_warmup_zero_clamped_to_one(self):
-        steps = render_search({"as_warmup_time_periods": [0, 0, 0]})
+        steps = render_search({"as_phases": 3, "as_warmup_time_periods": [0], "as_search_clients": [1]})
         assert all(s["warmup-time-period"] == 1 for s in steps)
 
     def test_warmup_positive_value_preserved(self):
-        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0]})
+        steps = render_search({"as_phases": 4, "as_warmup_time_periods": [30, 0, 0, 0], "as_search_clients": [1]})
         # first phase (2 steps: s10 and s100) should keep warmup=30
         assert steps[0]["warmup-time-period"] == 30
         assert steps[1]["warmup-time-period"] == 30
@@ -71,17 +85,18 @@ class TestSearchAutoscaleSchedule:
         assert all(s["warmup-time-period"] == 1 for s in steps[2:])
 
     def test_single_element_time_periods_repeats(self):
-        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [1800]})
+        steps = render_search({"as_phases": 4, "as_search_clients": [1], "as_time_periods": [1800]})
         assert all(s["time-period"] == 1800 for s in steps)
 
     def test_single_element_clients_repeats(self):
-        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_search_clients": [8]})
+        steps = render_search({"as_phases": 4, "as_search_clients": [8]})
         assert all(s["clients"] == 8 for s in steps)
 
     def test_target_throughput_applied_when_positive(self):
         steps = render_search(
             {
-                "as_warmup_time_periods": [30, 0, 0, 0],
+                "as_phases": 4,
+                "as_search_clients": [1],
                 "as_search_target_throughputs": [500, 2500, 500, 2500],
             }
         )
@@ -93,7 +108,8 @@ class TestSearchAutoscaleSchedule:
     def test_single_element_throughput_repeats(self):
         steps = render_search(
             {
-                "as_warmup_time_periods": [30, 0, 0, 0],
+                "as_phases": 4,
+                "as_search_clients": [1],
                 "as_search_target_throughputs": [1000],
             }
         )
@@ -102,31 +118,13 @@ class TestSearchAutoscaleSchedule:
     def test_minimal_multi_phase_override(self):
         steps = render_search(
             {
-                "as_warmup_time_periods": [30, 0, 0, 0],
+                "as_phases": 4,
+                "as_search_clients": [1],
                 "as_search_target_throughputs": [500, 2500, 500, 2500],
             }
         )
         assert len(steps) == 8
         assert all(s["warmup-time-period"] >= 1 for s in steps)
-
-    def test_two_element_clients_roundrobin_across_four_phases(self):
-        # [1, 8] over 4 phases → clients per phase: 1, 8, 1, 8
-        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_search_clients": [1, 8]})
-        # each phase produces 2 steps (s10 and s100)
-        phase_clients = [steps[i * 2]["clients"] for i in range(4)]
-        assert phase_clients == [1, 8, 1, 8]
-
-    def test_two_element_time_periods_roundrobin_across_four_phases(self):
-        # [900, 1800] over 4 phases → time-period per phase: 900, 1800, 900, 1800
-        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [900, 1800]})
-        phase_time_periods = [steps[i * 2]["time-period"] for i in range(4)]
-        assert phase_time_periods == [900, 1800, 900, 1800]
-
-    def test_two_element_throughput_roundrobin_across_four_phases(self):
-        # [500, 2500] over 4 phases → target-throughput per phase: 500, 2500, 500, 2500
-        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_search_target_throughputs": [500, 2500]})
-        phase_throughputs = [steps[i * 2]["target-throughput"] for i in range(4)]
-        assert phase_throughputs == [500, 2500, 500, 2500]
 
 
 # --- ingest-search-autoscale-schedule.json ---
@@ -147,41 +145,48 @@ class TestIngestSearchAutoscaleSchedule:
         items = render_ingest_search()
         assert len(items) == INGEST_HEADER_STEPS + 5
 
-    def test_phase_count_driven_by_warmup_array(self):
-        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0]})
+    def test_default_single_element_ingest_clients_repeats(self):
+        # Template default as_ingest_clients=[1] applies to all 5 phases
+        items = render_ingest_search()
+        ingest_tasks = [t for t in all_tasks(items) if "bulk" in t["operation"]["operation-type"]]
+        assert all(t["clients"] == 1 for t in ingest_tasks)
+
+    def test_phase_count_driven_by_as_phases(self):
+        items = render_ingest_search({"as_phases": 4, "as_search_clients": [1]})
         assert len(parallel_steps(items)) == 4
 
     def test_task_warmup_zero_clamped_to_one(self):
-        items = render_ingest_search({"as_warmup_time_periods": [0, 0, 0]})
+        items = render_ingest_search({"as_phases": 3, "as_warmup_time_periods": [0], "as_search_clients": [1]})
         for task in all_tasks(items):
             assert task["warmup-time-period"] >= 1
 
     def test_task_warmup_positive_value_preserved(self):
-        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0]})
+        items = render_ingest_search({"as_phases": 4, "as_warmup_time_periods": [30, 0, 0, 0], "as_search_clients": [1]})
         first_phase_tasks = parallel_steps(items)[0]["parallel"]["tasks"]
         assert all(t["warmup-time-period"] == 30 for t in first_phase_tasks)
         for task in all_tasks(items)[len(first_phase_tasks) :]:
             assert task["warmup-time-period"] == 1
 
     def test_single_element_time_periods_repeats(self):
-        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [900]})
+        items = render_ingest_search({"as_phases": 4, "as_search_clients": [1], "as_time_periods": [900]})
         for task in all_tasks(items):
             assert task["time-period"] == 900
 
     def test_single_element_ingest_clients_repeats(self):
-        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_clients": [4]})
+        items = render_ingest_search({"as_phases": 4, "as_search_clients": [1], "as_ingest_clients": [4]})
         ingest_tasks = [t for t in all_tasks(items) if "bulk" in t["operation"]["operation-type"]]
         assert all(t["clients"] == 4 for t in ingest_tasks)
 
     def test_single_element_search_clients_repeats(self):
-        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_search_clients": [8]})
+        items = render_ingest_search({"as_phases": 4, "as_search_clients": [8]})
         search_tasks = [t for t in all_tasks(items) if t["operation"]["operation-type"] == "search"]
         assert all(t["clients"] == 8 for t in search_tasks)
 
     def test_search_target_throughput_applied_when_positive(self):
         items = render_ingest_search(
             {
-                "as_warmup_time_periods": [30, 0],
+                "as_phases": 2,
+                "as_search_clients": [1],
                 "as_search_target_throughputs": [500, 2500],
             }
         )
@@ -193,7 +198,8 @@ class TestIngestSearchAutoscaleSchedule:
     def test_ingest_target_throughput_applied_when_positive(self):
         items = render_ingest_search(
             {
-                "as_warmup_time_periods": [30, 0],
+                "as_phases": 2,
+                "as_search_clients": [1],
                 "as_ingest_target_throughputs": [200, 400],
             }
         )
@@ -202,29 +208,10 @@ class TestIngestSearchAutoscaleSchedule:
         assert ingest_tasks[0]["target-throughput"] == 200
         assert ingest_tasks[1]["target-throughput"] == 400
 
-    def test_two_element_search_clients_roundrobin_across_four_phases(self):
-        # [1, 8] over 4 phases → search clients per phase: 1, 8, 1, 8
-        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_search_clients": [1, 8]})
-        search_tasks = [t for t in all_tasks(items) if t["operation"]["operation-type"] == "search"]
-        assert [t["clients"] for t in search_tasks] == [1, 8, 1, 8]
-
-    def test_two_element_ingest_clients_roundrobin_across_four_phases(self):
-        # [2, 4] over 4 phases → ingest clients per phase: 2, 4, 2, 4
-        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_clients": [2, 4]})
-        ingest_tasks = [t for t in all_tasks(items) if t["operation"]["operation-type"] == "bulk"]
-        assert [t["clients"] for t in ingest_tasks] == [2, 4, 2, 4]
-
-    def test_two_element_time_periods_roundrobin_across_four_phases(self):
-        # [900, 1800] over 4 phases → time-period per phase: 900, 1800, 900, 1800
-        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [900, 1800]})
-        # all tasks in a phase share the same time-period; sample the search task per phase
-        search_tasks = [t for t in all_tasks(items) if t["operation"]["operation-type"] == "search"]
-        assert [t["time-period"] for t in search_tasks] == [900, 1800, 900, 1800]
-
 
 # --- ingest-autoscale-schedule.json ---
 
-INGEST_HEADER_STEPS = 4  # delete-index, create-index, check-cluster-health, initial-ingest
+INGEST_ONLY_HEADER_STEPS = 4  # delete-index, create-index, check-cluster-health, initial-ingest
 
 
 def ingest_phase_steps(items):
@@ -242,48 +229,42 @@ class TestIngestAutoscaleSchedule:
         items = render_ingest()
         assert len(ingest_phase_steps(items)) == 5
 
-    def test_phase_count_driven_by_warmup_array(self):
-        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0]})
+    def test_default_single_element_time_period_repeats(self):
+        # Template default as_time_periods=[1800] applies to all 5 phases
+        items = render_ingest()
+        assert all(s["time-period"] == 1800 for s in ingest_phase_steps(items))
+
+    def test_default_single_element_throughput_is_unlimited(self):
+        # Template default as_ingest_target_throughputs=[-1] means no throttle
+        items = render_ingest()
+        assert all("target-throughput" not in s for s in ingest_phase_steps(items))
+
+    def test_phase_count_driven_by_as_phases(self):
+        items = render_ingest({"as_phases": 4, "as_ingest_clients": [1]})
         assert len(ingest_phase_steps(items)) == 4
 
     def test_warmup_zero_clamped_to_one(self):
-        items = render_ingest({"as_warmup_time_periods": [0, 0, 0]})
+        items = render_ingest({"as_phases": 3, "as_warmup_time_periods": [0], "as_ingest_clients": [1]})
         for step in ingest_phase_steps(items):
             assert step["warmup-time-period"] >= 1
 
     def test_warmup_positive_value_preserved(self):
-        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0]})
+        items = render_ingest({"as_phases": 4, "as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_clients": [1]})
         steps = ingest_phase_steps(items)
         assert steps[0]["warmup-time-period"] == 30
         assert all(s["warmup-time-period"] == 1 for s in steps[1:])
 
     def test_single_element_clients_repeats(self):
-        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_clients": [4]})
+        items = render_ingest({"as_phases": 4, "as_ingest_clients": [4]})
         assert all(s["clients"] == 4 for s in ingest_phase_steps(items))
 
     def test_single_element_time_periods_repeats(self):
-        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [900]})
+        items = render_ingest({"as_phases": 4, "as_ingest_clients": [1], "as_time_periods": [900]})
         assert all(s["time-period"] == 900 for s in ingest_phase_steps(items))
 
     def test_target_throughput_applied_when_positive(self):
-        items = render_ingest({"as_warmup_time_periods": [30, 0], "as_ingest_target_throughputs": [200, 400]})
+        items = render_ingest({"as_phases": 2, "as_ingest_clients": [1], "as_ingest_target_throughputs": [200, 400]})
         steps = ingest_phase_steps(items)
         assert all("target-throughput" in s for s in steps)
         assert steps[0]["target-throughput"] == 200
         assert steps[1]["target-throughput"] == 400
-
-    def test_two_element_clients_roundrobin_across_four_phases(self):
-        # [2, 4] over 4 phases → clients per phase: 2, 4, 2, 4
-        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_clients": [2, 4]})
-        assert [s["clients"] for s in ingest_phase_steps(items)] == [2, 4, 2, 4]
-
-    def test_two_element_time_periods_roundrobin_across_four_phases(self):
-        # [900, 1800] over 4 phases → time-period per phase: 900, 1800, 900, 1800
-        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [900, 1800]})
-        assert [s["time-period"] for s in ingest_phase_steps(items)] == [900, 1800, 900, 1800]
-
-    def test_two_element_throughput_roundrobin_across_four_phases(self):
-        # [200, 400] over 4 phases → target-throughput per phase: 200, 400, 200, 400
-        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_target_throughputs": [200, 400]})
-        steps = ingest_phase_steps(items)
-        assert [s["target-throughput"] for s in steps] == [200, 400, 200, 400]

--- a/msmarco-v2-vector/tests/test_autoscale_schedule.py
+++ b/msmarco-v2-vector/tests/test_autoscale_schedule.py
@@ -1,0 +1,292 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import pathlib
+
+import jinja2
+import pytest
+
+COMMON_DIR = pathlib.Path(__file__).parents[1] / "challenges" / "common"
+
+
+def render(template_name, params):
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(COMMON_DIR)))
+    rendered = env.get_template(template_name).render(**params)
+    return json.loads(f"[{rendered}]")
+
+
+def render_search(params=None):
+    base = {"include_initial_indexing": False}
+    if params:
+        base.update(params)
+    return render("search-autoscale-schedule.json", base)
+
+
+def render_ingest_search(params=None):
+    return render("ingest-search-autoscale-schedule.json", params or {})
+
+
+def render_ingest(params=None):
+    return render("ingest-autoscale-schedule.json", params or {})
+
+
+# --- search-autoscale-schedule.json ---
+
+
+class TestSearchAutoscaleSchedule:
+    def test_default_params_five_phases(self):
+        steps = render_search()
+        # 5 default phases × 2 query sizes (k=10, k=100) = 10 steps
+        assert len(steps) == 10
+
+    def test_phase_count_driven_by_warmup_array(self):
+        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0]})
+        assert len(steps) == 8  # 4 phases × 2 query sizes
+
+    def test_warmup_zero_clamped_to_one(self):
+        steps = render_search({"as_warmup_time_periods": [0, 0, 0]})
+        assert all(s["warmup-time-period"] == 1 for s in steps)
+
+    def test_warmup_positive_value_preserved(self):
+        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0]})
+        # first phase (2 steps: s10 and s100) should keep warmup=30
+        assert steps[0]["warmup-time-period"] == 30
+        assert steps[1]["warmup-time-period"] == 30
+        # remaining phases clamped to 1
+        assert all(s["warmup-time-period"] == 1 for s in steps[2:])
+
+    def test_single_element_time_periods_repeats(self):
+        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [1800]})
+        assert all(s["time-period"] == 1800 for s in steps)
+
+    def test_single_element_clients_repeats(self):
+        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_search_clients": [8]})
+        assert all(s["clients"] == 8 for s in steps)
+
+    def test_target_throughput_applied_when_positive(self):
+        steps = render_search(
+            {
+                "as_warmup_time_periods": [30, 0, 0, 0],
+                "as_search_target_throughputs": [500, 2500, 500, 2500],
+            }
+        )
+        assert all("target-throughput" in s for s in steps)
+        # phase 0 → 500, phase 1 → 2500 (each phase produces 2 steps)
+        assert steps[0]["target-throughput"] == 500
+        assert steps[2]["target-throughput"] == 2500
+
+    def test_single_element_throughput_repeats(self):
+        steps = render_search(
+            {
+                "as_warmup_time_periods": [30, 0, 0, 0],
+                "as_search_target_throughputs": [1000],
+            }
+        )
+        assert all(s.get("target-throughput") == 1000 for s in steps)
+
+    def test_minimal_multi_phase_override(self):
+        steps = render_search(
+            {
+                "as_warmup_time_periods": [30, 0, 0, 0],
+                "as_search_target_throughputs": [500, 2500, 500, 2500],
+            }
+        )
+        assert len(steps) == 8
+        assert all(s["warmup-time-period"] >= 1 for s in steps)
+
+    def test_two_element_clients_roundrobin_across_four_phases(self):
+        # [1, 8] over 4 phases → clients per phase: 1, 8, 1, 8
+        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_search_clients": [1, 8]})
+        # each phase produces 2 steps (s10 and s100)
+        phase_clients = [steps[i * 2]["clients"] for i in range(4)]
+        assert phase_clients == [1, 8, 1, 8]
+
+    def test_two_element_time_periods_roundrobin_across_four_phases(self):
+        # [900, 1800] over 4 phases → time-period per phase: 900, 1800, 900, 1800
+        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [900, 1800]})
+        phase_time_periods = [steps[i * 2]["time-period"] for i in range(4)]
+        assert phase_time_periods == [900, 1800, 900, 1800]
+
+    def test_two_element_throughput_roundrobin_across_four_phases(self):
+        # [500, 2500] over 4 phases → target-throughput per phase: 500, 2500, 500, 2500
+        steps = render_search(
+            {"as_warmup_time_periods": [30, 0, 0, 0], "as_search_target_throughputs": [500, 2500]}
+        )
+        phase_throughputs = [steps[i * 2]["target-throughput"] for i in range(4)]
+        assert phase_throughputs == [500, 2500, 500, 2500]
+
+
+# --- ingest-search-autoscale-schedule.json ---
+
+INGEST_HEADER_STEPS = 4  # delete-index, create-index, check-cluster-health, initial-ingest
+
+
+def parallel_steps(items):
+    return [item for item in items if "parallel" in item]
+
+
+def all_tasks(items):
+    return [task for item in parallel_steps(items) for task in item["parallel"]["tasks"]]
+
+
+class TestIngestSearchAutoscaleSchedule:
+    def test_default_params_five_phases(self):
+        items = render_ingest_search()
+        assert len(items) == INGEST_HEADER_STEPS + 5
+
+    def test_phase_count_driven_by_warmup_array(self):
+        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0]})
+        assert len(parallel_steps(items)) == 4
+
+    def test_task_warmup_zero_clamped_to_one(self):
+        items = render_ingest_search({"as_warmup_time_periods": [0, 0, 0]})
+        for task in all_tasks(items):
+            assert task["warmup-time-period"] >= 1
+
+    def test_task_warmup_positive_value_preserved(self):
+        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0]})
+        first_phase_tasks = parallel_steps(items)[0]["parallel"]["tasks"]
+        assert all(t["warmup-time-period"] == 30 for t in first_phase_tasks)
+        for task in all_tasks(items)[len(first_phase_tasks) :]:
+            assert task["warmup-time-period"] == 1
+
+    def test_single_element_time_periods_repeats(self):
+        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [900]})
+        for task in all_tasks(items):
+            assert task["time-period"] == 900
+
+    def test_single_element_ingest_clients_repeats(self):
+        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_clients": [4]})
+        ingest_tasks = [t for t in all_tasks(items) if "bulk" in t["operation"]["operation-type"]]
+        assert all(t["clients"] == 4 for t in ingest_tasks)
+
+    def test_single_element_search_clients_repeats(self):
+        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_search_clients": [8]})
+        search_tasks = [t for t in all_tasks(items) if t["operation"]["operation-type"] == "search"]
+        assert all(t["clients"] == 8 for t in search_tasks)
+
+    def test_search_target_throughput_applied_when_positive(self):
+        items = render_ingest_search(
+            {
+                "as_warmup_time_periods": [30, 0],
+                "as_search_target_throughputs": [500, 2500],
+            }
+        )
+        search_tasks = [t for t in all_tasks(items) if t["operation"]["operation-type"] == "search"]
+        assert all("target-throughput" in t for t in search_tasks)
+        assert search_tasks[0]["target-throughput"] == 500
+        assert search_tasks[1]["target-throughput"] == 2500
+
+    def test_ingest_target_throughput_applied_when_positive(self):
+        items = render_ingest_search(
+            {
+                "as_warmup_time_periods": [30, 0],
+                "as_ingest_target_throughputs": [200, 400],
+            }
+        )
+        ingest_tasks = [t for t in all_tasks(items) if "bulk" in t["operation"]["operation-type"]]
+        assert all("target-throughput" in t for t in ingest_tasks)
+        assert ingest_tasks[0]["target-throughput"] == 200
+        assert ingest_tasks[1]["target-throughput"] == 400
+
+    def test_two_element_search_clients_roundrobin_across_four_phases(self):
+        # [1, 8] over 4 phases → search clients per phase: 1, 8, 1, 8
+        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_search_clients": [1, 8]})
+        search_tasks = [t for t in all_tasks(items) if t["operation"]["operation-type"] == "search"]
+        assert [t["clients"] for t in search_tasks] == [1, 8, 1, 8]
+
+    def test_two_element_ingest_clients_roundrobin_across_four_phases(self):
+        # [2, 4] over 4 phases → ingest clients per phase: 2, 4, 2, 4
+        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_clients": [2, 4]})
+        ingest_tasks = [t for t in all_tasks(items) if t["operation"]["operation-type"] == "bulk"]
+        assert [t["clients"] for t in ingest_tasks] == [2, 4, 2, 4]
+
+    def test_two_element_time_periods_roundrobin_across_four_phases(self):
+        # [900, 1800] over 4 phases → time-period per phase: 900, 1800, 900, 1800
+        items = render_ingest_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [900, 1800]})
+        # all tasks in a phase share the same time-period; sample the search task per phase
+        search_tasks = [t for t in all_tasks(items) if t["operation"]["operation-type"] == "search"]
+        assert [t["time-period"] for t in search_tasks] == [900, 1800, 900, 1800]
+
+
+# --- ingest-autoscale-schedule.json ---
+
+INGEST_HEADER_STEPS = 4  # delete-index, create-index, check-cluster-health, initial-ingest
+
+
+def ingest_phase_steps(items):
+    return [
+        item for item in items
+        if isinstance(item.get("operation"), dict)
+        and item["operation"].get("operation-type") == "bulk"
+        and "warmup-time-period" in item  # excludes the initial-ingest step
+    ]
+
+
+class TestIngestAutoscaleSchedule:
+    def test_default_params_five_phases(self):
+        items = render_ingest()
+        assert len(ingest_phase_steps(items)) == 5
+
+    def test_phase_count_driven_by_warmup_array(self):
+        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0]})
+        assert len(ingest_phase_steps(items)) == 4
+
+    def test_warmup_zero_clamped_to_one(self):
+        items = render_ingest({"as_warmup_time_periods": [0, 0, 0]})
+        for step in ingest_phase_steps(items):
+            assert step["warmup-time-period"] >= 1
+
+    def test_warmup_positive_value_preserved(self):
+        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0]})
+        steps = ingest_phase_steps(items)
+        assert steps[0]["warmup-time-period"] == 30
+        assert all(s["warmup-time-period"] == 1 for s in steps[1:])
+
+    def test_single_element_clients_repeats(self):
+        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_clients": [4]})
+        assert all(s["clients"] == 4 for s in ingest_phase_steps(items))
+
+    def test_single_element_time_periods_repeats(self):
+        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [900]})
+        assert all(s["time-period"] == 900 for s in ingest_phase_steps(items))
+
+    def test_target_throughput_applied_when_positive(self):
+        items = render_ingest({"as_warmup_time_periods": [30, 0], "as_ingest_target_throughputs": [200, 400]})
+        steps = ingest_phase_steps(items)
+        assert all("target-throughput" in s for s in steps)
+        assert steps[0]["target-throughput"] == 200
+        assert steps[1]["target-throughput"] == 400
+
+    def test_two_element_clients_roundrobin_across_four_phases(self):
+        # [2, 4] over 4 phases → clients per phase: 2, 4, 2, 4
+        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_clients": [2, 4]})
+        assert [s["clients"] for s in ingest_phase_steps(items)] == [2, 4, 2, 4]
+
+    def test_two_element_time_periods_roundrobin_across_four_phases(self):
+        # [900, 1800] over 4 phases → time-period per phase: 900, 1800, 900, 1800
+        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0], "as_time_periods": [900, 1800]})
+        assert [s["time-period"] for s in ingest_phase_steps(items)] == [900, 1800, 900, 1800]
+
+    def test_two_element_throughput_roundrobin_across_four_phases(self):
+        # [200, 400] over 4 phases → target-throughput per phase: 200, 400, 200, 400
+        items = render_ingest(
+            {"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_target_throughputs": [200, 400]}
+        )
+        steps = ingest_phase_steps(items)
+        assert [s["target-throughput"] for s in steps] == [200, 400, 200, 400]

--- a/msmarco-v2-vector/tests/test_autoscale_schedule.py
+++ b/msmarco-v2-vector/tests/test_autoscale_schedule.py
@@ -124,9 +124,7 @@ class TestSearchAutoscaleSchedule:
 
     def test_two_element_throughput_roundrobin_across_four_phases(self):
         # [500, 2500] over 4 phases → target-throughput per phase: 500, 2500, 500, 2500
-        steps = render_search(
-            {"as_warmup_time_periods": [30, 0, 0, 0], "as_search_target_throughputs": [500, 2500]}
-        )
+        steps = render_search({"as_warmup_time_periods": [30, 0, 0, 0], "as_search_target_throughputs": [500, 2500]})
         phase_throughputs = [steps[i * 2]["target-throughput"] for i in range(4)]
         assert phase_throughputs == [500, 2500, 500, 2500]
 
@@ -231,7 +229,8 @@ INGEST_HEADER_STEPS = 4  # delete-index, create-index, check-cluster-health, ini
 
 def ingest_phase_steps(items):
     return [
-        item for item in items
+        item
+        for item in items
         if isinstance(item.get("operation"), dict)
         and item["operation"].get("operation-type") == "bulk"
         and "warmup-time-period" in item  # excludes the initial-ingest step
@@ -285,8 +284,6 @@ class TestIngestAutoscaleSchedule:
 
     def test_two_element_throughput_roundrobin_across_four_phases(self):
         # [200, 400] over 4 phases → target-throughput per phase: 200, 400, 200, 400
-        items = render_ingest(
-            {"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_target_throughputs": [200, 400]}
-        )
+        items = render_ingest({"as_warmup_time_periods": [30, 0, 0, 0], "as_ingest_target_throughputs": [200, 400]})
         steps = ingest_phase_steps(items)
         assert [s["target-throughput"] for s in steps] == [200, 400, 200, 400]

--- a/msmarco-v2-vector/tests/test_autoscale_schedule.py
+++ b/msmarco-v2-vector/tests/test_autoscale_schedule.py
@@ -84,6 +84,11 @@ class TestSearchAutoscaleSchedule:
         # remaining phases clamped to 1
         assert all(s["warmup-time-period"] == 1 for s in steps[2:])
 
+    def test_as_warmup_time_periods_drives_phases_when_as_phases_absent(self):
+        # backward compat: existing configs that pass as_warmup_time_periods without as_phases
+        steps = render_search({"as_warmup_time_periods": [1200], "as_search_clients": [1000], "as_search_target_throughputs": [1000]})
+        assert len(steps) == 2  # 1 phase × 2 query sizes
+
     def test_single_element_time_periods_repeats(self):
         steps = render_search({"as_phases": 4, "as_search_clients": [1], "as_time_periods": [1800]})
         assert all(s["time-period"] == 1800 for s in steps)
@@ -166,6 +171,11 @@ class TestIngestSearchAutoscaleSchedule:
         assert all(t["warmup-time-period"] == 30 for t in first_phase_tasks)
         for task in all_tasks(items)[len(first_phase_tasks) :]:
             assert task["warmup-time-period"] == 1
+
+    def test_as_warmup_time_periods_drives_phases_when_as_phases_absent(self):
+        # backward compat: as_warmup_time_periods length sets phase count when as_phases is not given
+        items = render_ingest_search({"as_warmup_time_periods": [1200], "as_search_clients": [1000]})
+        assert len(parallel_steps(items)) == 1
 
     def test_single_element_time_periods_repeats(self):
         items = render_ingest_search({"as_phases": 4, "as_search_clients": [1], "as_time_periods": [900]})
@@ -253,6 +263,11 @@ class TestIngestAutoscaleSchedule:
         steps = ingest_phase_steps(items)
         assert steps[0]["warmup-time-period"] == 30
         assert all(s["warmup-time-period"] == 1 for s in steps[1:])
+
+    def test_as_warmup_time_periods_drives_phases_when_as_phases_absent(self):
+        # backward compat: as_warmup_time_periods length sets phase count when as_phases is not given
+        items = render_ingest({"as_warmup_time_periods": [1200], "as_ingest_clients": [1]})
+        assert len(ingest_phase_steps(items)) == 1
 
     def test_single_element_clients_repeats(self):
         items = render_ingest({"as_phases": 4, "as_ingest_clients": [4]})


### PR DESCRIPTION
All `as_*` parameters in the three autoscale schedule templates (search-autoscale, ingest-autoscale, ingest-search-autoscale) now use modulo indexing so shorter arrays repeat automatically across phases. A single-element array applies that value to every phase.

`warmup-time-period` values are clamped to a minimum of 1 to prevent Rally validation errors when users pass 0 to mean "no warmup".

`ingest-autoscale-schedule.json` loop driver was also aligned to `as_warmup_time_periods` for consistency with the other two templates.

Tests were added covering all three templates and README updated with shared autoscale parameter conventions.