### PR TITLE
github_archive continuous indexing search

### DIFF
--- a/github_archive/challenges/continuous-growth-with-search.json
+++ b/github_archive/challenges/continuous-growth-with-search.json
@@ -1,0 +1,63 @@
+{%- set p_indexing_target_docs_per_sec = indexing_target_docs_per_sec | default(2671) %}
+{%- set p_indexing_clients = indexing_clients | default(8) %}
+{%- set p_indexing_ramp_up_time_period = indexing_ramp_up_time_period | default(2700) %}
+{%- set p_indexing_warmup_time_period = indexing_warmup_time_period | default(2700) %}
+{
+  "name": "continuous-growth-with-search",
+  "description": "Index the full document corpus (all 15 corpora, ~6.6TB raw / ~1.5B documents) at a sustained, controllable rate while running a steady concurrent background search load throughout.",
+  "schedule": [
+    {{ rally.collect(parts="../common/schedule_setup.json") }},
+    {
+      "parallel": {
+        "completed-by": "index_full_corpus",
+        "tasks": [
+          {
+            "operation": "index_full_corpus",
+            "warmup-time-period": {{p_indexing_warmup_time_period}},
+            "ramp-up-time-period": {{p_indexing_ramp_up_time_period}},
+            "clients": {{p_indexing_clients}},
+            "target-throughput": "{{p_indexing_target_docs_per_sec}} docs/s"
+          },
+          {
+            "name": "background_default_search",
+            "operation": "default",
+            "warmup-time-period": {{search_warmup_time_period | default(600)}},
+            "clients": {{search_clients_default | default(2)}}
+          },
+          {
+            "name": "background_range_search",
+            "operation": "range",
+            "warmup-time-period": {{search_warmup_time_period | default(600)}},
+            "clients": {{search_clients_range | default(2)}}
+          },
+          {
+            "name": "background_filter_query",
+            "operation": "filter_query",
+            "warmup-time-period": {{search_warmup_time_period | default(600)}},
+            "clients": {{search_clients_filter | default(2)}}
+          },
+          {
+            "name": "background_autohisto_agg",
+            "operation": "autohisto_agg",
+            "warmup-time-period": {{search_warmup_time_period | default(600)}},
+            "clients": {{search_clients_agg | default(2)}}
+          },
+          {
+            "name": "background_top_contributors_weekly",
+            "operation": "top-es-contributors-weekly",
+            "warmup-time-period": {{search_warmup_time_period | default(600)}},
+            "clients": {{search_clients_terms_agg | default(1)}},
+            "target-interval": 4
+          },
+          {
+            "name": "background_top10_esql",
+            "operation": "top-10-repos-esql",
+            "warmup-time-period": {{search_warmup_time_period | default(600)}},
+            "clients": {{search_clients_esql | default(1)}},
+            "target-interval": 4
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/github_archive/challenges/continuous-growth-with-search.json
+++ b/github_archive/challenges/continuous-growth-with-search.json
@@ -21,38 +21,32 @@
           {
             "name": "background_default_search",
             "operation": "default",
-            "warmup-time-period": {{search_warmup_time_period | default(600)}},
             "clients": {{search_clients_default | default(2)}}
           },
           {
             "name": "background_range_search",
             "operation": "range",
-            "warmup-time-period": {{search_warmup_time_period | default(600)}},
             "clients": {{search_clients_range | default(2)}}
           },
           {
             "name": "background_filter_query",
             "operation": "filter_query",
-            "warmup-time-period": {{search_warmup_time_period | default(600)}},
             "clients": {{search_clients_filter | default(2)}}
           },
           {
             "name": "background_autohisto_agg",
             "operation": "autohisto_agg",
-            "warmup-time-period": {{search_warmup_time_period | default(600)}},
             "clients": {{search_clients_agg | default(2)}}
           },
           {
             "name": "background_top_contributors_weekly",
             "operation": "top-es-contributors-weekly",
-            "warmup-time-period": {{search_warmup_time_period | default(600)}},
             "clients": {{search_clients_terms_agg | default(1)}},
             "target-interval": 4
           },
           {
             "name": "background_top10_esql",
             "operation": "top-10-repos-esql",
-            "warmup-time-period": {{search_warmup_time_period | default(600)}},
             "clients": {{search_clients_esql | default(1)}},
             "target-interval": 4
           }

--- a/github_archive/challenges/continuous-growth-with-search.json
+++ b/github_archive/challenges/continuous-growth-with-search.json
@@ -1,5 +1,5 @@
 {%- set p_indexing_target_docs_per_sec = indexing_target_docs_per_sec | default(2671) %}
-{%- set p_indexing_clients = indexing_clients | default(8) %}
+{%- set p_bulk_indexing_clients = bulk_indexing_clients | default(8) %}
 {%- set p_indexing_ramp_up_time_period = indexing_ramp_up_time_period | default(2700) %}
 {%- set p_indexing_warmup_time_period = indexing_warmup_time_period | default(2700) %}
 {
@@ -10,12 +10,12 @@
     {
       "parallel": {
         "completed-by": "index_full_corpus",
+        "warmup-time-period": {{p_indexing_warmup_time_period}},
+        "ramp-up-time-period": {{p_indexing_ramp_up_time_period}},
         "tasks": [
           {
             "operation": "index_full_corpus",
-            "warmup-time-period": {{p_indexing_warmup_time_period}},
-            "ramp-up-time-period": {{p_indexing_ramp_up_time_period}},
-            "clients": {{p_indexing_clients}},
+            "clients": {{p_bulk_indexing_clients}},
             "target-throughput": "{{p_indexing_target_docs_per_sec}} docs/s"
           },
           {

--- a/github_archive/common/schedule_setup.json
+++ b/github_archive/common/schedule_setup.json
@@ -1,24 +1,4 @@
 {%- set p_set_ingest_timestamp = set_ingest_timestamp | default(true) %}
-{%- set _reroute_processors = [] %}
-{%- if multi_target %}
-{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-push", "tag": "gharchive", "if": "ctx?.type == \'PushEvent\'"}}') %}
-{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-create", "tag": "gharchive", "if": "ctx?.type == \'CreateEvent\'"}}') %}
-{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-pr", "tag": "gharchive", "if": "ctx?.type == \'PullRequestEvent\'"}}') %}
-{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-comment", "tag": "gharchive", "if": "ctx?.type == \'IssueCommentEvent\'"}}') %}
-{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-watch", "tag": "gharchive", "if": "ctx?.type == \'WatchEvent\'"}}') %}
-{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-delete", "tag": "gharchive", "if": "ctx?.type == \'DeleteEvent\'"}}') %}
-{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-prreview", "tag": "gharchive", "if": "ctx?.type == \'PullRequestReviewEvent\'"}}') %}
-{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-issues", "tag": "gharchive", "if": "ctx?.type == \'IssuesEvent\'"}}') %}
-{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-fork", "tag": "gharchive", "if": "ctx?.type == \'ForkEvent\'"}}') %}
-{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-prreviewcomment", "tag": "gharchive", "if": "ctx?.type == \'PullRequestReviewCommentEvent\'"}}') %}
-{%- endif %}
-{%- set _all_processors = [] %}
-{%- if p_set_ingest_timestamp %}
-{%- do _all_processors.append('{"set": {"field": "@timestamp", "value": "{{{_ingest.timestamp}}}"}}') %}
-{%- endif %}
-{%- for rp in _reroute_processors %}
-{%- do _all_processors.append(rp) %}
-{%- endfor %}
 {
   "name": "create-ingest-pipeline-pipeline",
   "operation": {
@@ -28,7 +8,86 @@
     "body": {
       "description": "Ingest pipeline for the github_archive Rally track",
       "processors": [
-        {{ _all_processors | join(",\n        ") }}
+        {%- if p_set_ingest_timestamp %}
+        {
+          "set": {
+            "field": "@timestamp",
+            "value": {{ '"{{{_ingest.timestamp}}}"' }}
+          }
+        }{% if multi_target %},{%- endif %}
+        {%- endif %}
+        {%- if multi_target %}
+        {
+          "reroute": {
+            "destination": "gharchive-event-push",
+            "tag": "gharchive",
+            "if": "ctx?.type == 'PushEvent'"
+          }
+        },
+        {
+          "reroute": {
+            "destination": "gharchive-event-create",
+            "tag": "gharchive",
+            "if": "ctx?.type == 'CreateEvent'"
+          }
+        },
+        {
+          "reroute": {
+            "destination": "gharchive-event-pr",
+            "tag": "gharchive",
+            "if": "ctx?.type == 'PullRequestEvent'"
+          }
+        },
+        {
+          "reroute": {
+            "destination": "gharchive-event-comment",
+            "tag": "gharchive",
+            "if": "ctx?.type == 'IssueCommentEvent'"
+          }
+        },
+        {
+          "reroute": {
+            "destination": "gharchive-event-watch",
+            "tag": "gharchive",
+            "if": "ctx?.type == 'WatchEvent'"
+          }
+        },
+        {
+          "reroute": {
+            "destination": "gharchive-event-delete",
+            "tag": "gharchive",
+            "if": "ctx?.type == 'DeleteEvent'"
+          }
+        },
+        {
+          "reroute": {
+            "destination": "gharchive-event-prreview",
+            "tag": "gharchive",
+            "if": "ctx?.type == 'PullRequestReviewEvent'"
+          }
+        },
+        {
+          "reroute": {
+            "destination": "gharchive-event-issues",
+            "tag": "gharchive",
+            "if": "ctx?.type == 'IssuesEvent'"
+          }
+        },
+        {
+          "reroute": {
+            "destination": "gharchive-event-fork",
+            "tag": "gharchive",
+            "if": "ctx?.type == 'ForkEvent'"
+          }
+        },
+        {
+          "reroute": {
+            "destination": "gharchive-event-prreviewcomment",
+            "tag": "gharchive",
+            "if": "ctx?.type == 'PullRequestReviewCommentEvent'"
+          }
+        }
+        {%- endif %}
       ]
     }
   },

--- a/github_archive/common/schedule_setup.json
+++ b/github_archive/common/schedule_setup.json
@@ -1,3 +1,24 @@
+{%- set p_set_ingest_timestamp = set_ingest_timestamp | default(true) %}
+{%- set _reroute_processors = [] %}
+{%- if multi_target %}
+{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-push", "tag": "gharchive", "if": "ctx?.type == \'PushEvent\'"}}') %}
+{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-create", "tag": "gharchive", "if": "ctx?.type == \'CreateEvent\'"}}') %}
+{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-pr", "tag": "gharchive", "if": "ctx?.type == \'PullRequestEvent\'"}}') %}
+{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-comment", "tag": "gharchive", "if": "ctx?.type == \'IssueCommentEvent\'"}}') %}
+{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-watch", "tag": "gharchive", "if": "ctx?.type == \'WatchEvent\'"}}') %}
+{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-delete", "tag": "gharchive", "if": "ctx?.type == \'DeleteEvent\'"}}') %}
+{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-prreview", "tag": "gharchive", "if": "ctx?.type == \'PullRequestReviewEvent\'"}}') %}
+{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-issues", "tag": "gharchive", "if": "ctx?.type == \'IssuesEvent\'"}}') %}
+{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-fork", "tag": "gharchive", "if": "ctx?.type == \'ForkEvent\'"}}') %}
+{%- do _reroute_processors.append('{"reroute": {"destination": "gharchive-event-prreviewcomment", "tag": "gharchive", "if": "ctx?.type == \'PullRequestReviewCommentEvent\'"}}') %}
+{%- endif %}
+{%- set _all_processors = [] %}
+{%- if p_set_ingest_timestamp %}
+{%- do _all_processors.append('{"set": {"field": "@timestamp", "value": "{{{_ingest.timestamp}}}"}}') %}
+{%- endif %}
+{%- for rp in _reroute_processors %}
+{%- do _all_processors.append(rp) %}
+{%- endfor %}
 {
   "name": "create-ingest-pipeline-pipeline",
   "operation": {
@@ -7,82 +28,7 @@
     "body": {
       "description": "Ingest pipeline for the github_archive Rally track",
       "processors": [
-        {
-          "set": {
-            "field": "@timestamp",
-            "value": {{ '"{{{_ingest.timestamp}}}"' }}
-          }
-        }{% if multi_target -%},
-        {
-          "reroute": {
-            "destination": "gharchive-event-push",
-            "tag": "gharchive",
-            "if": "ctx?.type == 'PushEvent'"
-          }
-        },
-        {
-          "reroute": {
-            "destination": "gharchive-event-create",
-            "tag": "gharchive",
-            "if": "ctx?.type == 'CreateEvent'"
-          }
-        },
-        {
-          "reroute": {
-            "destination": "gharchive-event-pr",
-            "tag": "gharchive",
-            "if": "ctx?.type == 'PullRequestEvent'"
-          }
-        },
-        {
-          "reroute": {
-            "destination": "gharchive-event-comment",
-            "tag": "gharchive",
-            "if": "ctx?.type == 'IssueCommentEvent'"
-          }
-        },
-        {
-          "reroute": {
-            "destination": "gharchive-event-watch",
-            "tag": "gharchive",
-            "if": "ctx?.type == 'WatchEvent'"
-          }
-        },
-        {
-          "reroute": {
-            "destination": "gharchive-event-delete",
-            "tag": "gharchive",
-            "if": "ctx?.type == 'DeleteEvent'"
-          }
-        },
-        {
-          "reroute": {
-            "destination": "gharchive-event-prreview",
-            "tag": "gharchive",
-            "if": "ctx?.type == 'PullRequestReviewEvent'"
-          }
-        },
-        {
-          "reroute": {
-            "destination": "gharchive-event-issues",
-            "tag": "gharchive",
-            "if": "ctx?.type == 'IssuesEvent'"
-          }
-        },
-        {
-          "reroute": {
-            "destination": "gharchive-event-fork",
-            "tag": "gharchive",
-            "if": "ctx?.type == 'ForkEvent'"
-          }
-        },
-        {
-          "reroute": {
-            "destination": "gharchive-event-prreviewcomment",
-            "tag": "gharchive",
-            "if": "ctx?.type == 'PullRequestReviewCommentEvent'"
-          }
-        }{% endif %}
+        {{ _all_processors | join(",\n        ") }}
       ]
     }
   },

--- a/github_archive/index-template.json
+++ b/github_archive/index-template.json
@@ -1,6 +1,8 @@
 {% import "rally.helpers" as rally with context %}
 {%- set p_use_ingest_pipeline = use_ingest_pipeline | default(true) %}
 {%- set p_data_stream = data_stream | default(false) %}
+{%- set p_set_ingest_timestamp = set_ingest_timestamp | default(true) %}
+{%- set p_sort_timestamp_field = "@timestamp" if p_set_ingest_timestamp else "created_at" %}
 {% set p_number_of_replicas = number_of_replicas | default(0) -%}
 {
   "index_patterns": ["gharchive*"],
@@ -32,7 +34,7 @@
         {% endif -%}
         {%- if p_use_ingest_pipeline == true %}
         "default_pipeline": "gharchive-pipeline",
-        "sort.field": ["type", "repo.id", "@timestamp"],
+        "sort.field": ["type", "repo.id", "{{ p_sort_timestamp_field }}"],
         "sort.order": ["asc", "asc", "desc"],
         {%- endif %}
         "mapping.total_fields.limit": 10000

--- a/github_archive/operations/indexing.json
+++ b/github_archive/operations/indexing.json
@@ -23,4 +23,22 @@
   "conflict-probability": {{p_conflict_probability}}
   {%- endif %}
   {{ rally.exists_set_param("detailed-results", p_detailed_results, default_value=False) }}
+},
+{
+  "name": "index_full_corpus",
+  "corpora": [
+    "github_archive0", "github_archive1", "github_archive2", "github_archive3",
+    "github_archive4", "github_archive5", "github_archive6", "github_archive7",
+    "github_archive8", "github_archive9", "github_archive10", "github_archive11",
+    "github_archive12", "github_archive13", "github_archive14"
+  ],
+  "operation-type": "bulk",
+  "bulk-size": {{bulk_size | default(1000)}},
+  "ingest-percentage": {{ingest_percentage | default(100)}}
+  {%- if conflicts is defined %},
+  "conflicts": "{{p_conflicts}}",
+  "on-conflict": "{{p_on_conflict}}",
+  "conflict-probability": {{p_conflict_probability}}
+  {%- endif %}
+  {{ rally.exists_set_param("detailed-results", p_detailed_results, default_value=False) }}
 }


### PR DESCRIPTION
Add a challenge to github_archive to test autosharding of standard indices. The purpose of the test is to validate the claim an index can grow to 4.8 TB (48 shards x 100 GB) without impact to performance as stated-- https://github.com/elastic/docs-content/pull/7151/changes#diff-645c71b472d290b11c8d77331631de31391beb0f9e303b70cbb53cd3bcd6e05fR162. 