### PR TITLE
[9.3] Backport CLI refactor (#968)

### DIFF
--- a/.github/workflows/backport.reminder.yml
+++ b/.github/workflows/backport.reminder.yml
@@ -11,14 +11,14 @@ on:
       single_pr:
         description: 'PR number to process (single-PR run; leave empty for bulk)'
         required: false
+      lookback_mode:
+        description: "PR lookback basis: 'updated' (default) or 'merged'"
+        required: false
+        default: 'updated'
       lookback_days:
         description: 'Lookback window for merged PRs (days)'
         required: false
         default: '7'
-      pending_label_age_days:
-        description: 'Minimum previous reminder age (days)'
-        required: false
-        default: '14'
       remove:
         description: 'If set to true, remove pending labels/reminders instead of adding/reminding'
         required: false
@@ -52,5 +52,5 @@ jobs:
         run: |
           pr_number_clause="${{ github.event.inputs.single_pr && format('--pr-number {0}', github.event.inputs.single_pr) || '' }}"
           remove_clause="${{ github.event.inputs.remove == 'true' && '--remove' || '' }}"
-          python github_ci_tools/scripts/backport.py $pr_number_clause label --lookback-days ${{ github.event.inputs.lookback_days || '7' }} $remove_clause
-          python github_ci_tools/scripts/backport.py $pr_number_clause remind --pending-reminder-age-days ${{ github.event.inputs.pending_label_age_days || '14' }} $remove_clause
+          python github_ci_tools/scripts/backport.py $pr_number_clause label --lookback-days ${{ github.event.inputs.lookback_days || '7' }} --lookback-mode ${{ github.event.inputs.lookback_mode || 'updated' }} $remove_clause
+          python github_ci_tools/scripts/backport.py $pr_number_clause remind --lookback-days ${{ github.event.inputs.lookback_days || '7' }} --lookback-mode ${{ github.event.inputs.lookback_mode || 'updated' }} $remove_clause

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the default track specifications for the Elasticsearch 
 Tracks are used to describe benchmarks in Rally. For each track, the README.md file documents the data used, explains its parameters and provides an example document.
 
 > [!NOTE]
-> You can also [create your own track](https://esrally.readthedocs.io/en/latest/adding_tracks.html) to ensure your benchmarks will be as realistic as possible.
+> It is also possible to create a [custom track](https://esrally.readthedocs.io/en/latest/adding_tracks.html) to ensure that benchmarks are as realistic as possible.
 
 # Versioning Scheme
 
@@ -13,10 +13,10 @@ Refer to the official [Rally docs](https://esrally.readthedocs.io/en/stable/trac
 
 # How to Contribute
 
-If you want to contribute a track, please ensure that it works against the main version of Elasticsearch (i.e. submit PRs against the master branch). We can then check whether it's feasible to backport the track to earlier Elasticsearch versions.
+Contributions of new tracks should be compatible with the main version of Elasticsearch (i.e., pull requests should be submitted against the master branch). Feasibility of backporting to earlier Elasticsearch versions will be evaluated following submission.
 
 > [!NOTE]
-> See all details in the [contributor guidelines](https://github.com/elastic/rally/blob/master/CONTRIBUTING.md).
+> For comprehensive instructions, refer to the [contributor guidelines](https://github.com/elastic/rally/blob/master/CONTRIBUTING.md).
 
 ## Development setup
 
@@ -37,44 +37,47 @@ make it
 
 # Backporting changes
 
-Backporting ensures that tracks do not work only for the latest `main` version of Elasticsearch but also for older versions, so it is important. As part of contributing to this repository, a reminder will periodically notify you that backport is pending.
+Backporting ensures that tracks are compatible not only with the latest `main` version of Elasticsearch, but also with previous versions. For this reason, backporting is an important part of the contribution process. Periodic reminders will be issued when a backport is pending.
 
-In order to backport your PR, at least one `vX.Y` label has to be added. 
-- Please supply all the labels that correspond to both current and past elasticsearch versions you expect this PR to work with, but choose only from all the available ones. 
-- If the PR being merged is using functionality from future Elasticsearch versions, please wait for the creation of new Elasticsearch `vX.Y` version branch. In such case, it would be useful if you kept the 'backport pending' label attached to the PR, so the backport reminder can periodically notify you.
+To initiate backporting of a pull request, at least one `vX.Y` label must be applied.
+- Apply all the labels that correspond to Elasticsearch minor versions expected to work with this PR, but select only from the available ones.
 
-When adding a `vX.Y` label, the creation of a new PR is triggered unless there are merge conflicts. Its status is reported through a comment and in case it is successfully created, you get a link to  the PR opened against the target version branch. This new PR has a `backport` label and expects a review. When approved, it will be automatically merged.
+When a `vX.Y` label is added, a new pull request is automatically created, unless merge conflicts are detected or if the label supplied points to the next Elasticsearch minor version. The status of this process is reported via a comment, and if successful, a link to the newly opened pull request targeting the specified version branch is provided. This pull request will include a backport label and will require a review. Upon approval, it will be merged automatically.
 
 ## Merge conflicts
-Merge conflicts need to be resolved manually. There are two ways to manually create a backport PR 
+Merge conflicts must be resolved manually. There are two primary methods for manually creating a backport pull request: 
 
-## Fork and cherry-pick
-1. Create a rally-tracks fork, and clone it locally.
-2. Pull and checkout to the intended version branch. 
-3. Create a new local branch from this version branch.
-4. Cherry-pick the commit from the PR that will be backported.
-5. Resolve merge conflicts, commit locally and push to fork.
-6. Open a PR against the target branch, add `backport` label manually.
-7. Request a review and merge.
-8. Repeat for other version branches. 
+### Fork and cherry-pick
+1. Fork the rally-tracks repository and clone it locally.
+2. Pull and check out the intended version branch.
+3. Create a new local branch from the selected version branch.
+4. Cherry-pick the commit from the pull request to be backported.
+5. Resolve any merge conflicts, commit the changes locally, and push to the fork.
+6. Open a pull request against the target branch and manually add the backport label.
+7. Request a review and proceed with merging.
+8. Repeat this process for additional version branches as needed.
 
-## Use backport tool (requires node)
-1. Go to the [Backport tool](https://github.com/sorenlouv/backport?tab=readme-ov-file#backport-cli-tool) documentation and follow the guidelines to install it in your local `rally-tracks` directory. Note that you have to add your personal access secret token locally in `~/.backport/config.json` with the [specified](https://github.com/sorenlouv/backport/blob/main/docs/config-file-options.md#global-config-backportconfigjson) repository access. At the end of this step, you should be able to execute `backport` command inside rally-tracks repo.
-2. cd in your local `rally-tracks` repository and execute `backport --pr <merged_pr_number>`. This will open an interactive dialog where you are required to selected branches to backport to. You can only select the version branches that have merge conflicts. After selecting the branches, backport tool will mention some directory in a message `Please fix the conflicts in /home/<user>/.backport/repositories/elastic/rally-tracks` and you will have to go and resolve those conflicts manually for all of the selected branches. If it is not easy to tackle multiple branches in a single sweep, repeat this procedure for each target version branch separately.
-3. After resolving the merge conflicts you can execute `backport --pr <merged_pr_number>` which this time it will be successful. PRs will be opened against the target version branches and they will be ready for approval and merge.
+### Use backport tool (requires Node.js)
+1. Refer to the [Backport tool](https://github.com/sorenlouv/backport?tab=readme-ov-file#backport-cli-tool) for installation instructions in the local rally-tracks directory. Ensure that a personal access token is configured in `~/.backport/config.json` with the required [repository access](https://github.com/sorenlouv/backport/blob/main/docs/config-file-options.md#global-config-backportconfigjson). Upon completion, the `backport` command should be available within the rally-tracks repository.
+2. Navigate to the local `rally-tracks` repository and execute `backport --pr <merged_pr_number>`. This command initiates an interactive dialog for selecting branches to backport to. Only version branches with merge conflicts can be selected. After branch selection, the tool will indicate a directory (e.g., `Please fix the conflicts in /home/<user>/.backport/repositories/elastic/rally-tracks`) where conflicts must be resolved manually for each selected branch. If resolving multiple branches simultaneously is not feasible, repeat the procedure for each target version branch individually.
+3. Once merge conflicts are resolved, re-execute `backport --pr <merged_pr_number>`. The process should now complete successfully, and pull requests will be opened against the target version branches, ready for review and merging.
+
+> [!NOTE]
+> In the event of conflicts, git blame is a useful tool for identifying changes that must be included in a version branch prior to backporting. The history of modified files can be compared between the target backport branch and the master branch.
 
 ## Backporting Notes
-- CI is essential to this procedure. Whenever you commit something in a backport PR, check the test results.
-- In case of conflicts, git blame is a wonderful tool to understand what changes need to be included in a version branch before backporting your PR. You can always check the history of the files you touch between the target backport branch and master version branch.
-- Sometimes it is necessary to remove individual operations from a track that are not supported by earlier versions. This graceful fallback is a compromise to allow to run a subset of the track on older versions of Elasticsearch too.
+- Continuous Integration (CI) is integral to the backporting process. After each commit to a backport pull request, review the test results to ensure correctness.
+- In the event of conflicts, git blame can be used to identify which changes need to be included in a version branch prior to backporting. The history of modified files can be compared between the target backport branch and the master branch.
+- In some cases, it may be necessary to remove individual operations from a track that are not supported by earlier versions. This approach allows a subset of the track to run on older versions of Elasticsearch, providing a graceful fallback.
 
-## Finish line
-For wrapping up ensure the following:
-- Your merged PR has all the correct version labels.
-- Every related backport PR has the `backport` label.
-- Every related backport PR is merged to the correct version branches.
+## Final steps
+To complete the process, ensure the following:
 
-Finally, remove the `backport pending` label from your PR.
+- The merged pull request includes all relevant version labels.
+- Each associated backport pull request is labeled with backport.
+- Each backport pull request is merged into the appropriate version branch.
+
+Finally, remove the `backport pending` label.
 
 # License
 

--- a/github_ci_tools/scripts/backport.py
+++ b/github_ci_tools/scripts/backport.py
@@ -39,18 +39,18 @@ Commands:
 
 Flags:
     --lookback-days N                    Days to scan in bulk
-    --pending-reminder-age-days M           Days between reminders
+    --lookback-mode MODE                 Bulk mode lookback basis: updated (default) or merged
     --remove                             Remove 'backport pending' label
 
 Quick usage:
     backport.py --pr-number 42 label
     backport.py --repo owner/name label --lookback-days 7
-    backport.py --repo owner/name remind --lookback-days 30 --pending-reminder-age-days 14
+    backport.py --repo owner/name remind --lookback-days 30
     backport.py --repo owner/name --dry-run -vv label --lookback-days 30
 
 Logic:
     Add label when: no version label (regex vX(.Y)), no pending or 'backport' label.
-    Remind when: pending label present AND (no previous reminder OR last reminder older than M days).
+    Remind when: pending label present AND (no previous reminder OR last reminder older than lookback window).
     Marker: <!-- backport-pending-reminder -->
 
 Exit codes: 0 success / 1 error.
@@ -78,19 +78,20 @@ VERSION_LABEL_RE = re.compile(r"^v\d{1,2}(?:\.\d{1,2})?$")
 BACKPORT_LABEL = "backport"
 PENDING_LABEL = "backport pending"
 PENDING_LABEL_COLOR = "fff2bf"
-COULD_NOT_CREATE_LABEL_WARNING = "Could not create label"
+COULD_NOT_CREATE_LABEL_ERROR = "Could not create label"
+COULD_NOT_REMOVE_LABEL_ERROR = "Could not remove label"
 GITHUB_API = "https://api.github.com"
 COMMENT_MARKER_BASE = "<!-- backport-pending-reminder -->"  # static for detection
 REMINDER_BODY = (
-    "A backport is pending for this PR. Please add all required `vX.Y` version labels.\n\n"
-    "   - If it is intended for the current Elasticsearch release version, apply the corresponding version label.\n"
-    "   - If it also supports past released versions, add those labels too.\n"
-    "   - If it only targets a future version, wait until that version label exists and then add it.\n"
-    "     (Each rally-tracks version label is created during the feature freeze of a new Elasticsearch branch).\n\n"
-    "Backporting entails: \n"
+    "A backport is pending for this PR.\n"
+    "Apply all the labels that correspond to Elasticsearch minor versions expected to work with this PR, but select only from the available ones.\n"
+    "If intended for future releases, apply label for next minor\n\n"
+    "When a `vX.Y` label is added, a new pull request will be automatically created, unless merge conflicts are detected or if the label supplied points to the next Elasticsearch minor version. If successful, a link to the newly opened backport PR will be provided in a comment.\n\n"
+    "In case of merge conflicts during backporting, create the backport PR manually following the steps from [README](https://github.com/elastic/rally-tracks?tab=readme-ov-file#merge-conflicts):\n"
+    "**Final steps to complete the backporting process:**\n"
     "   1. Ensure the correct version labels exist in this PR.\n"
-    "   2. Ensure backport PRs have `backport` label and are passing tests.\n"
-    "   3. Merge backport PRs (you can approve yourself and enable auto-merge).\n"
+    "   2. Ensure each backport pull request is labeled with `backport`.\n"
+    "   3. Review and merge each backport pull request into the appropriate version branch.\n"
     "   4. Remove `backport pending` label from this PR once all backport PRs are merged.\n\n"
     "Thank you!"
 )
@@ -98,26 +99,26 @@ REMINDER_BODY = (
 
 @dataclass
 class BackportConfig:
-    token: str | None = None
-    repo: str | None = None
+    token: str = ""
+    repo: str = ""
     dry_run: bool = False
     log_level: int = logging.INFO
-    command: str | None = None
+    command: str = ""
     verbose: int = 0
     quiet: int = 0
 
 
 CONFIG = BackportConfig(
-    token=os.environ.get("BACKPORT_TOKEN"),
-    repo=os.environ.get("GITHUB_REPOSITORY"),
+    token=os.environ.get("BACKPORT_TOKEN", ""),
+    repo=os.environ.get("GITHUB_REPOSITORY", ""),
 )
 
 
 # ----------------------------- GH Helpers -----------------------------
 def gh_request(method: str = "GET", path: str = "", body: dict[str, Any] | None = None, params: dict[str, str] | None = None) -> Any:
-    if params:
-        path = f"{path}?{urlencode(params)}"
     url = f"{GITHUB_API}/{path}"
+    if params:
+        url += f"?{urlencode(params)}"
     data = None
     if body is not None:
         data = json.dumps(body).encode()
@@ -129,17 +130,13 @@ def gh_request(method: str = "GET", path: str = "", body: dict[str, Any] | None 
     req = urllib.request.Request(url, data=data, method=method)
     req.add_header("Authorization", f"Bearer {CONFIG.token}")
     req.add_header("Accept", "application/vnd.github+json")
-    try:
-        with urllib.request.urlopen(req) as resp:
-            charset = resp.headers.get_content_charset() or "utf-8"
-            txt = resp.read().decode(charset)
-            LOG.debug(f"Response {resp.status} {method}")
-            if resp.status >= 300:
-                raise RuntimeError(f"HTTP {resp.status}: {txt}")
-            return json.loads(txt) if txt.strip() else {}
-    except urllib.error.HTTPError as e:
-        err = e.read().decode()
-        raise RuntimeError(f"HTTP {e.code} {e.reason} {err}") from e
+    with urllib.request.urlopen(req) as resp:
+        charset = resp.headers.get_content_charset() or "utf-8"
+        txt = resp.read().decode(charset)
+        LOG.debug(f"Response {resp.status} {method}")
+        if resp.status >= 300:
+            raise RuntimeError(f"HTTP {resp.status}: {txt}")
+        return json.loads(txt) if txt.strip() else {}
 
 
 @dataclass
@@ -149,18 +146,19 @@ class PRInfo:
 
     @classmethod
     def from_dict(cls, pr: dict[str, Any]) -> "PRInfo":
-        number = int(pr.get("number") or pr.get("url", "").rstrip("/").strip().rsplit("/", 1) or -1)
-        labels = [lbl.get("name", "") for lbl in pr.get("labels", [])]
-        if number == -1 and not labels:
-            raise ValueError("...")
-        return cls(number, labels)
+        try:
+            number = int(pr.get("number") or pr.get("url", "").rstrip("/").strip().rsplit("/", 1))
+        except ValueError as e:
+            raise ValueError(f"No PR number in dict {pr}") from e
+        labels = [lbl["name"] for lbl in pr.get("labels", []) if "name" in lbl]
+        return cls(number=number, labels=labels)
 
 
 # ----------------------------- PR Extraction  -----------------------------
-def list_prs(q_filter: str, since: dt.datetime) -> Iterable[dict[str, Any]]:
-    """Query the GH API with a filter to iterate over PRs updated after a given timestamp."""
+def iter_prs(q_filter: str, since: dt.datetime, lookback_mode: str = "updated") -> Iterable[dict[str, Any]]:
+    """Query the GH API to iterate over PRs within the lookback window."""
     q_date = since.strftime("%Y-%m-%d")
-    q = f"{q_filter} updated:>={q_date}"
+    q = f"{q_filter} {lookback_mode}:>={q_date}"
     LOG.debug(f"Fetch PRs with filter '{q}'")
     params = {"q": f"{q}", "per_page": "100"}
     for page in itertools.count(1):
@@ -181,27 +179,19 @@ def add_repository_label(repository: str | None, name: str, color: str):
         if is_dry_run()
         else LOG.info(f"Creating label '{name}' with color '{color}' in repo '{repository}'")
     )
-    gh_request(method="POST", path=f"repos/{repository}/labels", body={"name": name, "color": color})
-
-
-def repo_needs_pending_label(repo_labels: list[str]) -> bool:
-    LOG.debug(f"{PENDING_LABEL} in repo labels: {repo_labels} -> {PENDING_LABEL in repo_labels}")
-    return PENDING_LABEL not in repo_labels
+    try:
+        gh_request(method="POST", path=f"repos/{repository}/labels", body={"name": name, "color": color})
+    except Exception as e:
+        raise RuntimeError(f"{COULD_NOT_CREATE_LABEL_ERROR}: {e}")
 
 
 def ensure_backport_pending_label() -> None:
     """If the exact PENDING_LABEL string does not appear at least once, we create it."""
-    try:
-        existing = gh_request(path=f"repos/{CONFIG.repo}/labels", params={"per_page": "100"})
-    except Exception as e:
-        existing = []
-    names = [lbl.get("name", "") for lbl in existing]
-    if not repo_needs_pending_label(names):
-        return
-    try:
-        add_repository_label(repository=CONFIG.repo, name=PENDING_LABEL, color=PENDING_LABEL_COLOR)
-    except Exception as e:
-        LOG.warning(f"{COULD_NOT_CREATE_LABEL_WARNING}: {e}")
+    # It checks if the label is already set.
+    for label in gh_request(path=f"repos/{CONFIG.repo}/labels", params={"per_page": "100"}):
+        if label.get("name") == PENDING_LABEL:
+            return
+    add_repository_label(repository=CONFIG.repo, name=PENDING_LABEL, color=PENDING_LABEL_COLOR)
 
 
 def pr_needs_pending_label(info: PRInfo) -> bool:
@@ -220,7 +210,10 @@ def remove_pull_request_label(pr_number: int, label: str) -> None:
         if is_dry_run()
         else LOG.info(f"Removing label '{label}' from PR #{pr_number}")
     )
-    gh_request(method="DELETE", path=f"repos/{CONFIG.repo}/issues/{pr_number}/labels", body={"labels": [label]})
+    try:
+        gh_request(method="DELETE", path=f"repos/{CONFIG.repo}/issues/{pr_number}/labels", body={"labels": [label]})
+    except Exception as e:
+        raise RuntimeError(f"{COULD_NOT_REMOVE_LABEL_ERROR}: {e}")
 
 
 def run_label(prefetched_prs: list[dict[str, Any]], remove: bool) -> int:
@@ -228,10 +221,7 @@ def run_label(prefetched_prs: list[dict[str, Any]], remove: bool) -> int:
     if not prefetched_prs:
         raise RuntimeError("No PRs prefetched for labeling")
     # Ensure repository has pending label definition before any per-PR action.
-    try:
-        ensure_backport_pending_label()
-    except Exception as e:
-        raise RuntimeError(f"Cannot ensure that backport pending label exists in repo: {e}")
+    ensure_backport_pending_label()
     errors = 0
     for pr in prefetched_prs:
         try:
@@ -295,7 +285,7 @@ def pr_needs_reminder(info: PRInfo, threshold: dt.datetime) -> bool:
     prev_time = last_reminder_time(comments, COMMENT_MARKER_BASE)
     if prev_time is None:
         return True
-    return prev_time < threshold
+    return prev_time.date() <= threshold.date()
 
 
 def delete_reminders(info: PRInfo) -> None:
@@ -315,12 +305,12 @@ def delete_reminders(info: PRInfo) -> None:
             LOG.info(f"Deleted comment ID {comment_id} on PR #{info.number}")
 
 
-def run_remind(prefetched_prs: list[dict[str, Any]], pending_reminder_age_days: int, remove: bool) -> int:
+def run_remind(prefetched_prs: list[dict[str, Any]], lookback_days: int, remove: bool) -> int:
     """Post reminders using prefetched merged PR list."""
     if not prefetched_prs:
         raise RuntimeError("No PRs prefetched for reminding")
     now = dt.datetime.now(dt.timezone.utc)
-    threshold = now - dt.timedelta(days=pending_reminder_age_days)
+    threshold = now - dt.timedelta(days=lookback_days)
     errors = 0
     for pr in prefetched_prs:
         try:
@@ -368,13 +358,13 @@ def configure(args: argparse.Namespace) -> None:
     CONFIG.quiet = args.quiet
     CONFIG.log_level = (CONFIG.quiet - CONFIG.verbose) * (logging.INFO - logging.DEBUG) + logging.INFO
     CONFIG.command = args.command
-    CONFIG.token = os.environ.get("BACKPORT_TOKEN")
-    CONFIG.repo = args.repo if args.repo is not None else os.environ.get("GITHUB_REPOSITORY")
+    CONFIG.token = os.environ.get("BACKPORT_TOKEN", "")
+    CONFIG.repo = args.repo if args.repo else os.environ.get("GITHUB_REPOSITORY", "")
     logging.basicConfig(level=CONFIG.log_level, format="%(asctime)s %(levelname)s %(name)s %(message)s")
     require_mandatory_vars()
 
 
-def prefetch_prs(pr_number: int | None, lookback_days: int) -> list[dict[str, Any]]:
+def prefetch_prs(pr_number: int | None, lookback_days: int, lookback_mode: str = "updated") -> list[dict[str, Any]]:
     if pr_number is not None:
         q_path = f"repos/{CONFIG.repo}/pulls/{pr_number}"
         pr_data = gh_request(path=q_path)
@@ -389,99 +379,101 @@ def prefetch_prs(pr_number: int | None, lookback_days: int) -> list[dict[str, An
             raise RuntimeError(f"Invalid merged_at format: {merged_at}") from e
         now = dt.datetime.now(dt.timezone.utc)
         age_days = (now - merged_dt).days
-        if age_days >= lookback_days + 1:
+        if age_days > lookback_days:
             LOG.info(
-                f"PR #{pr_data.get('number','?')} merged_at {merged_at} age={age_days}d "
-                f"exceeds lookback_days={lookback_days}; filtering out."
+                f"PR #{pr_data.get('number','?')} merged_at {merged_at} age={age_days}d " f"exceeds {lookback_days} days; filtering out."
             )
             return []
         return [pr_data]
     now = dt.datetime.now(dt.timezone.utc)
-    since = now - dt.timedelta(days=lookback_days)
+    since = now - dt.timedelta(days=lookback_days + 2)  # Add safety margin for edge cases.
     # Note that we rely on is:merged to filter out unmerged PRs.
-    return list(list_prs(f"repo:{CONFIG.repo} is:pr is:merged", since))
+    return list(iter_prs(f"repo:{CONFIG.repo} is:pr is:merged", since, lookback_mode=lookback_mode))
 
 
 def parse_args() -> argparse.Namespace:
-    try:
-        parser = argparse.ArgumentParser(
-            description="Backport utilities",
-            epilog="""\nExamples:\n  backport.py --pr-number 42 label\n  backport.py label --lookback-days 7\n  backport.py remind --lookback-days 30 --pending-reminder-age-days 14\n  backport.py --dry-run -vv label --lookback-days 30\n\nSingle PR mode fetches PR by number (--pr-number) .\nBulk mode searches merged PRs updated within lookback (--lookback-days).\n""",
-            formatter_class=argparse.RawDescriptionHelpFormatter,
-        )
-        parser.add_argument(
-            "--repo",
-            help="Target repository in owner/repo form (overrides GITHUB_REPOSITORY env)",
-            required=False,
-            default=None,
-        )
-        parser.add_argument(
-            "--pr-number",
-            action="store",
-            help="Single PR mode. Default: bulk scan via search API",
-        )
-        parser.add_argument(
-            "--dry-run",
-            action="store_true",
-            help="Simulate actions without modifying GitHub state",
-        )
-        parser.add_argument(
-            "-v",
-            "--verbose",
-            action="count",
-            default=0,
-            help="Increase verbosity (can be used multiple times, e.g., -vv for more verbose)",
-        )
-        parser.add_argument(
-            "-q",
-            "--quiet",
-            action="count",
-            default=0,
-            help="Decrease verbosity (can be used multiple times)",
-        )
-        sub = parser.add_subparsers(dest="command", required=True)
+    parser = argparse.ArgumentParser(
+        description="Backport utilities",
+        epilog="""\nExamples:\n  backport.py --pr-number 42 label\n  backport.py label --lookback-days 7\n  backport.py remind --lookback-days 30\n  backport.py --dry-run -vv label --lookback-days 30\n\nSingle PR mode fetches PR by number (--pr-number) .\nBulk mode searches merged PRs updated within lookback (--lookback-days).\n""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--repo",
+        help="Target repository in owner/repo form (overrides GITHUB_REPOSITORY env)",
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
+        "--pr-number",
+        action="store",
+        help="Single PR mode. Default: bulk scan via search API",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Simulate actions without modifying GitHub state",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity (can be used multiple times, e.g., -vv for more verbose)",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="count",
+        default=0,
+        help="Decrease verbosity (can be used multiple times)",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
 
-        p_label = sub.add_parser(
-            "label", help="Add backport pending label to merged PRs lacking 'backport', 'backport pending' or version label"
-        )
-        p_label.add_argument(
-            "--lookback-days",
-            type=int,
-            required=False,
-            default=7,
-            help="Days to look back (default: 7).",
-        )
-        p_label.add_argument(
-            "--remove",
-            action="store_true",
-            default=False,
-            help="Removes backport pending label",
-        )
+    p_label = sub.add_parser(
+        "label", help="Add backport pending label to merged PRs lacking 'backport', 'backport pending' or version label"
+    )
+    p_label.add_argument(
+        "--lookback-days",
+        type=int,
+        required=False,
+        default=7,
+        help="Days to look back (default: 7).",
+    )
+    p_label.add_argument(
+        "--lookback-mode",
+        choices=["updated", "merged"],
+        required=False,
+        default="updated",
+        help="Bulk mode lookback basis: 'updated' (default) or 'merged'.",
+    )
+    p_label.add_argument(
+        "--remove",
+        action="store_true",
+        default=False,
+        help="Removes backport pending label",
+    )
 
-        p_remind = sub.add_parser("remind", help="Post reminders on merged PRs still pending backport")
-        p_remind.add_argument(
-            "--lookback-days",
-            type=int,
-            required=False,
-            default=7,
-            help="Days to look back (default: 7).",
-        )
-        p_remind.add_argument(
-            "--pending-reminder-age-days",
-            type=int,
-            required=False,
-            default=14,
-            help="Days between reminders for the same PR (default: 14). Adds initial reminder if none posted yet.",
-        )
-        p_remind.add_argument(
-            "--remove",
-            action="store_true",
-            default=False,
-            help="Remove backport pending reminder comments instead of adding new ones",
-        )
-
-    except Exception:
-        raise RuntimeError("Command parsing failed")
+    p_remind = sub.add_parser("remind", help="Post reminders on merged PRs still pending backport")
+    p_remind.add_argument(
+        "--lookback-days",
+        type=int,
+        required=False,
+        default=7,
+        help="Days to look back (default: 7).",
+    )
+    p_remind.add_argument(
+        "--lookback-mode",
+        choices=["updated", "merged"],
+        required=False,
+        default="updated",
+        help="Bulk mode lookback basis: 'updated' (default) or 'merged'.",
+    )
+    p_remind.add_argument(
+        "--remove",
+        action="store_true",
+        default=False,
+        help="Remove backport pending reminder comments instead of adding new ones",
+    )
     return parser.parse_args()
 
 
@@ -490,13 +482,13 @@ def main():
     configure(args)
 
     LOG.debug(f"Parsed arguments: {args}")
-    prefetched = prefetch_prs(int(args.pr_number) if args.pr_number else None, args.lookback_days)
+    prefetched = prefetch_prs(int(args.pr_number) if args.pr_number else None, args.lookback_days, lookback_mode=args.lookback_mode)
     LOG.debug(f"Prefetched {len(prefetched)} PRs for command '{args.command}': {[pr.get('number') for pr in prefetched]}")
     match args.command:
         case "label":
             return run_label(prefetched, args.remove)
         case "remind":
-            return run_remind(prefetched, args.pending_reminder_age_days, args.remove)
+            return run_remind(prefetched, args.lookback_days, args.remove)
         case _:
             raise NotImplementedError(f"Unknown command {args.command}")
 

--- a/github_ci_tools/tests/conftest.py
+++ b/github_ci_tools/tests/conftest.py
@@ -36,7 +36,6 @@ from urllib.parse import urlencode
 
 import pytest
 
-from github_ci_tools.scripts import backport
 from github_ci_tools.tests.utils import NOW, TEST_REPO, convert_str_to_date
 
 
@@ -54,8 +53,10 @@ def set_env() -> None:
 
 # --------------------------- Module Loader ---------------------------
 @pytest.fixture(scope="function")
-def backport_mod(monkeypatch) -> Any:
-    module = backport
+def backport_mod(set_env, monkeypatch) -> Any:
+    # Lazy import so module-level CONFIG reads env vars set by `set_env`.
+    from github_ci_tools.scripts import backport as module
+
     fixed = convert_str_to_date(NOW)
 
     class FixedDateTime(dt.datetime):

--- a/github_ci_tools/tests/resources/case_registry.py
+++ b/github_ci_tools/tests/resources/case_registry.py
@@ -114,6 +114,18 @@ PR_CASES: list[PullRequestCase] = [
             COMMENTS["really_old_reminder"],
         ],
     ),
+    _pr(
+        number=110,
+        merged_at="2025-10-23T10:00:00Z",
+        labels=LABELS["pending"],
+        backport_pending_in_labels=True,
+        needs_reminder=True,
+        comments=[
+            COMMENTS["reminder_slightly_older_than_a_week"],
+            COMMENTS["old_reminder"],
+            COMMENTS["old_comment"],
+        ],
+    ),
     # Unmerged PRs should be ignored no matter what their state is.
     _pr(number=201, merged=False, needs_pending=True, needs_reminder=True),
     _pr(
@@ -291,7 +303,7 @@ class GHInteractAction(Enum):
     PR_POST_REMINDER_COMMENT = "post_reminder_comment"
     REPO_GET_LABELS = "get_repo_labels"
     REPO_ADD_LABEL = "add_repo_label"
-    LIST_PRS = "list_prs"
+    ITER_PRS = "iter_prs"
 
 
 def build_gh_routes_comments(method: str, prs: list[PullRequestCase]) -> list[GHRoute]:
@@ -347,7 +359,22 @@ def build_gh_routes_labels(method: str, prs: list[PullRequestCase]) -> list[GHRo
     return routes
 
 
-def expected_actions_for_prs(action: GHInteractAction, prs: list[PullRequestCase]) -> list[tuple[str, str]]:
+def build_gh_routes_repo() -> list[GHRoute]:
+    return [
+        GHRoute(
+            f"/repos/{TEST_REPO}/labels",
+            method="GET",
+            response={},
+        ),
+        GHRoute(
+            f"/repos/{TEST_REPO}/labels",
+            method="POST",
+            response={},
+        ),
+    ]
+
+
+def expected_actions_for_prs(action: GHInteractAction, prs: list[PullRequestCase], lookback_mode: str = "updated") -> list[tuple[str, str]]:
     actions = []
     match action:
         case GHInteractAction.PR_ADD_PENDING_LABEL:
@@ -366,8 +393,8 @@ def expected_actions_for_prs(action: GHInteractAction, prs: list[PullRequestCase
         case GHInteractAction.PR_POST_REMINDER_COMMENT:
             for pr in prs:
                 actions.append(("POST", f"/repos/{TEST_REPO}/issues/{pr.number}/comments"))
-        case GHInteractAction.LIST_PRS:
-            actions.append(("GET", f"/search/issues...merged...updated..."))
+        case GHInteractAction.ITER_PRS:
+            actions.append(("GET", f"/search/issues...merged...{lookback_mode}..."))
         case _:
             raise ValueError(f"Unsupported PR action: {action}")
     return actions

--- a/github_ci_tools/tests/resources/cases.py
+++ b/github_ci_tools/tests/resources/cases.py
@@ -123,7 +123,6 @@ class GHInteractionCase:
     repo: RepoCase = field(default_factory=RepoCase)
     routes: list[GHRoute] = field(default_factory=list)
     lookback_days: int = 7
-    pending_reminder_age_days: int = 7
     expected_prefetch_prs: list[dict[str, Any]] | None = field(default_factory=list)
     expected_order: list[tuple[str, str]] = field(default_factory=list)
     strict: bool = True

--- a/github_ci_tools/tests/test_backport_label.py
+++ b/github_ci_tools/tests/test_backport_label.py
@@ -1,10 +1,13 @@
 from dataclasses import asdict
 
+import pytest
+
 from github_ci_tools.tests.resources.case_registry import (
     GHInteractAction,
     build_gh_routes_labels,
     case_by_number,
     expected_actions_for_prs,
+    expected_actions_for_repo,
     select_pull_requests,
 )
 from github_ci_tools.tests.resources.cases import GHInteractionCase, RepoCase, cases
@@ -30,17 +33,27 @@ def test_repo_ensure_backport_pending_label(backport_mod, gh_mock, caplog, case:
 
     if case.needs_pending:
         if case.create_raises:
-            gh_mock.add(static_create_pending_label.method, static_create_pending_label.path, exception=RuntimeError("fail create"))
+            gh_mock.add(
+                static_create_pending_label.method, static_create_pending_label.path, exception=RuntimeError("Could not create label")
+            )
+            with pytest.raises(RuntimeError, match=backport_mod.COULD_NOT_CREATE_LABEL_ERROR):
+                backport_mod.ensure_backport_pending_label()
+            assertions = [
+                *expected_actions_for_repo(GHInteractAction.REPO_GET_LABELS),
+                (static_create_pending_label.method, static_create_pending_label.path),
+            ]
+            gh_mock.assert_calls_in_order(*assertions)
+            return
         else:
             gh_mock.add(static_create_pending_label.method, static_create_pending_label.path, response=static_create_pending_label.response)
+            backport_mod.ensure_backport_pending_label()
+    else:
+        backport_mod.ensure_backport_pending_label()
 
-    backport_mod.ensure_backport_pending_label()
-    assertions = [(static_get_labels.method, static_get_labels.path)]
-    if case.needs_pending:
+    assertions = [*expected_actions_for_repo(GHInteractAction.REPO_GET_LABELS)]
+    if case.needs_pending and not case.create_raises:
         assertions.append((static_create_pending_label.method, static_create_pending_label.path))
     gh_mock.assert_calls_in_order(*assertions)
-    if case.create_raises and case.needs_pending:
-        assert any(f"{backport_mod.COULD_NOT_CREATE_LABEL_WARNING}" in rec.message for rec in caplog.records)
 
 
 @cases(

--- a/github_ci_tools/tests/test_backport_reminder.py
+++ b/github_ci_tools/tests/test_backport_reminder.py
@@ -80,19 +80,19 @@ def test_get_issue_comments(backport_mod, gh_mock, case: GHInteractionCase):
 
 
 @cases(
-    # pr_that_has_no_pending_label_does_not_get_commented=GHInteractionCase(
-    #     repo=RepoCase(prs=[case_by_number(101)]),
-    #     routes=[
-    #         *build_gh_routes_comments("GET", [case_by_number(101)]),
-    #     ],
-    # ),
-    # pr_has_pending_label_and_needs_reminder_gets_one=GHInteractionCase(
-    #     repo=RepoCase(prs=[case_by_number(108)]),
-    #     routes=[
-    #         *build_gh_routes_comments("GET", [case_by_number(108)]),
-    #         *build_gh_routes_comments("POST", [case_by_number(108)]),
-    #     ],
-    # ),
+    pr_that_has_no_pending_label_does_not_get_reminder=GHInteractionCase(
+        repo=RepoCase(prs=[case_by_number(101)]),
+        routes=[
+            *build_gh_routes_comments("GET", [case_by_number(101)]),
+        ],
+    ),
+    pr_has_pending_label_and_needs_reminder_gets_one=GHInteractionCase(
+        repo=RepoCase(prs=[case_by_number(110)]),
+        routes=[
+            *build_gh_routes_comments("GET", [case_by_number(110)]),
+            *build_gh_routes_comments("POST", [case_by_number(110)]),
+        ],
+    ),
     all_prs_have_pending_label_and_needs_reminder_get_one=GHInteractionCase(
         repo=RepoCase(prs=select_pull_requests(backport_pending_in_labels=True, needs_reminder=True)),
         routes=[
@@ -100,20 +100,19 @@ def test_get_issue_comments(backport_mod, gh_mock, case: GHInteractionCase):
             *build_gh_routes_comments("POST", select_pull_requests(backport_pending_in_labels=True, needs_reminder=True)),
         ],
     ),
-    # all_prs_not_need_pending_and_has_reminder_does_not_get_one=GHInteractionCase(
-    #     repo=RepoCase(prs=select_pull_requests(backport_pending_in_labels=False, needs_reminder=False)),
-    #     routes=[
-    #         *build_gh_routes_comments("GET", select_pull_requests(backport_pending_in_labels=False, needs_reminder=False)),
-    #     ],
-    # ),
+    all_prs_not_need_pending_and_has_reminder_does_not_get_one=GHInteractionCase(
+        repo=RepoCase(prs=select_pull_requests(backport_pending_in_labels=False, needs_reminder=False)),
+        routes=[
+            *build_gh_routes_comments("GET", select_pull_requests(backport_pending_in_labels=False, needs_reminder=False)),
+        ],
+    ),
 )
 def test_remind_logic(backport_mod, gh_mock, case: GHInteractionCase):
     """Test of the exact logic as in run_label."""
     case.register(gh_mock)
-    threshold = backport_mod.dt.datetime.now(backport_mod.dt.timezone.utc) - backport_mod.dt.timedelta(days=case.pending_reminder_age_days)
+    threshold = backport_mod.dt.datetime.now(backport_mod.dt.timezone.utc) - backport_mod.dt.timedelta(days=case.lookback_days)
     for pr in case.repo.prs:
         # Test of the exact logic as in run_remind.
-
         needs_reminder = backport_mod.pr_needs_reminder(backport_mod.PRInfo.from_dict(asdict(pr)), threshold)
         assert needs_reminder is pr.needs_reminder
 

--- a/github_ci_tools/tests/utils.py
+++ b/github_ci_tools/tests/utils.py
@@ -110,12 +110,6 @@ SEARCH_ISSUES_PER_PAGE = 100
 NOW = "2025-10-30T12:00:00Z"
 ISO_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
-AGES = {
-    "old_7_days": dt.datetime.strptime("2025-10-23T12:00:00Z", ISO_FORMAT).replace(tzinfo=dt.timezone.utc),
-    "old_14_days": dt.datetime.strptime("2025-10-16T12:00:00Z", ISO_FORMAT).replace(tzinfo=dt.timezone.utc),
-    "really_old": dt.datetime.strptime("2023-10-01T12:00:00Z", ISO_FORMAT).replace(tzinfo=dt.timezone.utc),
-}
-
 # Note that we should not import from the backport module directly to avoid circular imports.
 PENDING_LABEL = "backport pending"
 PENDING_LABEL_COLOR = "fff2bf"
@@ -135,6 +129,11 @@ LABELS = {
 COMMENT_MARKER_BASE = "<!-- backport-pending-reminder -->"
 COMMENTS = {
     "recent_reminder": Comment(f"{COMMENT_MARKER_BASE}\nThis is a recent reminder.", created_at="2025-10-23T12:00:00Z", is_reminder=True),
+    "reminder_slightly_older_than_a_week": Comment(
+        f"{COMMENT_MARKER_BASE}\nThis is a recent reminder, just above the 7 days threshold.",
+        created_at="2025-10-23T10:00:00Z",
+        is_reminder=True,
+    ),
     "old_reminder": Comment(f"{COMMENT_MARKER_BASE}\nThis is an old reminder.", created_at="2025-10-01T12:00:00Z", is_reminder=True),
     "really_old_reminder": Comment(
         f"\nThis is a really old reminder.{COMMENT_MARKER_BASE}", created_at="2023-10-01T12:00:00Z", is_reminder=True


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.3`:
 - [Backport CLI refactor (#968)](https://github.com/elastic/rally-tracks/pull/968)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Nick Dris","email":"nick.dris@elastic.co"},"sourceCommit":{"committedDate":"2026-02-11T21:04:12Z","message":"Backport CLI refactor (#968)\n\nRephrased instructions in README to be more formal\nUpdated reminder comment to follow the case of next minor version support.\nDropped --pending-age-reminder-days.\nAdded --lookback mode {updated|merged}","sha":"bf7024e4d1209461d5669dc758d9de07e9b1ae20","branchLabelMapping":{"^v9.4$":"master","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v8.15","v8.19","v9.3","v9.4"],"title":"Backport CLI refactor","number":968,"url":"https://github.com/elastic/rally-tracks/pull/968","mergeCommit":{"message":"Backport CLI refactor (#968)\n\nRephrased instructions in README to be more formal\nUpdated reminder comment to follow the case of next minor version support.\nDropped --pending-age-reminder-days.\nAdded --lookback mode {updated|merged}","sha":"bf7024e4d1209461d5669dc758d9de07e9b1ae20"}},"sourceBranch":"master","suggestedTargetBranches":["8.15","8.19","9.3"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.3","label":"v9.3","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"master","label":"v9.4","branchLabelMappingKey":"^v9.4$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/rally-tracks/pull/968","number":968,"mergeCommit":{"message":"Backport CLI refactor (#968)\n\nRephrased instructions in README to be more formal\nUpdated reminder comment to follow the case of next minor version support.\nDropped --pending-age-reminder-days.\nAdded --lookback mode {updated|merged}","sha":"bf7024e4d1209461d5669dc758d9de07e9b1ae20"}}]}] BACKPORT-->