### PR TITLE
Disable flaky scaling-search test in github_archive

### DIFF
--- a/it_tracks_serverless/test_selected_tracks_and_challenges.py
+++ b/it_tracks_serverless/test_selected_tracks_and_challenges.py
@@ -49,7 +49,7 @@ class TestTrackRepository:
     ]
 
     skip_challenges = {
-        "github_archive": ["scaling-search"],  # (flaky)
+        "github_archive": ["scaling-search"],  # (flaky due to shard recovery)
         "nyc_taxis": ["esql-views"],
         "tsdb": ["downsample"],
         "tsdb_k8s_queries": ["esql"],

--- a/it_tracks_serverless/test_selected_tracks_and_challenges.py
+++ b/it_tracks_serverless/test_selected_tracks_and_challenges.py
@@ -49,9 +49,10 @@ class TestTrackRepository:
     ]
 
     skip_challenges = {
+        "github_archive": ["scaling-search"], # (flaky)
+        "nyc_taxis": ["esql-views"],
         "tsdb": ["downsample"],
         "tsdb_k8s_queries": ["esql"],
-        "nyc_taxis": ["esql-views"],
     }
     skip_challenges_user = {
         "geonames": ["append-no-conflicts"],

--- a/it_tracks_serverless/test_selected_tracks_and_challenges.py
+++ b/it_tracks_serverless/test_selected_tracks_and_challenges.py
@@ -49,7 +49,7 @@ class TestTrackRepository:
     ]
 
     skip_challenges = {
-        "github_archive": ["scaling-search"], # (flaky)
+        "github_archive": ["scaling-search"],  # (flaky)
         "nyc_taxis": ["esql-views"],
         "tsdb": ["downsample"],
         "tsdb_k8s_queries": ["esql"],


### PR DESCRIPTION
The `scaling-search` challenge in `github_archive` turns out to be flaky in serverless ITs due to recovering shards. The unit tests use `--on-error=abort`, while nightlies `--on-error=continue`. We could either introduce a "continue" override for this particular challenge or skip it. I think `--on-error=continue` does not offer much value in ITs, so I'm proposing the latter.