### PR TITLE
[9.4] Fix BBOX arguments in Geopoint (#1221)

### DIFF
--- a/geopoint/operations/default.json
+++ b/geopoint/operations/default.json
@@ -792,7 +792,7 @@
     {
       "name": "geoGrid_aggs_geohash-esql",
       "operation-type": "esql",
-      "query": "FROM osmgeopoints | WHERE ST_Intersects(location, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.75, 48.95)\")) | EVAL geohash = ST_GEOHASH(location, 5, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.75, 48.95)\")) | STATS count = COUNT(*) BY geohash"
+      "query": "FROM osmgeopoints | WHERE ST_Intersects(location, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.95, 48.75)\")) | EVAL geohash = ST_GEOHASH(location, 5, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.95, 48.75)\")) | STATS count = COUNT(*) BY geohash"
     },
     {
       "name": "geoGrid_aggs_geotile",
@@ -824,7 +824,7 @@
     {
       "name": "geoGrid_aggs_geotile-esql",
       "operation-type": "esql",
-      "query": "FROM osmgeopoints | WHERE ST_Intersects(location, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.75, 48.95)\")) | EVAL geotile = ST_GEOTILE(location, 13, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.75, 48.95)\")) | STATS count = COUNT(*) BY geotile"
+      "query": "FROM osmgeopoints | WHERE ST_Intersects(location, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.95, 48.75)\")) | EVAL geotile = ST_GEOTILE(location, 13, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.95, 48.75)\")) | STATS count = COUNT(*) BY geotile"
     },
     {
       "name": "geoGrid_aggs_geohex",
@@ -856,5 +856,5 @@
     {
       "name": "geoGrid_aggs_geohex-esql",
       "operation-type": "esql",
-      "query": "FROM osmgeopoints | WHERE ST_Intersects(location, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.75, 48.95)\")) | EVAL geohex = ST_GEOHEX(location, 6, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.75, 48.95)\")) | STATS count = COUNT(*) BY geohex"
+      "query": "FROM osmgeopoints | WHERE ST_Intersects(location, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.95, 48.75)\")) | EVAL geohex = ST_GEOHEX(location, 6, TO_GEOSHAPE(\"BBOX(2.20, 2.40, 48.95, 48.75)\")) | STATS count = COUNT(*) BY geohex"
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.4`:
 - [Fix BBOX arguments in Geopoint (#1221)](https://github.com/elastic/rally-tracks/pull/1221)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Grzegorz Banasiak","email":"grzegorz.banasiak@elastic.co"},"sourceCommit":{"committedDate":"2026-07-03T08:06:54Z","message":"Fix BBOX arguments in Geopoint (#1221)","sha":"b4a6b7c84de9ec25e3287953fe8e1add5f8aa07f","branchLabelMapping":{"^v9.5$":"master","^vServerless$":"master","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["backport pending","v9.4","v9.5"],"title":"Fix BBOX arguments in Geopoint","number":1221,"url":"https://github.com/elastic/rally-tracks/pull/1221","mergeCommit":{"message":"Fix BBOX arguments in Geopoint (#1221)","sha":"b4a6b7c84de9ec25e3287953fe8e1add5f8aa07f"}},"sourceBranch":"master","suggestedTargetBranches":["9.4"],"targetPullRequestStates":[{"branch":"9.4","label":"v9.4","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"master","label":"v9.5","branchLabelMappingKey":"^v9.5$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/rally-tracks/pull/1221","number":1221,"mergeCommit":{"message":"Fix BBOX arguments in Geopoint (#1221)","sha":"b4a6b7c84de9ec25e3287953fe8e1add5f8aa07f"}}]}] BACKPORT-->