### PR TITLE
[8.15] Backport fix reminder and target branches (#964)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,9 +2,10 @@
   "repoOwner": "elastic",
   "repoName": "rally-tracks",
   "targetBranchChoices": [
-    "8.15",
-    "8.14",
-    "8.13"
+    "9.2",
+    "9.1",
+    "9.0",
+    "8.19",
   ],
   "targetPRLabels": [
     "backport"

--- a/.github/workflows/backport.reminder.yml
+++ b/.github/workflows/backport.reminder.yml
@@ -1,4 +1,4 @@
-name: Backport reminder
+name: Backport utilities
 
 on:
   pull_request_target:
@@ -8,20 +8,27 @@ on:
     - cron: '0 6 * * *'  # Every day at 06:00 UTC
   workflow_dispatch:
     inputs:
+      single_pr:
+        description: 'PR number to process (single-PR run; leave empty for bulk)'
+        required: false
       lookback_days:
-        description: 'How many days back to search merged PRs'
+        description: 'Lookback window for merged PRs (days)'
         required: false
         default: '7'
       pending_label_age_days:
-        description: 'Minimum age in days before reminding'
+        description: 'Minimum previous reminder age (days)'
         required: false
         default: '14'
+      remove:
+        description: 'If set to true, remove pending labels/reminders instead of adding/reminding'
+        required: false
+        default: 'false'
 
 env:
     BACKPORT_TOKEN: ${{ secrets.BACKPORT_TOKEN }}
 
 jobs:
-  reminder:
+  label_and_remind:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -30,13 +37,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Add Backport pending label (single PR)
+      - name: Add Backport pending label & remind (pull request)
         if: github.event_name == 'pull_request_target'
         run: |
-          python github_ci_tools/scripts/backport.py --pr-mode label
-          python github_ci_tools/scripts/backport.py --pr-mode remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
-      - name: Add Backport pending label (bulk)
-        if: github.event_name != 'pull_request_target'
+          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.pull_request.number }} label
+          python github_ci_tools/scripts/backport.py --pr-number ${{ github.event.pull_request.number }} remind
+      - name: Add Backport pending label & remind (scheduled)
+        if: github.event_name == 'schedule'
         run: |
-          python github_ci_tools/scripts/backport.py label --lookback-days ${{ github.event.inputs.lookback_days || '7' }}
-          python github_ci_tools/scripts/backport.py remind --lookback-days ${{ github.event.inputs.lookback_days || '7' }} --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }}
+          python github_ci_tools/scripts/backport.py label
+          python github_ci_tools/scripts/backport.py remind
+      - name: Add Backport pending label & remind (workflow dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          pr_number_clause="${{ github.event.inputs.single_pr && format('--pr-number {0}', github.event.inputs.single_pr) || '' }}"
+          remove_clause="${{ github.event.inputs.remove == 'true' && '--remove' || '' }}"
+          python github_ci_tools/scripts/backport.py $pr_number_clause label --lookback-days ${{ github.event.inputs.lookback_days || '7' }} $remove_clause
+          python github_ci_tools/scripts/backport.py $pr_number_clause remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }} $remove_clause

--- a/github_ci_tools/scripts/backport.py
+++ b/github_ci_tools/scripts/backport.py
@@ -28,7 +28,7 @@ Usage: backport.py [options] <command> [flags]
 
 Options:
     --repo                               owner/repo
-    --pr-mode                            Single PR mode (use event payload); Handle PR through GITHUB_EVENT_PATH.
+    --pr-number                          Single PR mode.
     -v, --verbose                        Increase verbosity (can be repeated: -vv)
     -q, --quiet                          Decrease verbosity (can be repeated: -qq)
     --dry-run                            Simulate actions without modifying GitHub state
@@ -43,7 +43,7 @@ Flags:
     --remove                             Remove 'backport pending' label
 
 Quick usage:
-    backport.py label --pr-mode
+    backport.py --pr-number 42 label
     backport.py --repo owner/name label --lookback-days 7
     backport.py --repo owner/name remind --lookback-days 30 --pending-reminder-age-days 14
     backport.py --repo owner/name --dry-run -vv label --lookback-days 30
@@ -156,24 +156,7 @@ class PRInfo:
         return cls(number, labels)
 
 
-# ----------------------------- PR Extraction (single or bulk) -----------------------------
-def load_event() -> dict:
-    """Load the GitHub event payload from GITHUB_EVENT_PATH for single PR mode.
-
-    Returns an empty dict if the path is missing to allow callers to decide on fallback behavior.
-    """
-    path = os.environ.get("GITHUB_EVENT_PATH", "").strip()
-    if not path:
-        raise FileNotFoundError("GITHUB_EVENT_PATH environment variable is empty")
-    if not os.path.isfile(path):
-        raise FileNotFoundError(f"File not found: {path}")
-    with open(path, "r", encoding="utf-8") as f:
-        data = json.load(f)
-    if not isinstance(data, dict):
-        raise TypeError(f"Event data is a {type(data)}, want a dict.")
-    return data
-
-
+# ----------------------------- PR Extraction  -----------------------------
 def list_prs(q_filter: str, since: dt.datetime) -> Iterable[dict[str, Any]]:
     """Query the GH API with a filter to iterate over PRs updated after a given timestamp."""
     q_date = since.strftime("%Y-%m-%d")
@@ -332,7 +315,7 @@ def delete_reminders(info: PRInfo) -> None:
             LOG.info(f"Deleted comment ID {comment_id} on PR #{info.number}")
 
 
-def run_remind(prefetched_prs: list[dict[str, Any]], pending_reminder_age_days: int, lookback_days: int) -> int:
+def run_remind(prefetched_prs: list[dict[str, Any]], pending_reminder_age_days: int, remove: bool) -> int:
     """Post reminders using prefetched merged PR list."""
     if not prefetched_prs:
         raise RuntimeError("No PRs prefetched for reminding")
@@ -344,7 +327,9 @@ def run_remind(prefetched_prs: list[dict[str, Any]], pending_reminder_age_days: 
             if not pr:
                 continue
             info = PRInfo.from_dict(pr)
-            if pr_needs_reminder(info, threshold):
+            if remove is True:
+                delete_reminders(info)
+            elif pr_needs_reminder(info, threshold):
                 author = pr.get("user", {}).get("login", "PR author")
                 delete_reminders(info)
                 add_comment(info.number, f"{COMMENT_MARKER_BASE}\n@{author}\n{REMINDER_BODY}")
@@ -389,15 +374,10 @@ def configure(args: argparse.Namespace) -> None:
     require_mandatory_vars()
 
 
-def prefetch_prs(pr_mode: bool, lookback_days: int) -> list[dict[str, Any]]:
-    if pr_mode:
-        event = load_event()
-        if event:
-            pr_data = event.get("pull_request")
-        else:
-            raise RuntimeError("Failed to load event data")
-        if not pr_data:
-            raise RuntimeError(f"No pull_request data in event: {event}")
+def prefetch_prs(pr_number: int | None, lookback_days: int) -> list[dict[str, Any]]:
+    if pr_number is not None:
+        q_path = f"repos/{CONFIG.repo}/pulls/{pr_number}"
+        pr_data = gh_request(path=q_path)
         # Ensure PR is merged.
         merged_flag = pr_data.get("merged")
         merged_at = pr_data.get("merged_at")
@@ -418,16 +398,15 @@ def prefetch_prs(pr_mode: bool, lookback_days: int) -> list[dict[str, Any]]:
         return [pr_data]
     now = dt.datetime.now(dt.timezone.utc)
     since = now - dt.timedelta(days=lookback_days)
-    repo = CONFIG.repo
     # Note that we rely on is:merged to filter out unmerged PRs.
-    return list(list_prs(f"repo:{repo} is:pr is:merged", since))
+    return list(list_prs(f"repo:{CONFIG.repo} is:pr is:merged", since))
 
 
 def parse_args() -> argparse.Namespace:
     try:
         parser = argparse.ArgumentParser(
             description="Backport utilities",
-            epilog="""\nExamples:\n  backport.py label --pr-mode\n  backport.py label --lookback-days 7\n  backport.py remind --lookback-days 30 --pending-reminder-age-days 14\n  backport.py --dry-run -vv label --lookback-days 30\n\nSingle PR mode (--pr-mode) reads the pull_request payload from GITHUB_EVENT_PATH.\nBulk mode searches merged PRs updated within --lookback-days.\n""",
+            epilog="""\nExamples:\n  backport.py --pr-number 42 label\n  backport.py label --lookback-days 7\n  backport.py remind --lookback-days 30 --pending-reminder-age-days 14\n  backport.py --dry-run -vv label --lookback-days 30\n\nSingle PR mode fetches PR by number (--pr-number) .\nBulk mode searches merged PRs updated within lookback (--lookback-days).\n""",
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
         parser.add_argument(
@@ -437,9 +416,9 @@ def parse_args() -> argparse.Namespace:
             default=None,
         )
         parser.add_argument(
-            "--pr-mode",
-            action="store_true",
-            help="Single PR mode (use GITHUB_EVENT_PATH pull_request payload). Default: bulk scan via search API",
+            "--pr-number",
+            action="store",
+            help="Single PR mode. Default: bulk scan via search API",
         )
         parser.add_argument(
             "--dry-run",
@@ -470,12 +449,11 @@ def parse_args() -> argparse.Namespace:
             type=int,
             required=False,
             default=7,
-            help="Days to look back (default: 7). Ignored in --pr-mode",
+            help="Days to look back (default: 7).",
         )
         p_label.add_argument(
             "--remove",
             action="store_true",
-            required=False,
             default=False,
             help="Removes backport pending label",
         )
@@ -486,7 +464,7 @@ def parse_args() -> argparse.Namespace:
             type=int,
             required=False,
             default=7,
-            help="Days to look back (default: 7). Ignored in --pr-mode",
+            help="Days to look back (default: 7).",
         )
         p_remind.add_argument(
             "--pending-reminder-age-days",
@@ -494,6 +472,12 @@ def parse_args() -> argparse.Namespace:
             required=False,
             default=14,
             help="Days between reminders for the same PR (default: 14). Adds initial reminder if none posted yet.",
+        )
+        p_remind.add_argument(
+            "--remove",
+            action="store_true",
+            default=False,
+            help="Remove backport pending reminder comments instead of adding new ones",
         )
 
     except Exception:
@@ -506,13 +490,13 @@ def main():
     configure(args)
 
     LOG.debug(f"Parsed arguments: {args}")
-    prefetched = prefetch_prs(args.pr_mode, args.lookback_days)
+    prefetched = prefetch_prs(int(args.pr_number) if args.pr_number else None, args.lookback_days)
     LOG.debug(f"Prefetched {len(prefetched)} PRs for command '{args.command}': {[pr.get('number') for pr in prefetched]}")
     match args.command:
         case "label":
             return run_label(prefetched, args.remove)
         case "remind":
-            return run_remind(prefetched, args.pending_reminder_age_days, args.lookback_days)
+            return run_remind(prefetched, args.pending_reminder_age_days, args.remove)
         case _:
             raise NotImplementedError(f"Unknown command {args.command}")
 

--- a/github_ci_tools/tests/conftest.py
+++ b/github_ci_tools/tests/conftest.py
@@ -268,12 +268,3 @@ def gh_mock(backport_mod, monkeypatch: pytest.MonkeyPatch) -> GitHubMock:
     mock = GitHubMock()
     monkeypatch.setattr(backport_mod, "gh_request", mock)
     return mock
-
-
-# --------------------------- Event Payload ---------------------------
-@pytest.fixture()
-def event_file(tmp_path, monkeypatch) -> Path:
-    """Create a temporary GitHub event JSON."""
-    path = tmp_path / "event.json"
-    monkeypatch.setenv("GITHUB_EVENT_PATH", str(path))
-    return path

--- a/github_ci_tools/tests/resources/cases.py
+++ b/github_ci_tools/tests/resources/cases.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any, Callable, TypeVar
 
 import pytest
@@ -95,8 +95,12 @@ class RepoCase:
                 gh_mock.add(
                     static_create_pending_label.method, static_create_pending_label.path, response=static_create_pending_label.response
                 )
-
-        pass
+        for pr in self.prs:
+            gh_mock.add(
+                "GET",
+                f"/repos/{self.name}/pulls/{pr.number}",
+                response=asdict(pr),
+            )
 
 
 # ---------------- Unified Interaction Case -----------------

--- a/github_ci_tools/tests/test_backport_cli.py
+++ b/github_ci_tools/tests/test_backport_cli.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import sys
 from dataclasses import asdict
@@ -145,17 +144,16 @@ def test_backport_cli_parsing(backport_mod, monkeypatch, case: BackportCliCase):
         raises_error=RuntimeError,
     ),
 )
-def test_prefetch_prs_in_single_pr_mode(backport_mod, event_file, case: GHInteractionCase):
-    # Prepare event payload file for single PR mode
-    payload = {"pull_request": asdict(case.repo.prs[0])}
-    event_file.write_text(json.dumps(payload), encoding="utf-8")
+def test_prefetch_prs_in_single_pr_mode(backport_mod, gh_mock, case: GHInteractionCase):
+    case.register(gh_mock)
+    backport_mod.CONFIG.repo = TEST_REPO
 
     # Prefetched PRs must be one, None or raise error
     if case.raises_error:
         with pytest.raises(case.raises_error):
-            prefetched_prs = backport_mod.prefetch_prs(pr_mode=True, lookback_days=case.lookback_days)
+            prefetched_prs = backport_mod.prefetch_prs(pr_number=case.repo.prs[0].number, lookback_days=case.lookback_days)
         return
-    prefetched_prs = backport_mod.prefetch_prs(pr_mode=True, lookback_days=case.lookback_days)
+    prefetched_prs = backport_mod.prefetch_prs(pr_number=case.repo.prs[0].number, lookback_days=case.lookback_days)
     if prefetched_prs:
         assert len(prefetched_prs) == 1
     prefetched_pr = prefetched_prs if prefetched_prs else None
@@ -164,7 +162,7 @@ def test_prefetch_prs_in_single_pr_mode(backport_mod, event_file, case: GHIntera
 
 
 @cases(
-    adds_repo_label_and_labels_only_w=BackportCliCase(
+    adds_repo_label_and_labels_only_within_lookback=BackportCliCase(
         argv=["backport.py", "label"],
         gh_interaction=GHInteractionCase(
             repo=RepoCase(repo_labels=[], prs=select_pull_requests()),
@@ -225,7 +223,7 @@ def test_backport_run(backport_mod, gh_mock, monkeypatch, case: BackportCliCase)
     args = backport_mod.parse_args()
     backport_mod.configure(args)
 
-    prefetched = backport_mod.prefetch_prs(args.pr_mode, args.lookback_days)
+    prefetched = backport_mod.prefetch_prs(args.pr_number, args.lookback_days)
     try:
         match args.command:
             case "label":
@@ -234,7 +232,7 @@ def test_backport_run(backport_mod, gh_mock, monkeypatch, case: BackportCliCase)
                 result = backport_mod.run_remind(
                     prefetched,
                     args.pending_reminder_age_days,
-                    args.lookback_days,
+                    args.remove,
                 )
                 for pr in prefetched:
                     if pr.get("needs_pending", False) is False:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.15`:
 - [Backport fix reminder and target branches (#964)](https://github.com/elastic/rally-tracks/pull/964)

<!--- Backport version: 12.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Dris","email":"nick.dris@elastic.co"},"sourceCommit":{"committedDate":"2025-12-15T13:05:52Z","message":"Backport fix reminder and target branches (#964)\n\n- Instead of --pr-mode we have --pr-number which enforces backport cli to fetch data of a single PR from github API, instead of getting it through github event from actions.\n- PR number argument added to the workflow_dispatch manual mode and if given backport ci\n- Unit tests for --pr-mode removed\n- Unit tests for --pr-number added\n- Added remove reminders capability\n- Added --remove option to workflow_dispatch","sha":"2219240bb9c1b8986053fb2aa3548641eecf5af7"},"sourcePullRequest":{"labels":["v9.4"],"title":"Backport fix reminder and target branches","number":964,"url":"https://github.com/elastic/rally-tracks/pull/964","mergeCommit":{"message":"Backport fix reminder and target branches (#964)\n\n- Instead of --pr-mode we have --pr-number which enforces backport cli to fetch data of a single PR from github API, instead of getting it through github event from actions.\n- PR number argument added to the workflow_dispatch manual mode and if given backport ci\n- Unit tests for --pr-mode removed\n- Unit tests for --pr-number added\n- Added remove reminders capability\n- Added --remove option to workflow_dispatch","sha":"2219240bb9c1b8986053fb2aa3548641eecf5af7"}},"sourceBranch":"master","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->