### PR TITLE
fix(geonames): use scroll-search for scroll operation

### DIFF
--- a/geonames/operations/default.json
+++ b/geonames/operations/default.json
@@ -90,7 +90,7 @@
     },
     {
       "name": "scroll",
-      "operation-type": "search",
+      "operation-type": "scroll-search",
       "pages": 25,
       "results-per-page": 1000,
       "body": {


### PR DESCRIPTION
## Summary
- Update the geonames `scroll` operation to use `operation-type: scroll-search` instead of deprecated `search` with pages.

Fixes #624

## Test plan
- [ ] Confirm `geonames/operations/default.json` scroll op uses `scroll-search`
- [ ] Run geonames track (or dry-check) and verify the deprecation warning is gone