### PR TITLE
Avoid using runtime fields when index mode is logsdb_columnar.

### DIFF
--- a/elastic/logs/tasks/index-setup.json
+++ b/elastic/logs/tasks/index-setup.json
@@ -87,14 +87,16 @@
           }
         },
         "mappings" : {
-          "runtime": {
-            "rally.doc_size": {
-              "type": "long"
+          {% if index_mode | default('standard') != 'logsdb_columnar' %}
+            "runtime": {
+              "rally.doc_size": {
+                "type": "long"
+              },
+              "rally.message_size": {
+                "type": "long"
+              }
             },
-            "rally.message_size": {
-              "type": "long"
-            }
-          },
+          {% endif %}
           "properties" : {
             "event": {
               "properties": {


### PR DESCRIPTION
Runtime fields were disallowed via elastic/elasticsearch#151494 for columnar index modes.