### PR TITLE
[9.5] Cut iteration count on extremely slow queries (#1250)

### DIFF
--- a/geopoint/challenges/default.json
+++ b/geopoint/challenges/default.json
@@ -339,8 +339,8 @@
         },
         {
           "operation": "distanceSort-esql-partial",
-          "warmup-iterations": 50,
-          "iterations": 50,
+          "warmup-iterations": 2,
+          "iterations": 2,
           "tags": ["distance", "esql", "sort"]
         },
         {
@@ -357,8 +357,8 @@
         },
         {
           "operation": "distanceFilterSort-esql-partial",
-          "warmup-iterations": 50,
-          "iterations": 50,
+          "warmup-iterations": 2,
+          "iterations": 2,
           "tags": ["distance", "esql", "sort"]
         },
         {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `9.5`:
 - [Cut iteration count on extremely slow queries (#1250)](https://github.com/elastic/rally-tracks/pull/1250)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

<!--BACKPORT [{"author":{"name":"Craig Taverner","email":"craig@amanzi.com"},"sourceCommit":{"committedDate":"2026-09-04T13:12:18Z","message":"Cut iteration count on extremely slow queries (#1250)","sha":"46ade2b4cad6111514d2f04cf1f91ec42b690af3","branchLabelMapping":{"^v9.6$":"master","^vServerless$":"master","^v(\\d{1,2}).(\\d{1,2})$":"$1.$2"}},"sourcePullRequest":{"labels":["v8.19","v9.4","v9.5","v9.6"],"title":"Cut iteration count on extremely slow queries","number":1250,"url":"https://github.com/elastic/rally-tracks/pull/1250","mergeCommit":{"message":"Cut iteration count on extremely slow queries (#1250)","sha":"46ade2b4cad6111514d2f04cf1f91ec42b690af3"}},"sourceBranch":"master","suggestedTargetBranches":["8.19","9.4","9.5"],"targetPullRequestStates":[{"branch":"8.19","label":"v8.19","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.4","label":"v9.4","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"9.5","label":"v9.5","branchLabelMappingKey":"^v(\\d{1,2}).(\\d{1,2})$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"master","label":"v9.6","branchLabelMappingKey":"^v9.6$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/rally-tracks/pull/1250","number":1250,"mergeCommit":{"message":"Cut iteration count on extremely slow queries (#1250)","sha":"46ade2b4cad6111514d2f04cf1f91ec42b690af3"}}]}] BACKPORT-->