### PR TITLE
feat(elastic/logs): add early-termination coverage for keyword index sort

### DIFF
--- a/elastic/logs/challenges/logging-querying.json
+++ b/elastic/logs/challenges/logging-querying.json
@@ -105,6 +105,36 @@
       "iterations": 100
     },
     {
+      "operation": "discovery-search-sorted-by-host-top10",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50
+    },
+    {
+      "operation": "discovery-search-sorted-by-host-ts-top50",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50
+    },
+    {
+      "operation": "discovery-search-errors-sorted-by-host-top20",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50
+    },
+    {
+      "operation": "discovery-search-sorted-by-host-search-after",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50
+    },
+    {
+      "operation": "discovery-search-sorted-by-host-ts-search-after",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50
+    },
+    {
       "name": "logging-queries",
       "parallel": {
         "time-period": {{ p_query_time_period }},
@@ -240,6 +270,13 @@
       "warmup-iterations": 5,
       "iterations": 20,
       "tags": ["esql", "dissect"]
+    },
+    {
+      "operation": "esql_sort_by_host",
+      "clients": 1,
+      "warmup-iterations": 10,
+      "iterations": 50,
+      "tags": ["esql"]
     },
     {
       "operation": "term_query_with_matches",

--- a/elastic/logs/operations/esql.json
+++ b/elastic/logs/operations/esql.json
@@ -313,6 +313,14 @@
       {%- endif %}
     },
     {
+      "name": "esql_sort_by_host",
+      "operation-type": "esql",
+      "query": "FROM {{p_esql_target_prefix}}logs-* | SORT host.name ASC | KEEP host.name, @timestamp | LIMIT 10"
+      {%- if p_esql_ccs_extra_body %},
+      "body": {{ p_esql_ccs_extra_body | tojson }}
+      {%- endif %}
+    },
+    {
       "name": "esql_date_histogram_fixed_interval",
       "operation-type": "esql",
       "query": "FROM {{p_esql_target_prefix}}logs-* | STATS COUNT(*) BY b=BUCKET(@timestamp, 1 WEEK) | SORT b"

--- a/elastic/logs/operations/search-with-source.json
+++ b/elastic/logs/operations/search-with-source.json
@@ -124,5 +124,84 @@
     {{ discovery_search_props(size) }}
   }
   {% endif %}
-  {{ "," if not loop.last else "" }}
+  ,
 {% endfor %}
+{
+  "name": "discovery-search-sorted-by-host-top10",
+  "operation-type": "search",
+  "index": "logs-*",
+  "request-params": {
+    "ignore_unavailable": "true",
+    "track_total_hits": "false"
+  },
+  "body": {
+    "sort": [{ "host.name": { "order": "asc", "missing": "_last" } }],
+    "size": 10,
+    "_source": false
+  }
+},
+{
+  "name": "discovery-search-sorted-by-host-ts-top50",
+  "operation-type": "search",
+  "index": "logs-*",
+  "request-params": {
+    "ignore_unavailable": "true",
+    "track_total_hits": "false"
+  },
+  "body": {
+    "sort": [
+      { "host.name": { "order": "asc", "missing": "_last" } },
+      { "@timestamp": { "order": "desc" } }
+    ],
+    "size": 50,
+    "_source": false
+  }
+},
+{
+  "name": "discovery-search-errors-sorted-by-host-top20",
+  "operation-type": "search",
+  "index": "logs-*",
+  "request-params": {
+    "ignore_unavailable": "true",
+    "track_total_hits": "false"
+  },
+  "body": {
+    "query": { "term": { "log.level": "error" } },
+    "sort": [{ "host.name": { "order": "asc", "missing": "_last" } }],
+    "size": 20,
+    "_source": false
+  }
+},
+{
+  "name": "discovery-search-sorted-by-host-search-after",
+  "operation-type": "search",
+  "index": "logs-*",
+  "request-params": {
+    "ignore_unavailable": "true",
+    "track_total_hits": "false"
+  },
+  "body": {
+    "sort": [{ "host.name": { "order": "asc", "missing": "_last" } }],
+    "size": 10,
+    "search_after": ["{{ p_host_search_after }}"],
+    "_source": false
+  }
+},
+{
+  "name": "discovery-search-sorted-by-host-ts-search-after",
+  "operation-type": "search",
+  "index": "logs-*",
+  "request-params": {
+    "ignore_unavailable": "true",
+    "track_total_hits": "false"
+  },
+  "body": {
+    "sort": [
+      { "host.name": { "order": "asc", "missing": "_last" } },
+      { "@timestamp": { "order": "desc" } }
+    ],
+    "size": 50,
+    "search_after": ["{{ p_host_search_after }}", {{ p_search_after_timestamp }}],
+    "_source": false
+  }
+}

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -20,8 +20,8 @@
 {% set p_query_warmup_time_period = (query_warmup_time_period | default(120)) %}
 {% set p_query_time_period = (query_time_period | default(900)) %}
 {% set p_query_request_params = (query_request_params | default({}))%}
-{% set p_host_search_after = (host_search_after | default('m')) %}
-{% set p_search_after_timestamp = (search_after_timestamp | default(1700000000000)) %}
+{% set p_host_search_after = (host_search_after | default('elasticsearch-ci-immutable-debian-10-1599145396373086378')) %}
+{% set p_search_after_timestamp = (search_after_timestamp | default(1577880000000)) %}
 {% set p_include_esql_queries = (include_esql_queries | default(build_flavor != "serverless")) %}
 {% set p_exclude_serverless_templates = (exclude_serverless_templates | default(build_flavor == "serverless")) %}
 {% set p_throttle_indexing = (throttle_indexing | default(false)) %}

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -20,6 +20,8 @@
 {% set p_query_warmup_time_period = (query_warmup_time_period | default(120)) %}
 {% set p_query_time_period = (query_time_period | default(900)) %}
 {% set p_query_request_params = (query_request_params | default({}))%}
+{% set p_host_search_after = (host_search_after | default('m')) %}
+{% set p_search_after_timestamp = (search_after_timestamp | default(1700000000000)) %}
 {% set p_include_esql_queries = (include_esql_queries | default(build_flavor != "serverless")) %}
 {% set p_exclude_serverless_templates = (exclude_serverless_templates | default(build_flavor == "serverless")) %}
 {% set p_throttle_indexing = (throttle_indexing | default(false)) %}

--- a/elastic/logs/track.json
+++ b/elastic/logs/track.json
@@ -20,6 +20,9 @@
 {% set p_query_warmup_time_period = (query_warmup_time_period | default(120)) %}
 {% set p_query_time_period = (query_time_period | default(900)) %}
 {% set p_query_request_params = (query_request_params | default({}))%}
+{# NOTE: defaults derived from the elastic/logs corpus (23567 unique hosts). #}
+{# NOTE: host is the median by lexicographic order; timestamp is the midpoint #}
+{# NOTE: of the bulk_start_date/bulk_end_date window (2020-01-01T12:00:00Z). #}
 {% set p_host_search_after = (host_search_after | default('elasticsearch-ci-immutable-debian-10-1599145396373086378')) %}
 {% set p_search_after_timestamp = (search_after_timestamp | default(1577880000000)) %}
 {% set p_include_esql_queries = (include_esql_queries | default(build_flavor != "serverless")) %}


### PR DESCRIPTION
## TL;DR

No operation in `logging-querying` exercises the early-termination paths in the columnar keyword index sort fix. This PR adds six operations that sort leading with `host.name`, covering both the top-N and `search_after` code paths against both `logsdb` and `logsdb_columnar` in the existing nightly schedule.

## Summary

All existing sorted searches in `logging-querying` sort by `@timestamp` alone. A sort on `@timestamp` is not a leading prefix of the logsdb index sort `[host.name ASC, @timestamp DESC]`, so none of them trigger `TopFieldCollector.canEarlyTerminateOnPrefix()` or the `Lucene.canEarlyTerminate()` guard in `QueryPhase`. This PR covers the performance regressions tracked by [elastic/elasticsearch#158964](https://github.com/elastic/elasticsearch/issues/158964) (top-N prefix early termination) and [elastic/elasticsearch#158928](https://github.com/elastic/elasticsearch/issues/158928) (`search_after` early termination via `SearchAfterSortedDocQuery` injection).

Three DSL top-N operations and one ES|QL operation sort leading with `host.name`, which is a valid prefix of the index sort. Two additional DSL `search_after` operations cover the paginated page case, where [elastic/elasticsearch#158928](https://github.com/elastic/elasticsearch/issues/158928) caused every subsequent page to rescan all documents before the continuation point instead of binary-searching directly to it.

The nightly esbench schedule already runs `logging-querying` as two independent benchmarks (`elastic-logs-logsdb` and `elastic-logs-logsdb-columnar`), so this single addition provides dedicated coverage for both index modes without any schedule changes.

## Changes

- `elastic/logs/track.json`: add `host_search_after` and `search_after_timestamp` track parameters calibrated against the corpus (median host and 2020-01-01T12:00:00Z timestamp).
- `elastic/logs/operations/search-with-source.json`: add five DSL operations (three top-N and two `search_after`).
- `elastic/logs/operations/esql.json`: add one ES|QL top-N operation.
- `elastic/logs/challenges/logging-querying.json`: wire all six operations into the challenge.

## Query shapes

**`discovery-search-sorted-by-host-top10`** (`sort: [host.name ASC]`, `size: 10`, `track_total_hits: false`). Single-field leading prefix of the index sort. This is the minimal case that makes `TopFieldCollector.canEarlyTerminateOnPrefix()` return true. It has no secondary sort field and no filter, isolating the prefix-match condition directly.

**`discovery-search-sorted-by-host-ts-top50`** (`sort: [host.name ASC, @timestamp DESC]`, `size: 50`, `track_total_hits: false`). Full two-field match of the index sort `[host.name ASC, @timestamp DESC]`. Both collector fields align with the segment sort, so the collector can stop as soon as it has collected enough hits. This is the most representative Kibana Discovery first-page shape.

**`discovery-search-errors-sorted-by-host-top20`** (`sort: [host.name ASC]`, `size: 20`, `track_total_hits: false`, filtered by `log.level: error`). Same early-termination path as the top-10 variant but with a query filter that reduces the candidate document set before sorting. Verifies the path is not broken when a pre-filter changes the match count relative to the total segment size.

**`esql_sort_by_host`** (`SORT host.name ASC | LIMIT 10`). ES|QL exercises a separate call site: `LuceneTopNSourceOperator` rather than `TopFieldCollector`. The early-termination condition is checked independently in the ES|QL execution engine, so DSL coverage alone does not verify this path.

**`discovery-search-sorted-by-host-search-after`** (`sort: [host.name ASC]`, `search_after: [<cursor>]`, `size: 10`, `track_total_hits: false`). Covers the paginated page case for [elastic/elasticsearch#158928](https://github.com/elastic/elasticsearch/issues/158928). Without the fix, `Lucene.canEarlyTerminate()` in `QueryPhase` returns false for columnar keyword sorts, so `SearchAfterSortedDocQuery` is never injected and every page rescans all documents before the cursor. The default cursor (`host_search_after`) is `elasticsearch-ci-immutable-debian-10-1599145396373086378`, the median of 23,567 unique host names in the corpus, so roughly half the document space lies after it.

**`discovery-search-sorted-by-host-ts-search-after`** (`sort: [host.name ASC, @timestamp DESC]`, `search_after: [<cursor>, <timestamp>]`, `size: 50`, `track_total_hits: false`). Two-field `search_after` variant covering the most common Kibana Discovery pagination pattern. The default `search_after_timestamp` is `1577880000000` (2020-01-01T12:00:00Z), the midpoint of the `bulk_start_date`/`bulk_end_date` indexing window. Both cursor values are overridable via track parameters.

## Testing

```
# Validate Jinja2 rendering and confirm all operations are listed:
esrally list tracks --track-path=elastic/logs
esrally info --track-path=elastic/logs --challenge=logging-querying
```

Both commands succeed locally (esrally 2.12.0). All six new operations appear in the challenge at positions 15-19 and 37.

## References

- [elastic/elasticsearch#158964](https://github.com/elastic/elasticsearch/issues/158964): `TopFieldCollector` prefix early termination broken for columnar keyword index sorts
- [elastic/elasticsearch#158928](https://github.com/elastic/elasticsearch/issues/158928): `search_after` early termination broken for columnar keyword index sorts

> **NOTE:** The nightly dashboards that track `logging-querying` latency will need to be updated to include the six new operations added by this PR. Without dashboard coverage, regressions in these operations will not be visible in the nightly results.