### PR TITLE
feat(logs): make ingest_percentage effective in elastic/logs

### DIFF
--- a/elastic/logs/README.md
+++ b/elastic/logs/README.md
@@ -257,7 +257,7 @@ The following parameters are available:
 * `throttle_indexing` (default: `false`) - Whether indexing should be throttled to the rate determined by `raw_data_volume_per_day`, assuming a uniform distribution of data, or whether indexing should go as fast as possible. 
 * `disable_pipelines` (default: `false`) - Prevent installing ingest node pipelines. This parameter is experimental and is to be used with indexing-only challenges.
 * `initial_indices_count` (default: 0) - Number of initial indices to create, each containing `100` auditbeat style documents. Parameter is applicable in [many-shards-quantitative challenge](#many-shards-quantitative-many-shards-quantitative) and in [many-shards-snapshots challenge](#many-shards-snapshots-many-shards-snapshots).
-* `ingest_percentage` (default: 100) - The percentage of data to be ingested.
+* `ingest_percentage` (default: 100) - A number in (0, 100] that scales the number of documents derived from `raw_data_volume_per_day`. Generated timestamps still cover the whole date range, so the same period is indexed with proportionally fewer documents. Supported by the `logging-indexing` and `logging-indexing-querying` challenges.
 * `index_mode` (default: unset): What index mode to use. Accepted values: `standard`, `logs` or `logsdb_columnar`. 
 * `force_merge_max_num_segments` (default: unset): An integer specifying the max amount of segments the force-merge operation should use. Only supported in `logging-querying` track.
 * `include_non_serverless_index_settings` (default: true for non-serverless clusters, false for serverless clusters): Whether to include non-serverless index settings.

--- a/elastic/logs/challenges/logging-indexing-querying.json
+++ b/elastic/logs/challenges/logging-indexing-querying.json
@@ -51,10 +51,10 @@
                 "time-format": "milliseconds",
                 "profile": "fixed_interval",
                 "bulk-size": {{ p_runtime_bulk_size }},
+                "ingest-percentage": {{ ingest_percentage | default(100) }},
                 "detailed-results": true
               },
-              "clients": {{ p_runtime_indexing_clients }},
-              "ingest-percentage": {{ ingest_percentage | default(100) }}
+              "clients": {{ p_runtime_indexing_clients }}
               {% if p_throttle_indexing %},
                 "ignore-response-error-level": "{{error_level | default('non-fatal')}}",
                 "schedule": "timestamp-throttler",

--- a/elastic/logs/challenges/logging-indexing.json
+++ b/elastic/logs/challenges/logging-indexing.json
@@ -13,6 +13,7 @@
         "time-format": "milliseconds",
         "profile": "fixed_interval",
         "bulk-size": {{ p_bulk_size }},
+        "ingest-percentage": {{ ingest_percentage | default(100) }},
         "detailed-results": true
       },
       "clients": {{ p_bulk_indexing_clients }}{% if p_throttle_indexing %},

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -9,7 +9,6 @@
 {% set p_bulk_indexing_clients = (bulk_indexing_clients | default(8)) %}
 {% set p_search_clients = (search_clients | default(1)) %}
 {% set p_runtime_indexing_clients = (runtime_indexing_clients | default(p_bulk_indexing_clients)) %}
-{% set p_ingest_percentage = (ingest_percentage | default(100)) %}
 {% set p_initial_indices_count = (initial_indices_count | default(0)) %}
 {% set p_initial_frozen_indices_count = (initial_frozen_indices_count | default(0)) %}
 {% set p_bulk_size = bulk_size | default(1000) %}

--- a/elastic/shared/parameter_sources/processed.py
+++ b/elastic/shared/parameter_sources/processed.py
@@ -137,6 +137,12 @@ class ProcessedCorpusParamSource:
             raise exceptions.InvalidSyntax('Mandatory parameter "bulk-size" is missing')
         except ValueError:
             raise exceptions.InvalidSyntax('"bulk-size" must be numeric')
+        try:
+            self.ingest_percentage = float(params.get("ingest-percentage", 100))
+        except ValueError:
+            raise exceptions.InvalidSyntax('"ingest-percentage" must be numeric')
+        if self.ingest_percentage <= 0 or self.ingest_percentage > 100:
+            raise exceptions.InvalidSyntax(f'"ingest-percentage" must be in the range (0, 100] but was {self.ingest_percentage}')
         self.corpus = next(
             (c for c in track.corpora if c.meta_data.get("generated", False)),
             None,
@@ -353,6 +359,11 @@ class ProcessedCorpusParamSource:
         self.total_docs_per_day = math.ceil(
             self.total_corpus_docs * ((self._volume_per_day_gb * 1024 * 1024 * 1024) / self.total_corpus_bytes)
         )
+        if self.ingest_percentage < 100:
+            # NOTE: scale the daily document count instead of truncating the doc stream so
+            # generated timestamps still cover the full date range and query workflows find
+            # data in every window; this must happen before the timestamp generator is built
+            self.total_docs_per_day = math.ceil(self.total_docs_per_day * self.ingest_percentage / 100)
         self.total_docs = self.total_docs_per_day * self._number_of_days
         if self._client_index == 0:
             self.logger.info(f"Total Docs: [{self.total_docs}]")

--- a/elastic/tests/parameter_sources/processed_test.py
+++ b/elastic/tests/parameter_sources/processed_test.py
@@ -55,6 +55,39 @@ def test_corpus_read():
     assert total_batches == 1748
 
 
+def test_corpus_read_with_ingest_percentage():
+    cwd = os.path.dirname(__file__)
+    test_track = StaticTrack(
+        parameters={
+            "track-id": "test_file_write",
+            "end-date": "2020-09-01:00:00:00",
+            "start-date": "2020-08-31:00:00:00",
+            "raw-data-volume-per-day": "0.1MB",
+        },
+        generated_document_paths=[os.path.join(cwd, "resources", "processed_test", "test_corpus_read", "0.json")],
+    )
+
+    param_source = ProcessedCorpusParamSource(
+        track=test_track,
+        params={
+            "time-format": "milliseconds",
+            "profile": "fixed_interval",
+            "bulk-size": 10,
+            "ingest-percentage": 50,
+        },
+    )
+    client_param_source = param_source.partition(partition_index=0, total_partitions=1)
+    total_batches = 0
+    while True:
+        try:
+            client_param_source.params()
+            total_batches += 1
+        except StopIteration:
+            break
+    # half of the 1748 batches that test_corpus_read gets at 100 percent
+    assert total_batches == 874
+
+
 def test_corpus_read_changing_bulk_size():
     cwd = os.path.dirname(__file__)
     test_track = StaticTrack(
@@ -411,6 +444,31 @@ def test_negative_bulk_size():
             params={"bulk-size": -1},
         )
     assert invalid_syntax.value.message == '"bulk-size" must be positive but was -1'
+
+
+def test_invalid_ingest_percentage():
+    def create_with_ingest_percentage(ingest_percentage):
+        return ProcessedCorpusParamSource(
+            track=StaticTrack(
+                parameters={
+                    "track-id": "test_file_write",
+                    "raw-data-volume-per-day": "0.001MB",
+                }
+            ),
+            params={"bulk-size": 10, "ingest-percentage": ingest_percentage},
+        )
+
+    with pytest.raises(InvalidSyntax) as invalid_syntax:
+        create_with_ingest_percentage(0)
+    assert invalid_syntax.value.message == '"ingest-percentage" must be in the range (0, 100] but was 0.0'
+
+    with pytest.raises(InvalidSyntax) as invalid_syntax:
+        create_with_ingest_percentage(100.1)
+    assert invalid_syntax.value.message == '"ingest-percentage" must be in the range (0, 100] but was 100.1'
+
+    with pytest.raises(InvalidSyntax) as invalid_syntax:
+        create_with_ingest_percentage("half")
+    assert invalid_syntax.value.message == '"ingest-percentage" must be numeric'
 
 
 def test_no_data_volume():


### PR DESCRIPTION
## TL;DR

`elastic/logs` documents an `ingest_percentage` track parameter, but it has no runtime effect: setting it changes nothing about the benchmark. This implements the parameter in `ProcessedCorpusParamSource` so the documented behaviour becomes real.

## Summary

The parameter was inert for two independent reasons. `track.json` set a Jinja variable (`p_ingest_percentage`) that nothing referenced, and `logging-indexing-querying.json` emitted `ingest-percentage` at task level, where Rally passes it to schedulers rather than to the parameter source. Even at operation level it would have been ignored, because the indexing operations use the custom `processed-source` parameter source, which bypasses Rally's built-in `BulkIndexParamSource` (the component that implements `ingest-percentage` everywhere else). Because the dead Jinja variable referenced the parameter, Rally's unused-track-param check counted it as used, so a user setting it did not even get a warning.

The implementation scales `total_docs_per_day` (derived from `raw_data_volume_per_day`) before client partitioning and before the timestamp generator is built. Scaling the daily document count rather than truncating the document stream keeps generated timestamps covering the entire `start_date`..`end_date` range, so the same period is indexed with proportionally fewer documents and query workflows keep finding data in every window; it is equivalent to reducing `raw_data_volume_per_day` by the same factor. Validation matches Rally's built-in semantics: a number in `(0, 100]`, default 100, so existing invocations are unaffected. The operation-level parameter is wired into the `logging-indexing` and `logging-indexing-querying` challenges; the stale task-level occurrence and the dead Jinja variable are removed.

> **IMPORTANT**
> Anyone who previously set `ingest_percentage` on this track was silently getting a full-volume run. After this change the parameter takes effect, so such runs will ingest less data than before. Values other than 100 also shorten the throttled indexing phase proportionally, and in `logging-indexing-querying` the `completed-by: bulk-index` parallel block ends earlier, shortening the query phase with it.

## Testing

```
make test
make lint
```
