### PR TITLE
Elastic/logs: restrict default_field to text/match_only_text in logsdb_columnar mode

### DIFF
--- a/elastic/logs/templates/component/auditbeat-mappings.json
+++ b/elastic/logs/templates/component/auditbeat-mappings.json
@@ -23,6 +23,10 @@
         {%- endif -%}{# non-serverless-index-settings-marker-end #}
         "query": {
           "default_field": [
+            {% if index_mode | default('') == 'logsdb_columnar' %}
+            "message",
+            "error.message"
+            {% else %}
             "message",
             "tags",
             "agent.ephemeral_id",
@@ -351,6 +355,7 @@
             "jolokia.url",
             "file.pe.import_hash",
             "fields.*"
+            {% endif %}
           ]
         }
       }

--- a/elastic/logs/templates/component/logs-apache.access@package.json
+++ b/elastic/logs/templates/component/logs-apache.access@package.json
@@ -24,6 +24,10 @@
           },
           "query": {
             "default_field": [
+              {% if index_mode | default('') == 'logsdb_columnar' %}
+              "message",
+              "error.message"
+              {% else %}
               "cloud.account.id",
               "cloud.availability_zone",
               "cloud.instance.id",
@@ -93,6 +97,7 @@
               "apache.access.ssl.cipher",
               "apache.access.remote_addresses",
               "apache.access.identity"
+              {% endif %}
             ]
           }
         }

--- a/elastic/logs/templates/component/logs-apache.error@package.json
+++ b/elastic/logs/templates/component/logs-apache.error@package.json
@@ -24,6 +24,10 @@
           },
           "query": {
             "default_field": [
+              {% if index_mode | default('') == 'logsdb_columnar' %}
+              "message",
+              "error.message"
+              {% else %}
               "cloud.account.id",
               "cloud.availability_zone",
               "cloud.instance.id",
@@ -83,6 +87,7 @@
               "user_agent.original",
               "user_agent.os.name",
               "apache.error.module"
+              {% endif %}
             ]
           }
         }

--- a/elastic/logs/templates/component/logs-kafka.log@package.json
+++ b/elastic/logs/templates/component/logs-kafka.log@package.json
@@ -24,6 +24,11 @@
           },
           "query": {
             "default_field": [
+              {% if index_mode | default('') == 'logsdb_columnar' %}
+              "message",
+              "error.message",
+              "kafka.log.trace.message"
+              {% else %}
               "cloud.account.id",
               "cloud.availability_zone",
               "cloud.instance.id",
@@ -62,6 +67,7 @@
               "kafka.log.thread",
               "kafka.log.trace.class",
               "kafka.log.trace.message"
+              {% endif %}
             ]
           }
         }

--- a/elastic/logs/templates/component/logs-mysql.error@package.json
+++ b/elastic/logs/templates/component/logs-mysql.error@package.json
@@ -24,6 +24,10 @@
           },
           "query": {
             "default_field": [
+              {% if index_mode | default('') == 'logsdb_columnar' %}
+              "message",
+              "error.message"
+              {% else %}
               "cloud.account.id",
               "cloud.availability_zone",
               "cloud.instance.id",
@@ -63,6 +67,7 @@
               "message",
               "tags",
               "error.message"
+              {% endif %}
             ]
           }
         }

--- a/elastic/logs/templates/component/logs-mysql.slowlog@package.json
+++ b/elastic/logs/templates/component/logs-mysql.slowlog@package.json
@@ -24,6 +24,10 @@
           },
           "query": {
             "default_field": [
+              {% if index_mode | default('') == 'logsdb_columnar' %}
+              "message",
+              "error.message"
+              {% else %}
               "cloud.account.id",
               "cloud.availability_zone",
               "cloud.instance.id",
@@ -65,6 +69,7 @@
               "mysql.slowlog.killed",
               "mysql.slowlog.log_slow_rate_type",
               "mysql.slowlog.innodb.trx_id"
+              {% endif %}
             ]
           }
         }

--- a/elastic/logs/templates/component/logs-nginx.access@package.json
+++ b/elastic/logs/templates/component/logs-nginx.access@package.json
@@ -18,7 +18,7 @@
             "total_fields": {
               "limit": "10000"
             }
-          },
+          }{%- if index_mode | default('') != 'logsdb_columnar' %},
           "query": {
             "default_field": [
               "cloud.account.id",
@@ -78,7 +78,7 @@
               "user_agent.version",
               "nginx.access.remote_ip_list"
             ]
-          }
+          }{%- endif %}
         }
       },
       "mappings": {

--- a/elastic/logs/templates/component/logs-nginx.error@package.json
+++ b/elastic/logs/templates/component/logs-nginx.error@package.json
@@ -24,6 +24,9 @@
           },
           "query": {
             "default_field": [
+              {% if index_mode | default('') == 'logsdb_columnar' %}
+              "message"
+              {% else %}
               "cloud.account.id",
               "cloud.availability_zone",
               "cloud.instance.id",
@@ -55,6 +58,7 @@
               "ecs.version",
               "message",
               "tags"
+              {% endif %}
             ]
           }
         }

--- a/elastic/logs/templates/component/logs-postgresql.log@package.json
+++ b/elastic/logs/templates/component/logs-postgresql.log@package.json
@@ -24,6 +24,10 @@
           },
           "query": {
             "default_field": [
+              {% if index_mode | default('') == 'logsdb_columnar' %}
+              "message",
+              "error.message"
+              {% else %}
               "cloud.account.id",
               "cloud.availability_zone",
               "cloud.instance.id",
@@ -80,6 +84,7 @@
               "postgresql.log.location",
               "postgresql.log.application_name",
               "postgresql.log.backend_type"
+              {% endif %}
             ]
           }
         }

--- a/elastic/logs/templates/component/logs-redis.log@package.json
+++ b/elastic/logs/templates/component/logs-redis.log@package.json
@@ -24,6 +24,10 @@
           },
           "query": {
             "default_field": [
+              {% if index_mode | default('') == 'logsdb_columnar' %}
+              "message",
+              "error.message"
+              {% else %}
               "cloud.account.id",
               "cloud.availability_zone",
               "cloud.instance.id",
@@ -55,6 +59,7 @@
               "message",
               "tags",
               "redis.log.role"
+              {% endif %}
             ]
           }
         }

--- a/elastic/logs/templates/component/logs-redis.slowlog@package.json
+++ b/elastic/logs/templates/component/logs-redis.slowlog@package.json
@@ -21,7 +21,7 @@
             "total_fields": {
               "limit": "10000"
             }
-          },
+          }{%- if index_mode | default('') != 'logsdb_columnar' %},
           "query": {
             "default_field": [
               "cloud.account.id",
@@ -53,7 +53,7 @@
               "redis.slowlog.key",
               "redis.slowlog.args"
             ]
-          }
+          }{%- endif %}
         }
       },
       "mappings": {

--- a/elastic/logs/templates/component/logs-system.auth@package.json
+++ b/elastic/logs/templates/component/logs-system.auth@package.json
@@ -24,6 +24,10 @@
           },
           "query": {
             "default_field": [
+              {% if index_mode | default('') == 'logsdb_columnar' %}
+              "message",
+              "error.message"
+              {% else %}
               "cloud.account.id",
               "cloud.availability_zone",
               "cloud.instance.id",
@@ -99,6 +103,7 @@
               "system.auth.useradd.shell",
               "system.auth.syslog.version",
               "version"
+              {% endif %}
             ]
           }
         }

--- a/elastic/logs/templates/component/logs-system.syslog@package.json
+++ b/elastic/logs/templates/component/logs-system.syslog@package.json
@@ -24,6 +24,9 @@
           },
           "query": {
             "default_field": [
+              {% if index_mode | default('') == 'logsdb_columnar' %}
+              "message"
+              {% else %}
               "cloud.account.id",
               "cloud.availability_zone",
               "cloud.instance.id",
@@ -64,6 +67,7 @@
               "message",
               "process.name",
               "tags"
+              {% endif %}
             ]
           }
         }


### PR DESCRIPTION
When index_mode is logsdb_columnar, the index.query.default_field setting now only contains fields mapped as text or match_only_text. Templates where no such fields exist in the default_field list (nginx.access, redis.slowlog) omit the query setting entirely in logsdb_columnar mode.

This reason for this change is that with columnar mode fields are not indexed by default except text based fields. Queries are slow if a field isn't indexed and a few queries time out in elastic/logs logsdb_columnar benchmark now.