### PR TITLE
Backport #1181 to 9.4: Add `index.mode` and `index.mapping.source.mode` configuration to big5

### DIFF
--- a/big5/README.md
+++ b/big5/README.md
@@ -87,3 +87,6 @@ The following parameters are available:
 * `target_opensearch` (default: false) - Whether the target is an OpenSearch cluster
 * `warmup_iterations` (default: 100) - Number of iterations that each client should execute to warmup the benchmark candidate.
 * `iterations` (default: 1000) - Number of measurement iterations that each client executes.
+* `query_clients` (default: 1) - Number of clients issuing queries in parallel. Applies to the `big5-esql` challenge only; ignored by the default Big5 QueryDSL challenge.
+* `index_mode` (default: null, which means logsdb will be used since the data matches `logs-*-*`) - Index mode to use for the data.
+* `mapping_source_mode` (default: null, which means to use the index mode's default) - Index mapping source mode for data.

--- a/big5/operations/default.json
+++ b/big5/operations/default.json
@@ -1,6 +1,8 @@
     {%- set p_target_opensearch = (target_opensearch | default(false))%}
     {%- set p_number_of_shards = (number_of_shards | default(1))%}
     {%- set p_number_of_replicas = (number_of_replicas | default(0))%}
+    {%- set p_index_mode = (index_mode | default(null))%}
+    {%- set p_mapping_source_mode = (mapping_source_mode | default(null))%}
     {
       "name": "create-ilm-policy",
       "operation-type": "raw-request",

--- a/big5/request_body/index_template/elasticsearch.json
+++ b/big5/request_body/index_template/elasticsearch.json
@@ -29,6 +29,16 @@
           ]
         },
         "number_of_replicas": {{ p_number_of_replicas }}
+        {% if p_mapping_source_mode != null %}
+        ,"mapping": {
+          "source": {
+            "mode": "{{ p_mapping_source_mode }}"
+          }
+        }
+        {% endif %}
+        {% if p_index_mode != null %}
+        ,"mode": "{{ p_index_mode }}"
+        {% endif %}
       }
     },
     "mappings": {


### PR DESCRIPTION
Backport of #1181 to the `9.4` branch.

## Summary
- Adds `index_mode` and `mapping_source_mode` track parameters to the big5 track for ES 9.x benchmarks
- Without this, passing `index_mode` as a track param against a 9.x cluster fails with `TrackConfigError: Unused track parameters ['index_mode']` because Rally selects the `9.4` branch (not `master`) based on the ES version

## Conflict resolution
The original commit added lines after `query_clients` in README.md, but `query_clients` wasn't yet on `9.4`. Resolved by including the `query_clients` line as well (it's on master but missing from this branch).