### PR TITLE
feat(elastic/logs): add `enable_columnar_codec` track parameter

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -262,6 +262,7 @@ The following parameters are available:
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use. Only supported in `logging-querying` track.
 * `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
 * `codec` (default: unset): Configured the `index.codec` index setting, which controls how stored fields get stored / compressed.
+* `enable_columnar_codec` (default: `false`): When `true`, opts the index into the ColumNAR keyword doc-values codec via `index.columnar_codec.enabled`. Requires a strict-columnar index mode (`logsdb_columnar`) and a snapshot build with the `columnar_codec` feature flag.
 
 ### Querying parameters
 

--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -262,7 +262,7 @@ The following parameters are available:
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use. Only supported in `logging-querying` track.
 * `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.
 * `codec` (default: unset): Configured the `index.codec` index setting, which controls how stored fields get stored / compressed.
-* `enable_columnar_codec` (default: `false`): When `true`, opts the index into the ColumNAR keyword doc-values codec via `index.columnar_codec.enabled`. Requires a strict-columnar index mode (`logsdb_columnar`) and a snapshot build with the `columnar_codec` feature flag.
+* `enable_columnar_codec` (default: `false`): When `true` and `index_mode` is `logsdb_columnar`, opts the index into the ColumNAR keyword doc-values codec via `index.columnar_codec.enabled`. It has no effect in other index modes, since ColumNAR is only selected in a strict-columnar index mode. Requires a snapshot build with the `columnar_codec` feature flag.
 
 ### Querying parameters
 

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -25,7 +25,8 @@
             ,"use_time_series_doc_values_format": {{use_time_series_doc_values_format | tojson}}
             {% endif %}
             ,"use_time_series_doc_values_format_large_binary_block_size": true
-            {%- if enable_columnar_codec | default(false) %}
+            {#- ColumNAR keyword doc-values opt-in: emitted only for the strict-columnar `logsdb_columnar` mode, since the codec is never selected in other index modes, so the flag stays a no-op elsewhere -#}
+            {%- if enable_columnar_codec | default(false) and index_mode == "logsdb_columnar" %}
             ,"columnar_codec.enabled": true
             {%- endif %}
             {% if index_mode == "logsdb_columnar" or index_mode == "logsdb" or index_mode == "time_series" %}

--- a/elastic/logs/templates/component/track-shared-logsdb-mode.json
+++ b/elastic/logs/templates/component/track-shared-logsdb-mode.json
@@ -25,6 +25,9 @@
             ,"use_time_series_doc_values_format": {{use_time_series_doc_values_format | tojson}}
             {% endif %}
             ,"use_time_series_doc_values_format_large_binary_block_size": true
+            {%- if enable_columnar_codec | default(false) %}
+            ,"columnar_codec.enabled": true
+            {%- endif %}
             {% if index_mode == "logsdb_columnar" or index_mode == "logsdb" or index_mode == "time_series" %}
             ,"disable_sequence_numbers": true
             {% endif %}


### PR DESCRIPTION
## Summary

Add an opt-in track parameter that injects `index.columnar_codec.enabled` into the shared logsdb columnar index settings, so a single rally invocation can A/B between `ColumNAR` and `ES819` by passing different track params per experiment. The setting is honored only on builds where the `columnar_codec` feature flag is enabled.

## What changed

- `elastic/logs/templates/component/track-shared-logsdb-mode.json`: add a Jinja conditional in the `index` settings block, gated on the new `enable_columnar_codec` parameter (default `false`). Pair it with `index_mode: logsdb_columnar` to make the track's keyword fields eligible for ColumNAR.
- `elastic/logs/README.md`: document the new `enable_columnar_codec` track parameter under the indexing parameters.

When `enable_columnar_codec` is `false` (the default) the rendered template is byte-for-byte identical to the current baseline.

Part of elastic/elasticsearch#155883.
Depends elastic/elasticsearch#157369.
