### PR TITLE
[9.4] Use Rally Elasticsearch client to support ES 8.x (#1169)

### DIFF
--- a/elastic/shared/runners/datastream.py
+++ b/elastic/shared/runners/datastream.py
@@ -64,7 +64,7 @@ class DeleteRemoteDataStream:
             try:
                 self.logger.info("Deleting data stream: [%s] in cluster [%s]", data_stream, cluster_name)
                 await cluster_client.indices.delete_data_stream(name=data_stream)
-            except elasticsearch.ElasticsearchException as e:
+            except elasticsearch.ApiError as e:
                 msg = f"Failed to delete datastream [{data_stream}]; [{e}]"
                 self.logger.error("Deleting data stream: [%s] in cluster [%s]", data_stream, cluster_name)
                 raise BaseException(msg, e)

--- a/it_tracks/conftest.py
+++ b/it_tracks/conftest.py
@@ -15,15 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import contextlib
+
 import pytest
-from elasticsearch import Elasticsearch
+from esrally.client.synchronous import RallySyncElasticsearch
 
 
 @pytest.fixture(scope="function")
 def es_cluster_cleanup(es_cluster):
-    es = Elasticsearch(f"http://localhost:{es_cluster.http_port}")
-    es.indices.delete(index="*")
-    es.indices.delete_data_stream(name="*")
+    with contextlib.closing(RallySyncElasticsearch(f"http://localhost:{es_cluster.http_port}")) as es:
+        es.indices.delete(index="*")
+        es.indices.delete_data_stream(name="*")
 
 
 @pytest.fixture

--- a/it_tracks_serverless/conftest.py
+++ b/it_tracks_serverless/conftest.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 
 import pytest
 import requests
-from elasticsearch import Elasticsearch
+from esrally.client.synchronous import RallySyncElasticsearch
 
 BASE_URL = os.environ["RALLY_IT_SERVERLESS_BASE_URL"]
 API_KEY = os.environ["RALLY_IT_SERVERLESS_API_KEY"]
@@ -131,54 +131,55 @@ def project_config(project, tmpdir_factory):
     else:
         raise ValueError("Timed out waiting for DNS propagation")
 
-    print("Waiting for Elasticsearch")
-    for _ in range(60):  # 60 * 15 = 900 seconds = 15 minutes
-        try:
-            es = Elasticsearch(
-                f"https://{rally_target_host}",
-                basic_auth=(
-                    credentials["username"],
-                    credentials["password"],
-                ),
-                request_timeout=10,
-            )
-            info = es.info()
-            print("GET /")
-            print(json.dumps(info.body, indent=2))
+    with contextlib.closing(
+        RallySyncElasticsearch(
+            f"https://{rally_target_host}",
+            basic_auth=(credentials["username"], credentials["password"]),
+            request_timeout=10,
+        )
+    ) as es:
+        print("Waiting for Elasticsearch")
+        for _ in range(60):  # 60 * 15 = 900 seconds = 15 minutes
+            try:
+                info = es.info()
+                print("GET /")
+                print(json.dumps(info.body, indent=2))
 
-            authenticate = es.perform_request(method="GET", path="/_security/_authenticate")
-            print("GET /_security/_authenticate")
-            print(json.dumps(authenticate.body, indent=2))
+                authenticate = es.perform_request(method="GET", path="/_security/_authenticate")
+                print("GET /_security/_authenticate")
+                print(json.dumps(authenticate.body, indent=2))
 
-            break
-        except Exception as e:
-            print(f"GET / Failed with {str(e)}")
-            time.sleep(15)
-    else:
-        raise ValueError("Timed out waiting for Elasticsearch")
+                break
+            except Exception as e:
+                print(f"GET / Failed with {str(e)}")
+                time.sleep(15)
+        else:
+            raise ValueError("Timed out waiting for Elasticsearch")
 
-    # Create API key to test Rally with a public user privileges
-    print("Waiting for API key")
-    for _ in range(18):
-        try:
-            api_key = es.security.create_api_key(name="public-api-key")
-            break
-        except Exception as e:
-            print(f"API create failed with {str(e)}")
-            time.sleep(10)
-    else:
-        raise ValueError("Timed out waiting for API key")
+        # Create API key to test Rally with a public user privileges
+        print("Waiting for API key")
+        for _ in range(18):
+            try:
+                api_key = es.security.create_api_key(name="public-api-key")
+                break
+            except Exception as e:
+                print(f"API create failed with {str(e)}")
+                time.sleep(10)
+        else:
+            raise ValueError("Timed out waiting for API key")
 
     # Confirm API key is working fine
     print("Testing API key")
     for _ in range(18):  # 18 * 10 = 180 seconds = 3 minutes
         try:
-            es = Elasticsearch(
-                f"https://{rally_target_host}",
-                api_key=api_key.body["encoded"],
-                request_timeout=10,
-            )
-            info = es.info()
+            with contextlib.closing(
+                RallySyncElasticsearch(
+                    f"https://{rally_target_host}",
+                    api_key=api_key.body["encoded"],
+                    request_timeout=10,
+                )
+            ) as es:
+                info = es.info()
             break
         except Exception as e:
             print(f"API verification failed with {str(e)}")


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.4`:
 - [Use Rally Elasticsearch client to support ES 8.x (#1169)](https://github.com/elastic/rally-tracks/pull/1169)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Quentin Pradet","email":"quentin.pradet@elastic.co"},"sourceCommit":{"committedDate":"2026-06-05T10:11:12Z","message":"Use Rally Elasticsearch client to support ES 8.x (#1169)\n\n* Use Rally Elasticsearch client to support ES 8.x\n\n* Fix lint\n\n* Call EsClientFactory directly\n\n* Remove now empty test_utils directory\n\n* Fix lint\n\n* Remove dead import\n\n* Switch to RallySyncElasticsearch\n\n* Close ES client later\n\n* Fix scope","sha":"2d0bc30412f20c18ac84fa2eb1a6bfa6b736b225","branchLabelMapping":{"^v9.5$":"master","^vServerless$":"master","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v9.3","v9.4","v9.5"],"title":"Use Rally Elasticsearch client to support ES 8.x","number":1169,"url":"https://github.com/elastic/rally-tracks/pull/1169","mergeCommit":{"message":"Use Rally Elasticsearch client to support ES 8.x (#1169)\n\n* Use Rally Elasticsearch client to support ES 8.x\n\n* Fix lint\n\n* Call EsClientFactory directly\n\n* Remove now empty test_utils directory\n\n* Fix lint\n\n* Remove dead import\n\n* Switch to RallySyncElasticsearch\n\n* Close ES client later\n\n* Fix scope","sha":"2d0bc30412f20c18ac84fa2eb1a6bfa6b736b225"}},"sourceBranch":"master","suggestedTargetBranches":["9.3","9.4"],"targetPullRequestStates":[{"branch":"9.3","label":"v9.3","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"master","label":"v9.5","branchLabelMappingKey":"^v9.5$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/rally-tracks/pull/1169","number":1169,"mergeCommit":{"message":"Use Rally Elasticsearch client to support ES 8.x (#1169)\n\n* Use Rally Elasticsearch client to support ES 8.x\n\n* Fix lint\n\n* Call EsClientFactory directly\n\n* Remove now empty test_utils directory\n\n* Fix lint\n\n* Remove dead import\n\n* Switch to RallySyncElasticsearch\n\n* Close ES client later\n\n* Fix scope","sha":"2d0bc30412f20c18ac84fa2eb1a6bfa6b736b225"}}]}] BACKPORT-->