### PR TITLE
Cut iteration count on extremely slow queries

### DIFF
--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -339,8 +339,8 @@
         },
         {
           "operation": "distanceSort-esql-partial",
-          "warmup-iterations": 50,
-          "iterations": 50,
+          "warmup-iterations": 2,
+          "iterations": 2,
           "tags": ["distance", "esql", "sort"]
         },
         {
@@ -357,8 +357,8 @@
         },
         {
           "operation": "distanceFilterSort-esql-partial",
-          "warmup-iterations": 50,
-          "iterations": 50,
+          "warmup-iterations": 2,
+          "iterations": 2,
           "tags": ["distance", "esql", "sort"]
         },
         {


### PR DESCRIPTION
There has been a massive regression in ES|QL partial sorting, as reported at https://github.com/elastic/elasticsearch/issues/157181. But the fix is non-trivial, so in the meantime we need to cut the iteration count down because the benchmark is taking extremely long, and risks timeouts.

Since https://github.com/elastic/elasticsearch/pull/155923 was backported to 9.5, 9.4 and 8.19, we need to backport this to those branches too.