### PR TITLE
Elastic/logs: remove doc_values: false from component templates

### DIFF
--- a/elastic/logs/templates/component/auditbeat-mappings.json
+++ b/elastic/logs/templates/component/auditbeat-mappings.json
@@ -1850,8 +1850,7 @@
             },
             "public_key_exponent": {
               "index": false,
-              "type": "long",
-              "doc_values": false
+              "type": "long"
             },
             "not_before": {
               "type": "date"
@@ -4221,8 +4220,7 @@
                 },
                 "public_key_exponent": {
                   "index": false,
-                  "type": "long",
-                  "doc_values": false
+                  "type": "long"
                 },
                 "not_before": {
                   "type": "date"
@@ -4772,8 +4770,7 @@
             "original": {
               "ignore_above": 1024,
               "index": false,
-              "type": "keyword",
-              "doc_values": false
+              "type": "keyword"
             },
             "risk_score": {
               "type": "float"
@@ -6094,8 +6091,7 @@
                     },
                     "public_key_exponent": {
                       "index": false,
-                      "type": "long",
-                      "doc_values": false
+                      "type": "long"
                     },
                     "subject": {
                       "properties": {
@@ -6254,8 +6250,7 @@
                     },
                     "public_key_exponent": {
                       "index": false,
-                      "type": "long",
-                      "doc_values": false
+                      "type": "long"
                     },
                     "not_before": {
                       "type": "date"
@@ -6605,8 +6600,7 @@
                     },
                     "public_key_exponent": {
                       "index": false,
-                      "type": "long",
-                      "doc_values": false
+                      "type": "long"
                     },
                     "not_before": {
                       "type": "date"
@@ -6960,8 +6954,7 @@
                         },
                         "public_key_exponent": {
                           "index": false,
-                          "type": "long",
-                          "doc_values": false
+                          "type": "long"
                         },
                         "subject": {
                           "properties": {
@@ -7430,8 +7423,7 @@
                         },
                         "public_key_exponent": {
                           "index": false,
-                          "type": "long",
-                          "doc_values": false
+                          "type": "long"
                         },
                         "not_before": {
                           "type": "date"
@@ -7785,8 +7777,7 @@
                             },
                             "public_key_exponent": {
                               "index": false,
-                              "type": "long",
-                              "doc_values": false
+                              "type": "long"
                             },
                             "subject": {
                               "properties": {

--- a/elastic/logs/templates/component/logs-mysql.error@package.json
+++ b/elastic/logs/templates/component/logs-mysql.error@package.json
@@ -337,8 +337,7 @@
             "properties": {
               "original": {
                 "index": false,
-                "type": "keyword",
-                "doc_values": false
+                "type": "keyword"
               },
               "code": {
                 "ignore_above": 1024,

--- a/elastic/logs/templates/component/logs-system.auth@package.json
+++ b/elastic/logs/templates/component/logs-system.auth@package.json
@@ -592,8 +592,7 @@
               },
               "original": {
                 "index": false,
-                "type": "keyword",
-                "doc_values": false
+                "type": "keyword"
               },
               "created": {
                 "type": "date"


### PR DESCRIPTION
## Summary

- Removes all `"doc_values": false` settings from the three component template files under `elastic/logs/templates/component/`
- Affected files: `auditbeat-mappings.json` (9 occurrences), `logs-system.auth@package.json` (1), `logs-mysql.error@package.json` (1)
- Fields now fall back to the Elasticsearch default (`doc_values: true`)

## Test plan

- [ ] Verify `grep -rn '"doc_values"' elastic/logs/templates/` returns no matches
- [ ] Run the elastic/logs track to confirm templates apply without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)