### PR TITLE
Add a track `bring-your-own`

### DIFF
--- a/bring-your-own/README.md
+++ b/bring-your-own/README.md
@@ -1,0 +1,57 @@
+# ESRally Track: Search Template Benchmark
+
+This track allows benchmarking Elasticsearch search templates with randomized query inputs from a CSV file.
+It uses raw-request with a custom param-source to select random query strings.
+
+## File Structure
+
+```
+.rally/benchmarks/tracks/search_template/
+├── track.json            # Track definition
+├── track.py              # ParamSource: RandomParamSource
+├── queries.csv           # CSV file with one query per line
+└── README.md             # This file
+```
+ - track.json: Defines the track, operations, and challenges.
+ - track.py: Custom Python param source to supply randomized query strings.
+ - queries.csv: Input dataset for random queries. Each row should contain a realistic query string, which can include multiple terms. Providing realistic queries helps simulate actual search workloads and produces more accurate benchmarking results.
+
+
+## Requirements
+-	Elasticsearch Rally￼installed on a load driver. This machine needs to have sufficient CPU to generate the load for large number of clients. 
+-	The load driver needs to have access to the target Elasticsearch cluster and the monitoring cluster.
+-	The search template must exist in your cluster (defined with `PUT _scripts/<name>`)
+
+
+## Explanation of Options
+-	`--track-path`: Path to the track folder
+-	`--pipeline=benchmark-only`: Only runs the track operations, no system setup
+- `--target-hosts`: Elasticsearch hosts contains the target index and search template
+-	`--client-options`: Connection options, including api_key and use_ssl
+-	`--telemetry`: Collect node-level telemetry, defined in `.rally/rally.ini`
+-	`--kill-running-processes`: Stop any previous Rally processes
+-	`--user-tags`: Add custom tags to the run
+-	`--track-params`: Override runtime parameters (`index` and `search_template`)
+-	`--challenge`: Specify challenge schedule (e.g., `dryrun` or `real`)
+
+## Running the Track
+
+Example Command:
+```
+esrally race \
+  --track-path=<path_to>/.rally/benchmarks/tracks/search_template \
+  --pipeline=benchmark-only \
+  --target-hosts=<preprod_es_cluster_endpoint>:443 \
+  --client-options="api_key:'a0V...2dw==',use_ssl:True" \
+  --telemetry="node-stats" \
+  --kill-running-processes \
+  --user-tags="model:changeme" \
+  --track-params="index:my_index,search_template:my_search_template" \
+  --challenge="dryrun"
+```
+
+## Example queries.csv
+```
+common wealth bank
+apple banana orange
+```

--- a/bring-your-own/README.md
+++ b/bring-your-own/README.md
@@ -158,3 +158,4 @@ esrally race \
 - Keep `queries_file` aligned with the actual query terms your template expects.
 - If you use custom template parameters, prefer `params_file` so defaults stay out of the Python code.
 - The sample file [bring-your-own/params.json](params.json) is just an example and can be replaced with your own values.
+- On `--pipeline=benchmark-only` runs, Rally may print `[WARNING] ... indicating that the cluster is not in a defined clean state` for `merges_total_time`, `indexing_total_time`, `refresh_total_time`, and `flush_total_time`; since this track performs no indexing or merge operations, these warnings can be safely ignored.

--- a/bring-your-own/README.md
+++ b/bring-your-own/README.md
@@ -55,18 +55,22 @@ Use this track when you already have:
 
 ### Example command
 
+> Important: when using an inline `--track-params` string, the final key/value pair should not end with a `.json` file path. Rally will try to open the whole argument as a file if it detects a trailing `.json`, so the order of entries matters.
+
 ```bash
 esrally race \
-  --track-path=<path_to>/.rally/benchmarks/tracks/bring-your-own \
+  --track-path=bring-your-own \
   --pipeline=benchmark-only \
   --target-hosts=<es_cluster_endpoint>:443 \
-  --client-options="api_key:'a0V...2dw==',use_ssl:True" \
+  --client-options="basic_auth_user:my_user,basic_auth_password:my_password,use_ssl:True" \
   --telemetry="node-stats" \
   --kill-running-processes \
-  --user-tags="model:changeme" \
-  --track-params="index:my_index,search_template:my_search_template,queries_file:/tmp/my_queries.csv,params_file:/tmp/my_params.json" \
+  --user-tags="model:my_tag" \
+  --track-params="index:my_index,search_template:my_search_template,params_file:/tmp/my_params.json,queries_file:/tmp/my_queries.csv" \
   --challenge="dryrun"
 ```
+
+If Rally raises a `FileNotFoundError`, move the `params_file` entry before the trailing value or use a dedicated JSON file for `--track-params`.
 
 This file is optional and is useful when your template needs more than just `query_string`.
 
@@ -88,17 +92,17 @@ PUT _scripts/kibana_sample_flight_search_template
     "source": {
       "query": {
         "match": {
-          "DestCityName": "{{query_string}}",
-          "from": "{{from}}{{^from}}0{{/from}}",
-          "size": "{{size}}{{^size}}10{{/size}}"
-        }
+          "DestCityName": "{{query_string}}"
+        },
+        "from": "{{from}}{{^from}}0{{/from}}",
+        "size": "{{size}}{{^size}}10{{/size}}"
       }
     }
   }
 }
 ```
 
-### Example `params_file`, see params.json
+### Example `params_file`, see `./params.json`
 
 ```json
 {
@@ -108,7 +112,7 @@ PUT _scripts/kibana_sample_flight_search_template
 }
 ```
 
-### Example `queries_file`, see queries.csv
+### Example `queries_file`, see `./queries.csv`
 
 ```text
 Paris
@@ -130,7 +134,22 @@ POST kibana_sample_data_flights/_search/template
   }
 }
 ```
+### Example command when using kibana sample flight files
 
+Important: when `params_file` and `queries_files` are not specified in `--track-params`, the default files in this folder will be used instead.
+
+```bash
+esrally race \
+  --track=bring-your-own \
+  --pipeline=benchmark-only \
+  --target-hosts=<es_cluster_endpoint>:443 \
+  --client-options="basic_auth_user:my_user,basic_auth_password:my_password,use_ssl:True" \
+  --telemetry="node-stats" \
+  --kill-running-processes \
+  --user-tags="model:my_tag" \
+  --track-params="index:kibana_sample_data_flights,search_template:kibana_sample_flight_search_template" \
+  --challenge="dryrun"
+```
 ---
 
 ## Notes

--- a/bring-your-own/README.md
+++ b/bring-your-own/README.md
@@ -4,6 +4,8 @@ This track is used for Elasticsearch search benchmarking based on your own data 
 
 The Kibana sample data can be used as an example of how to construct the required files, but the track itself is designed for your own benchmark setup.
 
+This track can also be used offline when you already have a fixed dataset, a search template, and the query inputs available locally as it does not require any external data sources or live sample data.
+
 ## File structure
 
 ```

--- a/bring-your-own/README.md
+++ b/bring-your-own/README.md
@@ -9,7 +9,7 @@ This track can also be used offline when you already have a fixed dataset, a sea
 ## File structure
 
 ```
-.rally/benchmarks/tracks/search_template/
+.rally/benchmarks/tracks/bring-your-own/
 ├── track.json            # Track definition
 ├── track.py              # ParamSource: RandomParamSource
 ├── queries.csv           # CSV file with one query per line
@@ -27,10 +27,10 @@ This track can also be used offline when you already have a fixed dataset, a sea
 
 - Elasticsearch Rally is installed on a load driver.
 - The load driver has access to the target Elasticsearch cluster.
-- A index or alias to be queried already exists in the target Elasticsearch cluster.
+- An index or alias to be queried already exists in the target Elasticsearch cluster.
 - The search template already exists in the target Elasticsearch cluster (for example via `PUT _scripts/<name>`).
-- A `queries.csv` queries_file contains random query strings.
-- A `params.json` params_file contains all necessary params used for the search template.
+- A `queries.csv` file (provided via `queries_file`) contains random query strings.
+- An optional `params.json` file (provided via `params_file`) contains any additional params used by the search template.
 
 ## Common Rally options
 
@@ -106,7 +106,6 @@ PUT _scripts/kibana_sample_flight_search_template
 
 ```json
 {
-  "query_string": "Paris",
   "from": 0,
   "size": 5
 }

--- a/bring-your-own/README.md
+++ b/bring-your-own/README.md
@@ -1,45 +1,59 @@
 # ESRally Track: Search Template Benchmark
 
-This track allows benchmarking Elasticsearch search templates with randomized query inputs from a CSV file.
-It uses raw-request with a custom param-source to select random query strings and supports an optional JSON params file for custom template parameters.
+This track is used for Elasticsearch search benchmarking based on your own data and your own search template. It is commonly used to test different index options such as index size, sharding, mappings, and settings. It can also be used to test different search templates, such as loose or tight fuzziness, and to compare search performance across Elasticsearch versions.
 
-## File Structure
+The Kibana sample data can be used as an example of how to construct the required files, but the track itself is designed for your own benchmark setup.
+
+## File structure
 
 ```
 .rally/benchmarks/tracks/search_template/
 ├── track.json            # Track definition
 ├── track.py              # ParamSource: RandomParamSource
 ├── queries.csv           # CSV file with one query per line
-├── params.json           # Optional JSON params file with default template params
-└── README.md             # This file
+├── params.json           # Optional JSON params file with template defaults
+├── README.md             # This file
+└── _tests/               # Validation tests
 ```
- - track.json: Defines the track, operations, and challenges.
- - track.py: Custom Python param source to supply randomized query strings.
- - queries.csv: Input dataset for random queries. Each row should contain a realistic query string, which can include multiple terms. Providing realistic queries helps simulate actual search workloads and produces more accurate benchmarking results.
- - params.json: Optional template parameter defaults for your search template, such as `from` and `size`, when you want to keep those values out of the Python code.
 
+- `track.json`: Defines the track, operations, and challenges.
+- `track.py`: Custom Python param source to supply randomized query strings.
+- `queries.csv`: Input dataset for random queries. Each row should contain a realistic query string.
+- `params.json`: Query parameters used in the search template.
 
 ## Requirements
--	Elasticsearch Rally￼installed on a load driver. This machine needs to have sufficient CPU to generate the load for large number of clients. 
--	The load driver needs to have access to the target Elasticsearch cluster and the monitoring cluster.
--	The search template must exist in your cluster (defined with `PUT _scripts/<name>`)
 
+- Elasticsearch Rally is installed on a load driver.
+- The load driver has access to the target Elasticsearch cluster.
+- A index or alias to be queried already exists in the target Elasticsearch cluster.
+- The search template already exists in the target Elasticsearch cluster (for example via `PUT _scripts/<name>`).
+- A `queries.csv` queries_file contains random query strings.
+- A `params.json` params_file contains all necessary params used for the search template.
 
-## Explanation of Options
--	`--track-path`: Path to the track folder
--	`--pipeline=benchmark-only`: Only runs the track operations, no system setup
-- `--target-hosts`: Elasticsearch hosts contains the target index and search template
--	`--client-options`: Connection options, authenticate with either `api_key` or `basic_auth_user` with `basic_auth_password`. Set `use_ssl` as required.
--	`--telemetry`: Collect node-level telemetry, defined in `.rally/rally.ini`
--	`--kill-running-processes`: Stop any previous Rally processes
--	`--user-tags`: Add custom tags to the run
--	`--track-params`: Specify runtime parameters (`index`, `search_template` and `queries_file`)
--	`--challenge`: Specify challenge schedule (e.g., `dryrun` (for one client and one iteration) or `real`)
+## Common Rally options
 
-## Running the Track
+- `--track-path`: Path to the track folder
+- `--pipeline=benchmark-only`: Runs only the benchmark operations and skips system setup
+- `--target-hosts`: Elasticsearch hosts containing the target index and search template
+- `--client-options`: Connection settings such as `api_key` or both `basic_auth_user` and `basic_auth_password`; set `use_ssl` as required
+- `--telemetry`: Collect node-level telemetry, defined in `.rally/rally.ini`
+- `--kill-running-processes`: Stop any previous Rally processes
+- `--user-tags`: Add custom tags to the run
+- `--track-params`: Supply runtime parameters such as `index`, `search_template`, `queries_file`, and optionally `params_file`
+- `--challenge`: Select the challenge schedule, such as `dryrun` or `real`
 
-Bring your own `index`, `search_template` and `queries_file` example Command:
-```
+## Benchmarking with your own data
+
+Use this track when you already have:
+
+- an index with searchable documents
+- a search template deployed in Elasticsearch
+- a CSV file of query terms for `queries_file`
+- optionally a JSON file for `params_file` when your template needs more than `query_string`
+
+### Example command
+
+```bash
 esrally race \
   --track-path=<path_to>/.rally/benchmarks/tracks/bring-your-own \
   --pipeline=benchmark-only \
@@ -48,27 +62,23 @@ esrally race \
   --telemetry="node-stats" \
   --kill-running-processes \
   --user-tags="model:changeme" \
-  --track-params="index:my_index,search_template:my_search_template,queries_file:/tmp/my_queries.csv" \
+  --track-params="index:my_index,search_template:my_search_template,queries_file:/tmp/my_queries.csv,params_file:/tmp/my_params.json" \
   --challenge="dryrun"
 ```
 
-Running with the built-in `kibana_sample_flight` data command:
-```
-esrally race \
-  --track-path=<path_to>/.rally/benchmarks/tracks/bring-your-own \
-  --pipeline=benchmark-only \
-  --target-hosts=<es_cluster_endpoint>:443 \
-  --client-options="api_key:'a0V...2dw==',use_ssl:True" \
-  --telemetry="node-stats" \
-  --kill-running-processes \
-  --user-tags="model:changeme" \
-  --track-params="index:kibana_sample_data_flight,search_template:kibana_sample_flight_search_template,queries_file:/tmp/kibana_sample_flight_queries.csv,params_file:/tmp/kibana_sample_flight_params.json" \
-  --challenge="dryrun"
-```
+This file is optional and is useful when your template needs more than just `query_string`.
 
-- `search_template`:
-The following `kibana_sample_flight_search_template` will work with the [kibana_sample_data_flight](https://www.elastic.co/docs/manage-data/ingest/sample-data) index:
-```
+---
+
+## Kibana sample data as an example
+
+The Kibana sample data is useful as an example of how to structure the inputs for this track, but it is not a separate benchmark mode. It can help you understand the expected file layout and parameter shapes when building your own benchmark.
+
+### Example template
+
+This example uses the Kibana sample index [kibana_sample_data_flight](https://www.elastic.co/docs/manage-data/ingest/sample-data):
+
+```json
 PUT _scripts/kibana_sample_flight_search_template
 {
   "script": {
@@ -76,39 +86,55 @@ PUT _scripts/kibana_sample_flight_search_template
     "source": {
       "query": {
         "match": {
-          "DestCityName": "{{query_string}}"
-        },
-        "from": "{{from}}{{^from}}0{{/from}}",
-        "size": "{{size}}{{^size}}10{{/size}}"
+          "DestCityName": "{{query_string}}",
+          "from": "{{from}}{{^from}}0{{/from}}",
+          "size": "{{size}}{{^size}}10{{/size}}"
+        }
       }
     }
   }
 }
 ```
 
-- Example `params_file`:
-Once the sample index `kibana_sample_data_flight` is ingested, and the `kibana_sample_flight_search_template` search template is implemented, you can test the execution with the following:
-```
-POST kibana_sample_data_flights/_search/template
-{
-  "id": "kibana_sample_flight_search_template",
-  "params": {
-    "query_string": "Paris"
-  }
-}
-```
+### Example `params_file`, see params.json
 
-This is also the shape used in `params.json` for the track. Example:
 ```json
 {
-  "query_string": "Paris"
+  "query_string": "Paris",
+  "from": 0,
+  "size": 5
 }
 ```
 
-- Example `queries_file`:
-```
+### Example `queries_file`, see queries.csv
+
+```text
 Paris
 New York
 Tokyo
 Sydney
 ```
+
+### Example request
+
+```json
+POST kibana_sample_data_flights/_search/template
+{
+  "id": "kibana_sample_flight_search_template",
+  "params": {
+    "query_string": "Paris",
+    "from": 0,
+    "size": 5
+  }
+}
+```
+
+---
+
+## Notes
+
+- Use your own index, search template, and query set for the real benchmark.
+- Adjust the `clients`, `warmup-iterations`, `iterations` in the `real` challenges as required.
+- Keep `queries_file` aligned with the actual query terms your template expects.
+- If you use custom template parameters, prefer `params_file` so defaults stay out of the Python code.
+- The sample file [bring-your-own/params.json](params.json) is just an example and can be replaced with your own values.

--- a/bring-your-own/README.md
+++ b/bring-your-own/README.md
@@ -28,7 +28,7 @@ This track can also be used offline when you already have a fixed dataset, a sea
 - Elasticsearch Rally is installed on a load driver.
 - The load driver has access to the target Elasticsearch cluster.
 - An index or alias to be queried already exists in the target Elasticsearch cluster.
-- The search template already exists in the target Elasticsearch cluster (for example via `PUT _scripts/<name>`).
+- If you set `search_template`, that stored search template must already exist in the target Elasticsearch cluster (for example via `PUT _scripts/<name>`).
 - A `queries.csv` file (provided via `queries_file`) contains random query strings.
 - An optional `params.json` file (provided via `params_file`) contains any additional params used by the search template.
 

--- a/bring-your-own/README.md
+++ b/bring-your-own/README.md
@@ -27,31 +27,77 @@ It uses raw-request with a custom param-source to select random query strings.
 -	`--track-path`: Path to the track folder
 -	`--pipeline=benchmark-only`: Only runs the track operations, no system setup
 - `--target-hosts`: Elasticsearch hosts contains the target index and search template
--	`--client-options`: Connection options, including api_key and use_ssl
+-	`--client-options`: Connection options, authenticate with either `api_key` or `basic_auth_user` with `basic_auth_password`. Set `use_ssl` as required.
 -	`--telemetry`: Collect node-level telemetry, defined in `.rally/rally.ini`
 -	`--kill-running-processes`: Stop any previous Rally processes
 -	`--user-tags`: Add custom tags to the run
--	`--track-params`: Override runtime parameters (`index` and `search_template`)
--	`--challenge`: Specify challenge schedule (e.g., `dryrun` or `real`)
+-	`--track-params`: Specify runtime parameters (`index`, `search_template` and `query_file`)
+-	`--challenge`: Specify challenge schedule (e.g., `dryrun` (for one client and one iteration) or `real`)
 
 ## Running the Track
 
-Example Command:
+Bring your own `index`, `search_template` and `query_file` example Command:
 ```
 esrally race \
-  --track-path=<path_to>/.rally/benchmarks/tracks/search_template \
+  --track-path=<path_to>/.rally/benchmarks/tracks/bring-your-own \
   --pipeline=benchmark-only \
-  --target-hosts=<preprod_es_cluster_endpoint>:443 \
+  --target-hosts=<es_cluster_endpoint>:443 \
   --client-options="api_key:'a0V...2dw==',use_ssl:True" \
   --telemetry="node-stats" \
   --kill-running-processes \
   --user-tags="model:changeme" \
-  --track-params="index:my_index,search_template:my_search_template" \
+  --track-params="index:my_index,search_template:my_search_template,query_file:/tmp/my_queries.csv" \
   --challenge="dryrun"
 ```
 
-## Example queries.csv
+Running with the built-in `kibana_sample_flight` data command:
 ```
-common wealth bank
-apple banana orange
+esrally race \
+  --track-path=<path_to>/.rally/benchmarks/tracks/bring-your-own \
+  --pipeline=benchmark-only \
+  --target-hosts=<es_cluster_endpoint>:443 \
+  --client-options="api_key:'a0V...2dw==',use_ssl:True" \
+  --telemetry="node-stats" \
+  --kill-running-processes \
+  --user-tags="model:changeme" \
+  --track-params="index:kibana_sample_data_flight,search_template:kibana_sample_flight_search_template,query_file:/tmp/kibana_sample_flight_queries.csv" \
+  --challenge="dryrun"
+```
+
+- `search_template`:
+The following `kibana_sample_flight_search_template` will work with the [kibana_sample_data_flight](https://www.elastic.co/docs/manage-data/ingest/sample-data) index:
+```
+PUT _scripts/kibana_sample_flight_search_template
+{
+  "script": {
+    "lang": "mustache",
+    "source": {
+      "query": {
+        "match": {
+          "DestCityName": "{{query_string}}"
+        }
+      }
+    }
+  }
+}
+```
+
+- Example `params_file`:
+Once the sample index `kibana_sample_data_flight` is ingested, and the `kibana_sample_flight_search_template` search template is implemented, you can test the execution with the following:
+```
+POST kibana_sample_data_flights/_search/template
+{
+  "id": "kibana_sample_flight_search_template",
+  "params": {
+    "query_string": "Paris"
+  }
+}
+```
+
+- Example `query_file`:
+```
+Paris
+New York
+Tokyo
+Sydney
 ```

--- a/bring-your-own/README.md
+++ b/bring-your-own/README.md
@@ -1,7 +1,7 @@
 # ESRally Track: Search Template Benchmark
 
 This track allows benchmarking Elasticsearch search templates with randomized query inputs from a CSV file.
-It uses raw-request with a custom param-source to select random query strings.
+It uses raw-request with a custom param-source to select random query strings and supports an optional JSON params file for custom template parameters.
 
 ## File Structure
 
@@ -10,11 +10,13 @@ It uses raw-request with a custom param-source to select random query strings.
 ├── track.json            # Track definition
 ├── track.py              # ParamSource: RandomParamSource
 ├── queries.csv           # CSV file with one query per line
+├── params.json           # Optional JSON params file with default template params
 └── README.md             # This file
 ```
  - track.json: Defines the track, operations, and challenges.
  - track.py: Custom Python param source to supply randomized query strings.
  - queries.csv: Input dataset for random queries. Each row should contain a realistic query string, which can include multiple terms. Providing realistic queries helps simulate actual search workloads and produces more accurate benchmarking results.
+ - params.json: Optional template parameter defaults for your search template, such as `from` and `size`, when you want to keep those values out of the Python code.
 
 
 ## Requirements
@@ -31,12 +33,12 @@ It uses raw-request with a custom param-source to select random query strings.
 -	`--telemetry`: Collect node-level telemetry, defined in `.rally/rally.ini`
 -	`--kill-running-processes`: Stop any previous Rally processes
 -	`--user-tags`: Add custom tags to the run
--	`--track-params`: Specify runtime parameters (`index`, `search_template` and `query_file`)
+-	`--track-params`: Specify runtime parameters (`index`, `search_template` and `queries_file`)
 -	`--challenge`: Specify challenge schedule (e.g., `dryrun` (for one client and one iteration) or `real`)
 
 ## Running the Track
 
-Bring your own `index`, `search_template` and `query_file` example Command:
+Bring your own `index`, `search_template` and `queries_file` example Command:
 ```
 esrally race \
   --track-path=<path_to>/.rally/benchmarks/tracks/bring-your-own \
@@ -46,7 +48,7 @@ esrally race \
   --telemetry="node-stats" \
   --kill-running-processes \
   --user-tags="model:changeme" \
-  --track-params="index:my_index,search_template:my_search_template,query_file:/tmp/my_queries.csv" \
+  --track-params="index:my_index,search_template:my_search_template,queries_file:/tmp/my_queries.csv" \
   --challenge="dryrun"
 ```
 
@@ -60,7 +62,7 @@ esrally race \
   --telemetry="node-stats" \
   --kill-running-processes \
   --user-tags="model:changeme" \
-  --track-params="index:kibana_sample_data_flight,search_template:kibana_sample_flight_search_template,query_file:/tmp/kibana_sample_flight_queries.csv" \
+  --track-params="index:kibana_sample_data_flight,search_template:kibana_sample_flight_search_template,queries_file:/tmp/kibana_sample_flight_queries.csv,params_file:/tmp/kibana_sample_flight_params.json" \
   --challenge="dryrun"
 ```
 
@@ -75,7 +77,9 @@ PUT _scripts/kibana_sample_flight_search_template
       "query": {
         "match": {
           "DestCityName": "{{query_string}}"
-        }
+        },
+        "from": "{{from}}{{^from}}0{{/from}}",
+        "size": "{{size}}{{^size}}10{{/size}}"
       }
     }
   }
@@ -94,7 +98,14 @@ POST kibana_sample_data_flights/_search/template
 }
 ```
 
-- Example `query_file`:
+This is also the shape used in `params.json` for the track. Example:
+```json
+{
+  "query_string": "Paris"
+}
+```
+
+- Example `queries_file`:
 ```
 Paris
 New York

--- a/bring-your-own/README.md
+++ b/bring-your-own/README.md
@@ -9,7 +9,7 @@ This track can also be used offline when you already have a fixed dataset, a sea
 ## File structure
 
 ```
-.rally/benchmarks/tracks/bring-your-own/
+.rally/benchmarks/tracks/default/bring-your-own/
 ├── track.json            # Track definition
 ├── track.py              # ParamSource: RandomParamSource
 ├── queries.csv           # CSV file with one query per line
@@ -135,7 +135,7 @@ POST kibana_sample_data_flights/_search/template
 ```
 ### Example command when using kibana sample flight files
 
-Important: when `params_file` and `queries_files` are not specified in `--track-params`, the default files in this folder will be used instead.
+Important: when `params_file` and `queries_file` are not specified in `--track-params`, the default files in this folder will be used instead.
 
 ```bash
 esrally race \

--- a/bring-your-own/README.md
+++ b/bring-your-own/README.md
@@ -93,10 +93,10 @@ PUT _scripts/kibana_sample_flight_search_template
       "query": {
         "match": {
           "DestCityName": "{{query_string}}"
-        },
-        "from": "{{from}}{{^from}}0{{/from}}",
-        "size": "{{size}}{{^size}}10{{/size}}"
-      }
+        }
+      },
+      "from": "{{from}}{{^from}}0{{/from}}",
+      "size": "{{size}}{{^size}}10{{/size}}"
     }
   }
 }

--- a/bring-your-own/_tests/test_track.py
+++ b/bring-your-own/_tests/test_track.py
@@ -18,6 +18,8 @@ def test_random_query_source_has_query_string_only_when_no_params_file_is_used()
     source = TRACK.RandomParamSource(None, params)
     result = source.params()
 
+    assert result["method"] == "POST"
+    assert result["path"] == "/my_index/_search/template"
     assert "query_string" in result["body"]["params"]
     assert "from" not in result["body"]["params"]
     assert "size" not in result["body"]["params"]

--- a/bring-your-own/_tests/test_track.py
+++ b/bring-your-own/_tests/test_track.py
@@ -53,12 +53,14 @@ def test_bundled_sample_files_are_used_when_track_params_are_omitted():
 def test_params_file_overrides_template_values(tmp_path):
     params_path = tmp_path / "params.json"
     params_path.write_text(
-        json.dumps({
-            "query_string": "Paris",
-            "from": 2,
-            "size": 5,
-            "tenant": "acme",
-        })
+        json.dumps(
+            {
+                "query_string": "Paris",
+                "from": 2,
+                "size": 5,
+                "tenant": "acme",
+            }
+        )
     )
 
     params = {

--- a/bring-your-own/_tests/test_track.py
+++ b/bring-your-own/_tests/test_track.py
@@ -50,6 +50,20 @@ def test_bundled_sample_files_are_used_when_track_params_are_omitted():
     assert result["body"]["params"]["size"] == 5
 
 
+def test_inline_source_template_is_used_when_search_template_is_blank():
+    params = {
+        "index": "my_index",
+        "search_template": "",
+    }
+
+    source = TRACK.RandomParamSource(None, params)
+    result = source.params()
+
+    assert result["body"]["source"]["query"]["query_string"]["query"] == "{{query_string}}"
+    assert result["body"]["params"]["query_string"]
+    assert "id" not in result["body"]
+
+
 def test_params_file_overrides_template_values(tmp_path):
     params_path = tmp_path / "params.json"
     params_path.write_text(

--- a/bring-your-own/_tests/test_track.py
+++ b/bring-your-own/_tests/test_track.py
@@ -1,0 +1,50 @@
+import importlib.util
+import json
+import pathlib
+
+TRACK_PATH = pathlib.Path(__file__).resolve().parents[1] / "track.py"
+SPEC = importlib.util.spec_from_file_location("bring_your_own_track", TRACK_PATH)
+TRACK = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(TRACK)
+
+
+def test_random_query_source_has_query_string_only_when_no_params_file_is_used():
+    params = {
+        "index": "my_index",
+        "search_template": "my_template",
+        "queries_file": "queries.csv",
+    }
+
+    source = TRACK.RandomParamSource(None, params)
+    result = source.params()
+
+    assert "query_string" in result["body"]["params"]
+    assert "from" not in result["body"]["params"]
+    assert "size" not in result["body"]["params"]
+
+
+def test_params_file_overrides_template_values(tmp_path):
+    params_path = tmp_path / "params.json"
+    params_path.write_text(
+        json.dumps({
+            "query_string": "Paris",
+            "from": 2,
+            "size": 5,
+            "tenant": "acme",
+        })
+    )
+
+    params = {
+        "index": "my_index",
+        "search_template": "my_search_template",
+        "queries_file": "queries.csv",
+        "params_file": str(params_path),
+    }
+
+    source = TRACK.RandomParamSource(None, params)
+    result = source.params()
+
+    assert result["body"]["params"]["query_string"] == "Paris"
+    assert result["body"]["params"]["from"] == 2
+    assert result["body"]["params"]["size"] == 5
+    assert result["body"]["params"]["tenant"] == "acme"

--- a/bring-your-own/_tests/test_track.py
+++ b/bring-your-own/_tests/test_track.py
@@ -8,7 +8,16 @@ TRACK = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(TRACK)
 
 
-def test_random_query_source_has_query_string_only_when_no_params_file_is_used():
+def test_random_query_source_has_query_string_only_when_no_params_file_is_used(monkeypatch):
+    original_isfile = TRACK.os.path.isfile
+
+    def patched_isfile(path):
+        if path.endswith("params.json"):
+            return False
+        return original_isfile(path)
+
+    monkeypatch.setattr(TRACK.os.path, "isfile", patched_isfile)
+
     params = {
         "index": "my_index",
         "search_template": "my_template",
@@ -23,6 +32,22 @@ def test_random_query_source_has_query_string_only_when_no_params_file_is_used()
     assert "query_string" in result["body"]["params"]
     assert "from" not in result["body"]["params"]
     assert "size" not in result["body"]["params"]
+
+
+def test_bundled_sample_files_are_used_when_track_params_are_omitted():
+    params = {
+        "index": "my_index",
+        "search_template": "my_template",
+    }
+
+    source = TRACK.RandomParamSource(None, params)
+    result = source.params()
+
+    assert result["method"] == "POST"
+    assert result["path"] == "/my_index/_search/template"
+    assert result["body"]["params"]["query_string"]
+    assert result["body"]["params"]["from"] == 0
+    assert result["body"]["params"]["size"] == 5
 
 
 def test_params_file_overrides_template_values(tmp_path):

--- a/bring-your-own/params.json
+++ b/bring-your-own/params.json
@@ -1,5 +1,4 @@
 {
-  "query_string": "Paris",
   "from": 0,
   "size": 5
 }

--- a/bring-your-own/params.json
+++ b/bring-your-own/params.json
@@ -1,0 +1,3 @@
+{
+  "query_string": "Paris"
+}

--- a/bring-your-own/params.json
+++ b/bring-your-own/params.json
@@ -1,3 +1,5 @@
 {
-  "query_string": "Paris"
+  "query_string": "Paris",
+  "from": 0,
+  "size": 5
 }

--- a/bring-your-own/queries.csv
+++ b/bring-your-own/queries.csv
@@ -1,0 +1,100 @@
+Bangalore
+Belleville
+Belogorsk
+Bergamo
+Bogota
+Brisbane
+Buenos Aires
+Cagliari
+Chengdu
+Chitose / Tomakomai
+Cologne
+Copenhagen
+Dubai
+Dublin
+Durban
+Edmonton
+Frankfurt am Main
+Genova
+Greensboro
+Guangzhou
+Helsinki
+Hyderabad
+Indianapolis
+Jeju City
+Johannesburg
+Kansas City
+Las Vegas
+Lima
+London
+Los Angeles
+Louisville
+Manchester
+Melbourne
+Memphis
+Mexico City
+Miami
+Milan
+Minneapolis
+Moline
+Montreal
+Moscow
+Mumbai
+Munich
+Naples
+Nashville
+New Delhi
+New Orleans
+Newark
+Newport News
+Norfolk
+Olenegorsk
+Orlando
+Osaka
+Oslo
+Ottawa
+Palermo
+Paris
+Philadelphia
+Phoenix
+Pisa
+Pittsburgh
+Portland
+Quito
+Raleigh/Durham
+Reno
+Richmond
+Rochester
+Rome
+Salt Lake City
+San Antonio
+San Diego
+San Francisco
+San Juan
+Santiago
+Savannah
+Seattle
+Seoul
+Shanghai
+Spokane
+St Louis
+Stockholm
+Sydney
+Syracuse
+Tampa
+Tokoname
+Tokyo
+Torino
+Toronto
+Treviso
+Tucson
+Tulsa
+Venice
+Verona
+Vienna
+Warsaw
+Washington
+Wichita
+Winnipeg
+Xi'an
+Zurich

--- a/bring-your-own/track.json
+++ b/bring-your-own/track.json
@@ -1,0 +1,40 @@
+{
+  "version": 2,
+  "description": "Track querying index with random text with search templates",
+  "operations": [
+    {
+      "name": "template-search",
+      "operation-type": "raw-request",
+      "cache": false,
+      "param-source": "random_query_text",
+      "index": "{{index}}",
+      "search_template": "{{search_template}}"
+    }
+  ],
+  "challenges": [
+    {
+      "name": "dryrun",
+      "default": true,
+      "schedule": [
+        {
+          "operation": "template-search",
+          "clients": 1,
+          "warmup-iterations": 0,
+          "iterations": 1
+        }
+      ]
+    },
+    {
+      "name": "real",
+      "default": false,
+      "schedule": [
+        {
+          "operation": "template-search",
+          "clients": 100,
+          "warmup-iterations": 100,
+          "iterations": 1000
+        }
+      ]
+    }
+  ]
+}

--- a/bring-your-own/track.json
+++ b/bring-your-own/track.json
@@ -8,7 +8,9 @@
       "cache": false,
       "param-source": "random_query_text",
       "index": "{{index}}",
-      "search_template": "{{search_template}}"
+      "search_template": "{{search_template}}",
+      "queries_file": "{{queries_file}}",
+      "params_file": "{{params_file}}"
     }
   ],
   "challenges": [

--- a/bring-your-own/track.py
+++ b/bring-your-own/track.py
@@ -1,0 +1,45 @@
+import csv
+import os
+import random
+import json
+class QueryParamSource:
+    # We need to stick to the param source API
+    # noinspection PyUnusedLocal
+    def __init__(self, track, params, **kwargs):
+        self._params = params
+        self.infinite = True
+        # here we read the queries data file into arrays which we'll then later use randomly.
+        self.query_text = []
+        # be predictably random. The seed has been chosen by a fair dice roll. ;)
+        random.seed(4)
+        cwd = os.path.dirname(__file__)
+        with open(os.path.join(cwd, "queries.csv"), "r") as ins:
+            csvreader = csv.reader(ins)
+            for row in csvreader:
+                self.query_text.append(row[0])
+    # We need to stick to the param source API
+    # noinspection PyUnusedLocal
+    def partition(self, partition_index, total_partitions):
+        return self
+class RandomParamSource(QueryParamSource):
+    def params(self):
+        random_query = random.choice(self.query_text)
+        index = self._params["index"]
+
+        result = {
+            "body": {
+                "id": self._params["search_template"],
+                "params": {
+                    "query_string": random_query
+                }
+            },
+            "path": "/"+index+"/_search/template"
+        }
+
+        if "cache" in self._params:
+            result["cache"] = self._params["cache"]
+        #print("DEBUG:", json.dumps(result, indent=2))
+        return result
+
+def register(registry):
+    registry.register_param_source("random_query_text", RandomParamSource)

--- a/bring-your-own/track.py
+++ b/bring-your-own/track.py
@@ -72,10 +72,7 @@ class RandomParamSource(QueryParamSource):
             "search_template",
             "cache",
             "queries_file",
-            "query_file",
             "params_file",
-            "from",
-            "size",
         }
 
         for key, value in self._params.items():

--- a/bring-your-own/track.py
+++ b/bring-your-own/track.py
@@ -2,26 +2,88 @@ import csv
 import os
 import random
 import json
+
+
 class QueryParamSource:
     # We need to stick to the param source API
     # noinspection PyUnusedLocal
     def __init__(self, track, params, **kwargs):
         self._params = params
         self.infinite = True
-        # here we read the queries data file into arrays which we'll then later use randomly.
         self.query_text = []
+        self._param_variants = []
+
         # be predictably random. The seed has been chosen by a fair dice roll. ;)
         random.seed(4)
         cwd = os.path.dirname(__file__)
-        with open(os.path.join(cwd, "queries.csv"), "r") as ins:
+
+        params_file = self._params.get("params_file")
+        if params_file:
+            params_path = params_file if os.path.isabs(params_file) else os.path.join(cwd, params_file)
+            with open(params_path, "r") as ins:
+                param_data = json.load(ins)
+
+            if isinstance(param_data, dict):
+                if "params" in param_data and isinstance(param_data["params"], dict):
+                    param_data = [param_data["params"]]
+                else:
+                    param_data = [param_data]
+            elif not isinstance(param_data, list):
+                raise ValueError("params_file must contain a JSON object or array of objects")
+
+            self._param_variants = []
+            for entry in param_data:
+                if not isinstance(entry, dict):
+                    raise ValueError("Each entry in params_file must be a JSON object")
+                self._param_variants.append(entry)
+
+        queries_file = self._params.get("queries_file") or self._params.get("query_file", "queries.csv")
+        query_path = queries_file if os.path.isabs(queries_file) else os.path.join(cwd, queries_file)
+
+        with open(query_path, "r") as ins:
             csvreader = csv.reader(ins)
             for row in csvreader:
-                self.query_text.append(row[0])
+                if not row:
+                    continue
+                value = row[0].strip()
+                if value:
+                    self.query_text.append(value)
+
+        if not self.query_text:
+            raise ValueError(f"No query values found in {query_path}")
+
     # We need to stick to the param source API
     # noinspection PyUnusedLocal
     def partition(self, partition_index, total_partitions):
         return self
+
+
 class RandomParamSource(QueryParamSource):
+    def _template_params(self, random_query):
+        template_params = {}
+
+        if self._param_variants:
+            template_params.update(random.choice(self._param_variants))
+
+        template_params.setdefault("query_string", random_query)
+
+        reserved = {
+            "index",
+            "search_template",
+            "cache",
+            "queries_file",
+            "query_file",
+            "params_file",
+            "from",
+            "size",
+        }
+
+        for key, value in self._params.items():
+            if key not in reserved and key not in template_params:
+                template_params[key] = value
+
+        return template_params
+
     def params(self):
         random_query = random.choice(self.query_text)
         index = self._params["index"]
@@ -29,17 +91,16 @@ class RandomParamSource(QueryParamSource):
         result = {
             "body": {
                 "id": self._params["search_template"],
-                "params": {
-                    "query_string": random_query
-                }
+                "params": self._template_params(random_query)
             },
-            "path": "/"+index+"/_search/template"
+            "path": "/" + index + "/_search/template"
         }
 
         if "cache" in self._params:
             result["cache"] = self._params["cache"]
-        #print("DEBUG:", json.dumps(result, indent=2))
+
         return result
+
 
 def register(registry):
     registry.register_param_source("random_query_text", RandomParamSource)

--- a/bring-your-own/track.py
+++ b/bring-your-own/track.py
@@ -37,7 +37,7 @@ class QueryParamSource:
                     raise ValueError("Each entry in params_file must be a JSON object")
                 self._param_variants.append(entry)
 
-        queries_file = self._params.get("queries_file") or self._params.get("query_file", "queries.csv")
+        queries_file = self._params.get("queries_file")
         query_path = queries_file if os.path.isabs(queries_file) else os.path.join(cwd, queries_file)
 
         with open(query_path, "r") as ins:

--- a/bring-your-own/track.py
+++ b/bring-your-own/track.py
@@ -89,14 +89,26 @@ class RandomParamSource(QueryParamSource):
     def params(self):
         random_query = random.choice(self.query_text)
         index = self._params["index"]
+        search_template = self._params.get("search_template")
+        body = {
+            "params": self._template_params(random_query),
+        }
+
+        if search_template:
+            body["id"] = search_template
+        else:
+            body["source"] = {
+                "query": {
+                    "query_string": {
+                        "query": "{{query_string}}",
+                    }
+                }
+            }
 
         result = {
             "method": "POST",
             "path": f"/{index.lstrip('/')}/_search/template",
-            "body": {
-                "id": self._params["search_template"],
-                "params": self._template_params(random_query),
-            },
+            "body": body,
         }
 
         if "cache" in self._params:

--- a/bring-your-own/track.py
+++ b/bring-your-own/track.py
@@ -86,11 +86,12 @@ class RandomParamSource(QueryParamSource):
         index = self._params["index"]
 
         result = {
+            "method": "POST",
+            "path": f"/{index.lstrip('/')}\/_search\/template",
             "body": {
                 "id": self._params["search_template"],
-                "params": self._template_params(random_query)
+                "params": self._template_params(random_query),
             },
-            "path": "/" + index + "/_search/template"
         }
 
         if "cache" in self._params:

--- a/bring-your-own/track.py
+++ b/bring-your-own/track.py
@@ -1,7 +1,7 @@
 import csv
+import json
 import os
 import random
-import json
 
 
 class QueryParamSource:
@@ -16,8 +16,13 @@ class QueryParamSource:
         # be predictably random. The seed has been chosen by a fair dice roll. ;)
         random.seed(4)
         cwd = os.path.dirname(__file__)
+        default_params_path = os.path.join(cwd, "params.json")
+        default_queries_path = os.path.join(cwd, "queries.csv")
 
         params_file = self._params.get("params_file")
+        if not params_file and os.path.isfile(default_params_path):
+            params_file = default_params_path
+
         if params_file:
             params_path = params_file if os.path.isabs(params_file) else os.path.join(cwd, params_file)
             with open(params_path, "r") as ins:
@@ -37,7 +42,7 @@ class QueryParamSource:
                     raise ValueError("Each entry in params_file must be a JSON object")
                 self._param_variants.append(entry)
 
-        queries_file = self._params.get("queries_file")
+        queries_file = self._params.get("queries_file") or default_queries_path
         query_path = queries_file if os.path.isabs(queries_file) else os.path.join(cwd, queries_file)
 
         with open(query_path, "r") as ins:
@@ -87,7 +92,7 @@ class RandomParamSource(QueryParamSource):
 
         result = {
             "method": "POST",
-            "path": f"/{index.lstrip('/')}\/_search\/template",
+            "path": f"/{index.lstrip('/')}/_search/template",
             "body": {
                 "id": self._params["search_template"],
                 "params": self._template_params(random_query),


### PR DESCRIPTION
This track is used for Elasticsearch search benchmarking based on your own data and your own search template. It is commonly used to test different index options such as index size, sharding, mappings, and settings. It can also be used to test different search templates, such as loose or tight fuzziness, and to compare search performance across Elasticsearch versions.
