### PR TITLE
[8.19] Drive-by style fixes (#1209)

### DIFF
--- a/cohere_vector/_tools/parse_documents.py
+++ b/cohere_vector/_tools/parse_documents.py
@@ -70,7 +70,7 @@ def parse_arguments():
 
 
 if __name__ == "__main__":
-    (max_documents, start_page, end_page) = parse_arguments()
+    max_documents, start_page, end_page = parse_arguments()
     if max_documents == DEFAULT_MAX_DOCS:
         output_pages(start_page, end_page)
     else:

--- a/download.py
+++ b/download.py
@@ -29,9 +29,9 @@ from pathlib import Path
 REPO_URL = "https://github.com/elastic/rally-tracks.git"
 
 
-def rally_confdir():
-    default_home = os.path.expanduser("~")
-    return os.path.join(os.getenv("RALLY_HOME", default_home), ".rally")
+def rally_confdir() -> Path:
+    rally_home = Path(os.environ.get("RALLY_HOME") or Path.home())
+    return rally_home / ".rally"
 
 
 class TemplateRenderError(Exception):

--- a/github_ci_tools/tests/conftest.py
+++ b/github_ci_tools/tests/conftest.py
@@ -3,20 +3,20 @@
 Provides:
   - Dynamic loading of the `backport.py` module (so no package __init__ files required).
   - An injectable GitHub API mock (`gh_mock`) that records calls and returns
-	predefined responses or raises exceptions.
+        predefined responses or raises exceptions.
   - Helper fixtures for creating synthetic PR payloads and reminder comments.
   - A convenience fixture to run `configure()` with a minimal argparse.Namespace.
 
 Usage examples in tests:
 
   def test_needs_pending_label(backport_mod, pr_no_labels):
-	  assert backport_mod.needs_pending_label(pr_no_labels)
+          assert backport_mod.needs_pending_label(pr_no_labels)
 
   def test_label_api_called(backport_mod, gh_mock, pr_versioned):
-	  gh_mock.add(f'repos/{TEST_REPO}/labels/backport%20pending', method='GET', response={})  # label exists
-	  gh_mock.add(f'repos/{TEST_REPO}/issues/42/labels', method='POST', response={'ok': True})
-	  backport_mod.add_pull_request_label(42, backport_mod.PENDING_LABEL)
-	  assert any(f'repos/{TEST_REPO}/issues/42/labels' in c['path'] for c in gh_mock.calls)
+          gh_mock.add(f'repos/{TEST_REPO}/labels/backport%20pending', method='GET', response={})  # label exists
+          gh_mock.add(f'repos/{TEST_REPO}/issues/42/labels', method='POST', response={'ok': True})
+          backport_mod.add_pull_request_label(42, backport_mod.PENDING_LABEL)
+          assert any(f'repos/{TEST_REPO}/issues/42/labels' in c['path'] for c in gh_mock.calls)
 
 Note: We treat paths exactly as provided to `gh_request` after query param expansion.
 If you register a route with query parameters, include the full `path?query=..` string.

--- a/msmarco-v2-vector/_tools/parse_documents.py
+++ b/msmarco-v2-vector/_tools/parse_documents.py
@@ -73,7 +73,7 @@ def parse_arguments():
 
 
 if __name__ == "__main__":
-    (max_documents, start_page, end_page) = parse_arguments()
+    max_documents, start_page, end_page = parse_arguments()
     if max_documents == DEFAULT_MAX_DOCS:
         output_pages(start_page, end_page)
     else:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.19`:
 - [Drive-by style fixes (#1209)](https://github.com/elastic/rally-tracks/pull/1209)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Steve Shulman-Laniel","email":"steve.shulmanlaniel@elastic.co"},"sourceCommit":{"committedDate":"2026-07-02T10:23:14Z","message":"Drive-by style fixes (#1209)","sha":"b75b4e4e79b405e667f12402fc40c2889d95b5f2","branchLabelMapping":{"^v9.5$":"master","^vServerless$":"master","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["backport pending","v8.15","v8.19","v9.4","v9.5"],"title":"Drive-by style fixes","number":1209,"url":"https://github.com/elastic/rally-tracks/pull/1209","mergeCommit":{"message":"Drive-by style fixes (#1209)","sha":"b75b4e4e79b405e667f12402fc40c2889d95b5f2"}},"sourceBranch":"master","suggestedTargetBranches":["8.15","8.19","9.4"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"master","label":"v9.5","branchLabelMappingKey":"^v9.5$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/rally-tracks/pull/1209","number":1209,"mergeCommit":{"message":"Drive-by style fixes (#1209)","sha":"b75b4e4e79b405e667f12402fc40c2889d95b5f2"}}]}] BACKPORT-->