### PR TITLE
[8.15] Update documentation for backporting (#959)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,36 +22,44 @@ See all details in the [contributor guidelines](https://github.com/elastic/rally
 Backporting changes
 -------------------
 
-If you are a contributor with direct commit access to this repository then please backport your changes. This ensures that tracks do not work only for the latest `main` version of Elasticsearch but also for older versions. Apply backports with cherry-picks. Below you can find a walkthrough:
+Backporting ensures that tracks do not work only for the latest `main` version of Elasticsearch but also for older versions, so it is important. As part of contributing to this repository, a reminder will periodically notify you that backport is pending.
 
-Assume we've pushed commit `a7e0937` to master and want to backport it. This is a change to the `noaa` track. Let's check what branches are available for backporting:
+In order to backport your PR, at least one `vX.Y` label has to be added. 
+- Please supply all the labels that correspond to both current and past elasticsearch versions you expect this PR to work with, but choose only from all the available ones. 
+- If the PR being merged is using functionality from future Elasticsearch versions, please wait for the creation of new Elasticsearch `vX.Y` version branch. In such case, it would be useful if you kept the 'backport pending' label attached to the PR, so the backport reminder can periodically notify you.
 
-```
-daniel@io:tracks/default ‹master›$ git branch -r
-  origin/1
-  origin/2
-  origin/5
-  origin/HEAD -> origin/master
-  origin/master
-```
+When adding a `vX.Y` label, the creation of a new PR is triggered unless there are merge conflicts. Its status is reported through a comment and in case it is successfully created, you get a link to the PR opened against the target version branch. This new PR has a `backport` label and expects a review. When approved, it will be automatically merged.
 
-We'll go backwards starting from branch `5`, then branch `2` and finally branch `1`. After applying a change, we will test whether the track works as is for an older version of Elasticsearch.
+# Merge conflicts
+Merge conflicts need to be resolved manually. There are two ways to manually create a backport PR 
 
-```
-git checkout 5
-git cherry-pick a7e0937
+## Fork and cherry-pick
+1. Create a rally-tracks fork, and clone it locally.
+2. Pull and checkout to the intended version branch. 
+3. Create a new local branch from this version branch.
+4. Cherry-pick the commit from the PR that will be backported.
+5. Resolve merge conflicts, commit locally and push to fork.
+6. Open a PR against the target branch, add `backport` label manually.
+7. Request a review and merge.
+8. Repeat for other version branches. 
 
-# test the change now with an Elasticsearch 5.x distribution
-esrally race --track=noaa --distribution-version=5.4.3 --test-mode
+## Use backport tool (requires node)
+1. Go to the [Backport tool](https://github.com/sorenlouv/backport?tab=readme-ov-file#backport-cli-tool) documentation and follow the guidelines to install it in your local `rally-tracks` directory. Note that you have to add your personal access secret token locally in `~/.backport/config.json` with the [specified](https://github.com/sorenlouv/backport/blob/main/docs/config-file-options.md#global-config-backportconfigjson) repository access. At the end of this step, you should be able to execute `backport` command inside rally-tracks repo.
+2. cd in your local `rally-tracks` repository and execute `backport --pr <merged_pr_number>`. This will open an interactive dialog where you are required to selected branches to backport to. You can only select the version branches that have merge conflicts. After selecting the branches, backport tool will mention some directory in a message `Please fix the conflicts in /home/<user>/.backport/repositories/elastic/rally-tracks` and you will have to go and resolve those conflicts manually for all of the selected branches. If it is not easy to tackle multiple branches in a single sweep, repeat this procedure for each target version branch separately.
+3. After resolving the merge conflicts you can execute `backport --pr <merged_pr_number>` which this time it will be successful. PRs will be opened against the target version branches and they will be ready for approval and merge.
 
-# push the change
-git push origin 5
-```
+# Backporting Notes
+- CI is essential to this procedure. Whenever you commit something in a backport PR, check the test results.
+- In case of conflicts, git blame is a wonderful tool to understand what changes need to be included in a version branch before backporting your PR. You can always check the history of the files you touch between the target backport branch and master version branch.
+- Sometimes it is necessary to remove individual operations from a track that are not supported by earlier versions. This graceful fallback is a compromise to allow to run a subset of the track on older versions of Elasticsearch too.
 
-This particular track uses features that are only available in Elasticsearch 5 and later so we will stop here but the process continues until we've reached the earliest branch.
+# Finish line
+For wrapping up ensure the following:
+- Your merged PR has all the correct version labels.
+- Every related backport PR has the `backport` label.
+- Every related backport PR is merged to the correct version branches.
 
-Sometimes it is necessary to remove individual operations from a track that are not supported by earlier versions. This graceful fallback is a compromise to allow to run a subset of the track on older versions of Elasticsearch too. If this is necessary then it's best to do these changes in a separate commit. Also, don't forget to cherry-pick this separate commit too to even earlier versions if necessary.
-
+Finally, remove the `backport pending` label from your PR.
 
 License
 -------

--- a/github_ci_tools/scripts/backport.py
+++ b/github_ci_tools/scripts/backport.py
@@ -350,7 +350,7 @@ def run_remind(prefetched_prs: list[dict[str, Any]], pending_reminder_age_days: 
                 add_comment(info.number, f"{COMMENT_MARKER_BASE}\n@{author}\n{REMINDER_BODY}")
                 LOG.info(f"PR #{info.number}: initial reminder posted")
             else:
-                LOG.info(f"PR #{info.number}: cooling period not elapsed)")
+                LOG.info(f"PR #{info.number}: skip reminder")
         except Exception as ex:
             LOG.error(f"Remind error for PR #{pr.get('number', '?')}: {ex}")
             errors += 1


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.15`:
 - [Update documentation for backporting (#959)](https://github.com/elastic/rally-tracks/pull/959)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Dris","email":"nick.dris@elastic.co"},"sourceCommit":{"committedDate":"2025-12-10T15:14:37Z","message":"Update documentation for backporting (#959)\n\nBackport documentation updated","sha":"045362626515e7ade825cb58ca5673cec4b01a20","branchLabelMapping":{"^v(\\d{1,2})$":"$1","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["backport pending"],"title":"Add documentation for backporting","number":959,"url":"https://github.com/elastic/rally-tracks/pull/959","mergeCommit":{"message":"Update documentation for backporting (#959)\n\nBackport documentation updated","sha":"045362626515e7ade825cb58ca5673cec4b01a20"}},"sourceBranch":"master","suggestedTargetBranches":[],"targetPullRequestStates":[]}] BACKPORT-->