### PR TITLE
[8.15] Stop using third-party to free disk space (#1235)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,18 +162,14 @@ jobs:
       - run: echo "JAVA17_HOME=$JAVA_HOME_17_X64" >> $GITHUB_ENV
       - run: echo "JAVA11_HOME=$JAVA_HOME_11_X64" >> $GITHUB_ENV
       - name: Free Disk Space
-        continue-on-error: true
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-        with:
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-          tool-cache: false
-      - name: Check disk space before
-        run: df -h
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android
+          sudo apt-get clean
+          df -h
       - name: "Run tests${{ needs.filter-pr-changes.outputs.track_filter }}${{ needs.determine-es-build.outputs.revision }}${{ needs.determine-es-build.outputs.release_build }}"
         run: make it PY_VERSION=${{ matrix.python-version }} ARGS="${{ needs.filter-pr-changes.outputs.track_filter }}${{ needs.determine-es-build.outputs.revision }}${{ needs.determine-es-build.outputs.release_build }}"
         timeout-minutes: 160


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `8.15`:
 - [Stop using third-party to free disk space (#1235)](https://github.com/elastic/rally-tracks/pull/1235)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Quentin Pradet","email":"quentin.pradet@elastic.co"},"sourceCommit":{"committedDate":"2026-07-21T14:59:10Z","message":"Stop using third-party to free disk space (#1235)\n\nThis dependency was last updated in 2023, and doing it manually is enough for\nour needds.","sha":"cff4b31f89b3cb52f6c37f4f38920c8b3c39bb70","branchLabelMapping":{"^v9.6$":"master","^vServerless$":"master","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v8.15","v8.19","v9.4","v9.5","vServerless","v9.6"],"title":"Stop using third-party to free disk space","number":1235,"url":"https://github.com/elastic/rally-tracks/pull/1235","mergeCommit":{"message":"Stop using third-party to free disk space (#1235)\n\nThis dependency was last updated in 2023, and doing it manually is enough for\nour needds.","sha":"cff4b31f89b3cb52f6c37f4f38920c8b3c39bb70"}},"sourceBranch":"master","suggestedTargetBranches":["8.15","8.19","9.4","9.5"],"targetPullRequestStates":[{"branch":"8.15","label":"v8.15","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.19","label":"v8.19","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"master","label":"vServerless","branchLabelMappingKey":"^vServerless$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/rally-tracks/pull/1235","number":1235,"mergeCommit":{"message":"Stop using third-party to free disk space (#1235)\n\nThis dependency was last updated in 2023, and doing it manually is enough for\nour needds.","sha":"cff4b31f89b3cb52f6c37f4f38920c8b3c39bb70"}}]}] BACKPORT-->