### PR TITLE
Add `index.mode` and `index.mapping.source.mode` configuration to big5

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -88,5 +88,5 @@ The following parameters are available:
 * `warmup_iterations` (default: 100) - Number of iterations that each client should execute to warmup the benchmark candidate.
 * `iterations` (default: 1000) - Number of measurement iterations that each client executes.
 * `query_clients` (default: 1) - Number of clients issuing queries in parallel. Applies to the `big5-esql` challenge only; ignored by the default Big5 QueryDSL challenge.
-* `index_mode` (default: standard) - Index mode to use for the data.
+* `index_mode` (default: null, which means logsdb will be used since the data matches `logs-*-*`) - Index mode to use for the data.
 * `mapping_source_mode` (default: null, which means to use the index mode's default) - Index mapping source mode for data.

--- a/big5/README.md
+++ b/big5/README.md
@@ -88,3 +88,5 @@ The following parameters are available:
 * `warmup_iterations` (default: 100) - Number of iterations that each client should execute to warmup the benchmark candidate.
 * `iterations` (default: 1000) - Number of measurement iterations that each client executes.
 * `query_clients` (default: 1) - Number of clients issuing queries in parallel. Applies to the `big5-esql` challenge only; ignored by the default Big5 QueryDSL challenge.
+* `index_mode` (default: standard) - Index mode to use for the data.
+* `mapping_source_mode` (default: null, which means to use the index mode's default) - Index mapping source mode for data.

--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -1,6 +1,8 @@
     {%- set p_target_opensearch = (target_opensearch | default(false))%}
     {%- set p_number_of_shards = (number_of_shards | default(1))%}
     {%- set p_number_of_replicas = (number_of_replicas | default(0))%}
+    {%- set p_index_mode = (index_mode | default('standard'))%}
+    {%- set p_mapping_source_mode = (mapping_source_mode | default(null))%}
     {
       "name": "create-ilm-policy",
       "operation-type": "raw-request",

--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -1,7 +1,7 @@
     {%- set p_target_opensearch = (target_opensearch | default(false))%}
     {%- set p_number_of_shards = (number_of_shards | default(1))%}
     {%- set p_number_of_replicas = (number_of_replicas | default(0))%}
-    {%- set p_index_mode = (index_mode | default('standard'))%}
+    {%- set p_index_mode = (index_mode | default(null))%}
     {%- set p_mapping_source_mode = (mapping_source_mode | default(null))%}
     {
       "name": "create-ilm-policy",

--- a/big5/request_body/index_template/elasticsearch.json
+++ b/big5/request_body/index_template/elasticsearch.json
@@ -34,9 +34,11 @@
           "source": {
             "mode": "{{ p_mapping_source_mode }}"
           }
-        },
+        }
         {% endif %}
-        "mode": "{{ p_index_mode }}"
+        {% if p_index_mode != null %}
+        ,"mode": "{{ p_index_mode }}"
+        {% endif %}
       }
     },
     "mappings": {

--- a/big5/request_body/index_template/elasticsearch.json
+++ b/big5/request_body/index_template/elasticsearch.json
@@ -28,9 +28,9 @@
             "message"
           ]
         },
-        "number_of_replicas": {{ p_number_of_replicas }},
+        "number_of_replicas": {{ p_number_of_replicas }}
         {% if p_mapping_source_mode != null %}
-        "mapping": {
+        ,"mapping": {
           "source": {
             "mode": "{{ p_mapping_source_mode }}"
           }

--- a/big5/request_body/index_template/elasticsearch.json
+++ b/big5/request_body/index_template/elasticsearch.json
@@ -28,7 +28,15 @@
             "message"
           ]
         },
-        "number_of_replicas": {{ p_number_of_replicas }}
+        "number_of_replicas": {{ p_number_of_replicas }},
+        {% if p_mapping_source_mode != null %}
+        "mapping": {
+          "source": {
+            "mode": "{{ p_mapping_source_mode }}"
+          }
+        },
+        {% endif %}
+        "mode": "{{ p_index_mode }}"
       }
     },
     "mappings": {


### PR DESCRIPTION
This allows configuring the index and mapping source mode in the big5 configuration. These default to "standard" and unset respectively.